### PR TITLE
Fix vulnerable transitive npm dependencies (Dependabot alerts)

### DIFF
--- a/frontend/src/main/webapp/package-lock.json
+++ b/frontend/src/main/webapp/package-lock.json
@@ -2149,13 +2149,13 @@
       "optional": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -6481,13 +6481,6 @@
         "cypress": ">= 4"
       }
     },
-    "node_modules/cypress-browser-permissions/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cypress-recurse": {
       "version": "1.37.2",
       "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.37.2.tgz",
@@ -7490,9 +7483,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/main/webapp/package-lock.json
+++ b/frontend/src/main/webapp/package-lock.json
@@ -5748,16 +5748,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -11416,9 +11416,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/frontend/src/main/webapp/package.json
+++ b/frontend/src/main/webapp/package.json
@@ -87,6 +87,8 @@
   "overrides": {
     "fast-uri": "3.1.4",
     "lodash": "4.18.1",
+    "brace-expansion": "5.0.8",
+    "tar": "7.5.22",
     "@modelcontextprotocol/sdk": {
       "@hono/node-server": "2.0.11"
     }

--- a/frontend/src/main/webapp/package.json
+++ b/frontend/src/main/webapp/package.json
@@ -84,6 +84,13 @@
     "node": "^22.22.3 || ^24.15.0 || ^26.0.0",
     "npm": ">=11.17.0"
   },
+  "overrides": {
+    "fast-uri": "3.1.4",
+    "lodash": "^4.18.0",
+    "@modelcontextprotocol/sdk": {
+      "@hono/node-server": "^2.0.5"
+    }
+  },
   "allowScripts": {
     "core-js@3.49.0": true,
     "cypress@15.18.1": true,

--- a/frontend/src/main/webapp/package.json
+++ b/frontend/src/main/webapp/package.json
@@ -86,9 +86,9 @@
   },
   "overrides": {
     "fast-uri": "3.1.4",
-    "lodash": "^4.18.0",
+    "lodash": "4.18.1",
     "@modelcontextprotocol/sdk": {
-      "@hono/node-server": "^2.0.5"
+      "@hono/node-server": "2.0.11"
     }
   },
   "allowScripts": {


### PR DESCRIPTION
## Summary
Fixes the 5 open [Dependabot alerts](https://github.com/wrk-tafel/admin/security/dependabot) plus 2 additional issues surfaced by `npm audit` — all transitive `devDependencies`, none of which we depend on directly. `npm audit` now reports **0 vulnerabilities**.

| Package | Severity | Pulled in via | Pinned to |
|---|---|---|---|
| `fast-uri` ([#448](https://github.com/wrk-tafel/admin/security/dependabot/448)) | high | `ajv` (used by `@angular/cli`, `eslint`) | `3.1.4` |
| `@hono/node-server` ([#447](https://github.com/wrk-tafel/admin/security/dependabot/447)) | medium | `@modelcontextprotocol/sdk` (bundled by `@angular/cli`) | `2.0.11` (scoped override) |
| `lodash` ([#371](https://github.com/wrk-tafel/admin/security/dependabot/371), [#370](https://github.com/wrk-tafel/admin/security/dependabot/370), [#318](https://github.com/wrk-tafel/admin/security/dependabot/318)) | high/medium | `cypress-browser-permissions` (pins an exact vulnerable `4.17.21`, no range) | `4.18.1` |
| `brace-expansion` | high | `minimatch` | `5.0.8` |
| `tar` | moderate | `node-gyp`, `pacote` | `7.5.22` |

All overrides are pinned to exact versions (not ranges) for the same reproducibility reason as the rest of this dependency-locking work. Every override except `@hono/node-server` is an ordinary semver-compatible bump within the range the parent package already declares:
- `ajv` already declares `^3.0.1` for fast-uri, `cypress`/`wait-on` already resolve lodash to `4.18.1` elsewhere in the tree, `minimatch` declares `^5.0.5` for brace-expansion, `node-gyp`/`pacote` declare `^7.5.x`/`^7.4.3` for tar — all satisfied by the pinned versions.
- `@hono/node-server` is a major bump (1.x → 2.x) relative to what `@modelcontextprotocol/sdk` declares (`^1.19.9`). Scoped narrowly to that one dependency edge. This package is only used by Angular CLI's optional MCP server feature, which this project's build/test/lint pipeline never invokes, so the risk is minimal.

## Test plan
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run lint` passes
- [x] `npm run test-ci` passes (483 tests, 1 pre-existing skip)
- [x] `npm run build-prod` succeeds