### PR TITLE
Use npm ci instead of npm install in E2E workflow

### DIFF
--- a/.github/workflows/subflow_e2e_test.yml
+++ b/.github/workflows/subflow_e2e_test.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: admin-jarfile
           path: ./artifact
-      - run: npm install
+      - run: npm ci
         working-directory: frontend/src/main/webapp
       - name: Run cypress
         run: |

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -14,7 +14,7 @@ val npmInstall by tasks.registering(Exec::class) {
     val osName = System.getProperty("os.name")
     val isWindows = osName.lowercase().contains("windows")
     val npmCommand = if (isWindows) "npm.cmd" else "npm"
-    commandLine(npmCommand, "install")
+    commandLine(npmCommand, "ci")
 
     inputs.file("$webappDir/package.json")
     inputs.file("$webappDir/package-lock.json")


### PR DESCRIPTION
## Summary
- Fixes [code scanning alert #39](https://github.com/wrk-tafel/admin/security/code-scanning/39) (SonarCloud rule S8543): `.github/workflows/subflow_e2e_test.yml` used `npm install`, which can silently resolve newer versions than `package-lock.json` pins if the lock file is stale.
- Switched to `npm ci` in the E2E workflow, which installs strictly from the lock file and fails instead of resolving new versions.
- Also switched `frontend/build.gradle.kts`'s `npmInstall` Gradle task from `npm install` to `npm ci` for the same reason — outside the alert's specific scope (GitHub Actions only) but the same reproducibility argument applies to local/CI frontend builds triggered via Gradle.

## Test plan
- [x] `./gradlew :frontend:npmInstall` succeeds with `npm ci`
- [ ] CI passes (E2E workflow installs deps and runs Cypress successfully)