### PR TITLE
Fix SonarCloud code smells and CI script-execution hotspot

### DIFF
--- a/.github/workflows/subflow_e2e_test.yml
+++ b/.github/workflows/subflow_e2e_test.yml
@@ -37,7 +37,10 @@ jobs:
         with:
           name: admin-jarfile
           path: ./artifact
-      - run: npm ci
+      - run: npm ci --ignore-scripts
+        working-directory: frontend/src/main/webapp
+      - name: Install cypress binary
+        run: npx cypress install
         working-directory: frontend/src/main/webapp
       - name: Run cypress
         run: |

--- a/.github/workflows/subflow_e2e_test.yml
+++ b/.github/workflows/subflow_e2e_test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm ci --ignore-scripts
         working-directory: frontend/src/main/webapp
       - name: Install cypress binary
-        run: npx cypress install
+        run: node_modules/.bin/cypress install
         working-directory: frontend/src/main/webapp
       - name: Run cypress
         run: |

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/TafelActiveDistributionRequiredInterceptor.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/TafelActiveDistributionRequiredInterceptor.kt
@@ -21,11 +21,9 @@ class TafelActiveDistributionRequiredInterceptor(
             val methodAnnotation = handler.method.getAnnotation(TafelActiveDistributionRequired::class.java)
             val classAnnotation = handler.beanType.getAnnotation(TafelActiveDistributionRequired::class.java)
 
-            if (methodAnnotation != null || classAnnotation != null) {
-                // Check if an active distribution exists
-                if (distributionRepository.getCurrentDistribution() == null) {
-                    throw TafelValidationException("Ausgabe nicht gestartet!")
-                }
+            // Check if the method/class requires an active distribution and none exists
+            if ((methodAnnotation != null || classAnnotation != null) && distributionRepository.getCurrentDistribution() == null) {
+                throw TafelValidationException("Ausgabe nicht gestartet!")
             }
         }
         return true

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
@@ -88,13 +88,14 @@ class DistributionController(
     @TafelActiveDistributionRequired
     fun closeDistribution(@RequestParam forceClose: Boolean = false): ResponseEntity<DistributionCloseValidationResult> {
         val closeValidationResult = service.validateClose()
-        if (closeValidationResult.isInvalid()) {
+        return if (closeValidationResult.isInvalid()) {
             if (forceClose && closeValidationResult.hasOnlyWarnings()) {
-                return closeAndNotify()
+                closeAndNotify()
+            } else {
+                ResponseEntity.ok(closeValidationResult)
             }
-            return ResponseEntity.ok(closeValidationResult)
         } else {
-            return closeAndNotify()
+            closeAndNotify()
         }
     }
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
@@ -7,6 +7,7 @@ import at.wrk.tafel.admin.backend.database.common.lock.AdvisoryLockService
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.customer.CustomerRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.*
+import at.wrk.tafel.admin.backend.database.model.logistics.RouteEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
@@ -233,7 +234,7 @@ class DistributionService(
                 )
             } else {
                 // Warnings
-                val routes = routeRepository.findAll()
+                val routes: List<RouteEntity> = routeRepository.findAll()
                 val missingRoutes =
                     routes.map { it.number } - currentDistribution.foodCollections.map { it.route!!.number }
                 if (missingRoutes.isNotEmpty()) {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteService.kt
@@ -13,7 +13,7 @@ class RouteService(
 
     @Transactional
     fun getRoutes(): List<Route> {
-        val routes = routeRepository.findAll()
+        val routes: List<RouteEntity> = routeRepository.findAll()
         return routes.map { mapRoute(it) }
     }
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DailyReportPdfModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DailyReportPdfModel.kt
@@ -37,28 +37,26 @@ data class DailyReportPdfModel(
 
         other as DailyReportPdfModel
 
-        if (logoContentType != other.logoContentType) return false
-        if (!logoBytes.contentEquals(other.logoBytes)) return false
-        if (date != other.date) return false
-        if (employeeCount != other.employeeCount) return false
-        if (countCustomers != other.countCustomers) return false
-        if (countPersons != other.countPersons) return false
-        if (countInfants != other.countInfants) return false
-        if (averagePersonsPerCustomer != other.averagePersonsPerCustomer) return false
-        if (countCustomersNew != other.countCustomersNew) return false
-        if (countPersonsNew != other.countPersonsNew) return false
-        if (countCustomersProlonged != other.countCustomersProlonged) return false
-        if (countPersonsProlonged != other.countPersonsProlonged) return false
-        if (countCustomersUpdated != other.countCustomersUpdated) return false
-        if (shopsTotalCount != other.shopsTotalCount) return false
-        if (shopsWithFoodCount != other.shopsWithFoodCount) return false
-        if (foodTotalAmount != other.foodTotalAmount) return false
-        if (foodPerShopAverage != other.foodPerShopAverage) return false
-        if (routesLengthKm != other.routesLengthKm) return false
-        if (shelters != other.shelters) return false
-        if (personsInSheltersTotalCount != other.personsInSheltersTotalCount) return false
-
-        return true
+        return logoContentType == other.logoContentType &&
+                logoBytes.contentEquals(other.logoBytes) &&
+                date == other.date &&
+                employeeCount == other.employeeCount &&
+                countCustomers == other.countCustomers &&
+                countPersons == other.countPersons &&
+                countInfants == other.countInfants &&
+                averagePersonsPerCustomer == other.averagePersonsPerCustomer &&
+                countCustomersNew == other.countCustomersNew &&
+                countPersonsNew == other.countPersonsNew &&
+                countCustomersProlonged == other.countCustomersProlonged &&
+                countPersonsProlonged == other.countPersonsProlonged &&
+                countCustomersUpdated == other.countCustomersUpdated &&
+                shopsTotalCount == other.shopsTotalCount &&
+                shopsWithFoodCount == other.shopsWithFoodCount &&
+                foodTotalAmount == other.foodTotalAmount &&
+                foodPerShopAverage == other.foodPerShopAverage &&
+                routesLengthKm == other.routesLengthKm &&
+                shelters == other.shelters &&
+                personsInSheltersTotalCount == other.personsInSheltersTotalCount
     }
 
     override fun hashCode(): Int {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
@@ -313,7 +313,7 @@ class StatisticsService(
         return query.resultList.map { row ->
             val cols = row as Array<*>
             val label = cols[0] as String
-            val value = if (cols[1] != null) cols[1] as Number else 0
+            val value = cols[1] as? Number ?: 0
             // Locale.ROOT (dot decimal separator) here, not the JVM default (de-AT, comma separator) - this
             // round-trips through Kotlin's locale-independent String.toDouble(), which would throw
             // NumberFormatException on a comma-formatted string like "0,00".

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/api/ActiveDistributionRequiredInterceptorTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/api/ActiveDistributionRequiredInterceptorTest.kt
@@ -6,6 +6,7 @@ import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationExceptio
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionEntity
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.assertj.core.api.Assertions.assertThat
@@ -54,8 +55,41 @@ class ActiveDistributionRequiredInterceptorTest {
         assertTrue(result)
     }
 
+    @Test
+    fun `preHandle returns true and skips distribution lookup if HandlerMethod has no annotation`() {
+        val handlerMethod = mockk<HandlerMethod>()
+        val method = this::class.java.getDeclaredMethod("unannotatedMethod")
+        every { handlerMethod.method } returns method
+        every { handlerMethod.beanType } returns this::class.java
+
+        val result = interceptor.preHandle(request, response, handlerMethod)
+
+        assertTrue(result)
+        verify(exactly = 0) { distributionRepository.findFirstByOrderByIdDesc() }
+    }
+
+    @Test
+    fun `preHandle throws exception if only class annotation present and no active distribution`() {
+        val handlerMethod = mockk<HandlerMethod>()
+        val method = this::class.java.getDeclaredMethod("unannotatedMethod")
+        every { handlerMethod.method } returns method
+        every { handlerMethod.beanType } returns AnnotatedClass::class.java
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns null
+
+        val exception = assertThrows<TafelValidationException> {
+            interceptor.preHandle(request, response, handlerMethod)
+        }
+        assertThat(exception.message).isEqualTo("Ausgabe nicht gestartet!")
+    }
+
     @TafelActiveDistributionRequired
     fun annotatedMethod() {
     }
+
+    fun unannotatedMethod() {
+    }
+
+    @TafelActiveDistributionRequired
+    class AnnotatedClass
 
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sse_outbox/SseOutboxServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sse_outbox/SseOutboxServiceTest.kt
@@ -13,12 +13,15 @@ import io.mockk.verify
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder
 import tools.jackson.databind.json.JsonMapper
+import java.io.IOException
 import java.util.function.Consumer
 
 @ExtendWith(MockKExtension::class)
@@ -188,6 +191,78 @@ class SseOutboxServiceTest {
         service.sendEvent(sseEmitter, testPayload)
 
         verify { sseEmitter.send(any<SseEventBuilder>()) }
+    }
+
+    @Test
+    fun `forward notification events logs error when registering callback fails`() = runBlocking {
+        every {
+            sseOutboxListenerService.registerCallback(notificationName = notificationName, eventCallback = any())
+        } throws IllegalStateException("registration failed")
+
+        service.forwardNotificationEventsToSse(
+            sseEmitter = sseEmitter,
+            notificationName = notificationName,
+            resultType = TestJsonPayload::class.java
+        )
+        delay(1000)
+
+        verify {
+            sseOutboxListenerService.registerCallback(notificationName = notificationName, eventCallback = any())
+        }
+    }
+
+    @Test
+    fun `listen for notification events logs error when registering callback fails`() = runBlocking {
+        every {
+            sseOutboxListenerService.registerCallback(notificationName = notificationName, eventCallback = any())
+        } throws IllegalStateException("registration failed")
+
+        service.listenForNotificationEvents<Unit>(
+            sseEmitter = sseEmitter,
+            notificationName = notificationName,
+            resultType = null
+        ) { }
+        delay(1000)
+
+        verify {
+            sseOutboxListenerService.registerCallback(notificationName = notificationName, eventCallback = any())
+        }
+    }
+
+    @Test
+    fun `send event completes emitter when AsyncRequestNotUsableException occurs`() {
+        val sseEmitter = mockk<SseEmitter>()
+        every { sseEmitter.send(any<SseEventBuilder>()) } throws AsyncRequestNotUsableException("disconnected")
+        every { sseEmitter.complete() } returns Unit
+
+        assertThatCode { service.sendEvent(sseEmitter, testPayload) }.doesNotThrowAnyException()
+
+        verify { sseEmitter.complete() }
+    }
+
+    @Test
+    fun `send event ignores exception when completing an already completed emitter`() {
+        val sseEmitter = mockk<SseEmitter>()
+        every { sseEmitter.send(any<SseEventBuilder>()) } throws AsyncRequestNotUsableException("disconnected")
+        every { sseEmitter.complete() } throws IllegalStateException("already completed")
+
+        assertThatCode { service.sendEvent(sseEmitter, testPayload) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `send event handles IOException`() {
+        val sseEmitter = mockk<SseEmitter>()
+        every { sseEmitter.send(any<SseEventBuilder>()) } throws IOException("broken pipe")
+
+        assertThatCode { service.sendEvent(sseEmitter, testPayload) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `send event handles IllegalStateException`() {
+        val sseEmitter = mockk<SseEmitter>()
+        every { sseEmitter.send(any<SseEventBuilder>()) } throws IllegalStateException("already completed")
+
+        assertThatCode { service.sendEvent(sseEmitter, testPayload) }.doesNotThrowAnyException()
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/customer/CustomerControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/customer/CustomerControllerTest.kt
@@ -177,6 +177,15 @@ class CustomerControllerTest {
     }
 
     @Test
+    fun `create customer - force defaults to false when omitted`() {
+        every { customerService.existsByCustomerId(testCustomer.id!!) } returns false
+
+        controller.createCustomer(customer = testCustomer)
+
+        verify { customerService.createCustomer(testCustomer, false, false) }
+    }
+
+    @Test
     fun `update customer - does not exist`() {
         every { customerService.existsByCustomerId(testCustomer.id!!) } returns false
 
@@ -221,6 +230,24 @@ class CustomerControllerTest {
 
         assertThat(response.data).isEqualTo(testCustomer)
         verify { customerService.updateCustomer(testCustomer.id!!, testCustomer, true, isSupervisor) }
+    }
+
+    @Test
+    fun `update customer - force defaults to false when omitted`() {
+        every { customerService.existsByCustomerId(testCustomer.id!!) } returns true
+        every {
+            customerService.updateCustomer(
+                testCustomer.id!!,
+                testCustomer,
+                false,
+                isSupervisor
+            )
+        } returns CustomerUpdateResponse(data = testCustomer, errorMsg = null)
+
+        val response = controller.updateCustomer(customerId = testCustomer.id!!, customer = testCustomer)
+
+        assertThat(response.data).isEqualTo(testCustomer)
+        verify { customerService.updateCustomer(testCustomer.id!!, testCustomer, false, isSupervisor) }
     }
 
     @Test
@@ -309,6 +336,34 @@ class CustomerControllerTest {
     }
 
     @Test
+    fun `get customers - all filters default when omitted`() {
+        val testSearchResult = CustomerSearchResult(
+            items = listOf(testCustomer),
+            totalCount = 123,
+            currentPage = 1,
+            totalPages = 10,
+            pageSize = 10
+        )
+        every {
+            customerService.getCustomers(null, null, null, null, null, null)
+        } returns testSearchResult
+
+        val response = controller.getCustomers()
+
+        verify {
+            customerService.getCustomers(
+                firstname = null,
+                lastname = null,
+                page = null,
+                postProcessing = null,
+                costContribution = null,
+                valid = null,
+            )
+        }
+        assertThat(response.items).hasSize(1)
+    }
+
+    @Test
     fun `generate pdf - no result`() {
         every { customerService.generatePdf(any(), any()) } returns null
 
@@ -366,6 +421,34 @@ class CustomerControllerTest {
         assertThat(duplicatesResponse.pageSize).isEqualTo(searchResult.pageSize)
         assertThat(duplicatesResponse.totalPages).isEqualTo(searchResult.totalPages)
         assertThat(duplicatesResponse.totalCount).isEqualTo(searchResult.totalCount)
+    }
+
+    @Test
+    fun `get duplicates - page defaults to null when omitted`() {
+        val searchResult = CustomerDuplicateSearchResult(
+            items = emptyList(),
+            totalCount = 0,
+            currentPage = 1,
+            totalPages = 0,
+            pageSize = 5
+        )
+        every { customerDuplicationService.findDuplicates(null) } returns searchResult
+
+        val duplicatesResponse = controller.getDuplicates()
+
+        assertThat(duplicatesResponse.items).isEmpty()
+        verify { customerDuplicationService.findDuplicates(null) }
+    }
+
+    @Test
+    fun `merge into customer`() {
+        val customerId = 100L
+        val request = CustomerMergeRequest(sourceCustomerIds = listOf(200L, 300L))
+
+        val response = controller.mergeIntoCustomer(customerId, request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        verify { customerService.mergeCustomers(customerId, request.sourceCustomerIds) }
     }
 
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/customer/internal/CustomerServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/customer/internal/CustomerServiceTest.kt
@@ -254,6 +254,35 @@ class CustomerServiceTest {
     }
 
     @Test
+    fun `create customer - non-supervisor with invalid income should set validUntil to yesterday`() {
+        val testCustomer = mockk<Customer>(relaxed = true)
+        val testCustomerEntity = CustomerEntity()
+
+        every { customerConverter.mapEntityToCustomer(testCustomerEntity) } returns testCustomer
+        every { customerConverter.mapCustomerToEntity(testCustomer) } returns testCustomerEntity
+        every { customerRepository.save(any()) } returns testCustomerEntity
+
+        every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
+            valid = false,
+            totalSum = BigDecimal("1"),
+            limit = BigDecimal("2"),
+            toleranceValue = BigDecimal("3"),
+            amountExceededLimit = BigDecimal("4")
+        )
+
+        val result = service.createCustomer(testCustomer, force = false, isSupervisor = false)
+
+        assertThat(result).isEqualTo(
+            CustomerCreationResponse(
+                data = testCustomer,
+                errorMsg = "Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet"
+            )
+        )
+        assertThat(testCustomerEntity.validUntil).isEqualTo(LocalDate.now().minusDays(1))
+        verify(exactly = 1) { customerRepository.save(testCustomerEntity) }
+    }
+
+    @Test
     fun `update customer is valid`() {
         val customerId = 123L
 
@@ -310,6 +339,34 @@ class CustomerServiceTest {
         assertThat(result).isEqualTo(CustomerUpdateResponse(data = testCustomerUpdate, errorMsg = "Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet"))
         verify(exactly = 1) { customerRepository.save(testCustomerEntity) }
         verify(exactly = 1) { customerConverter.mapCustomerToEntity(any(), any()) }
+    }
+
+    @Test
+    fun `update customer - supervisor with invalid income and force=false should throw exception`() {
+        val customerId = 123L
+
+        val testCustomerUpdate = mockk<Customer>(relaxed = true)
+        every { testCustomerUpdate.id } returns customerId
+
+        val testCustomerEntity = CustomerEntity()
+        every { customerRepository.getReferenceByCustomerId(customerId) } returns testCustomerEntity
+        every { customerConverter.mapCustomerToEntity(any(), any()) } returns testCustomerEntity
+
+        every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
+            valid = false,
+            totalSum = BigDecimal("1"),
+            limit = BigDecimal("2"),
+            toleranceValue = BigDecimal("3"),
+            amountExceededLimit = BigDecimal("4")
+        )
+
+        val exception = assertThrows<TafelValidationException> {
+            service.updateCustomer(testCustomerUpdate.id!!, testCustomerUpdate, force = false, isSupervisor = true)
+        }
+
+        assertThat(exception.message).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
+        assertThat(exception.status).isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
+        verify(exactly = 0) { customerRepository.save(any()) }
     }
 
     @Test
@@ -396,6 +453,44 @@ class CustomerServiceTest {
         assertThat(result).isNotNull
         assertThat(result?.filename).isEqualTo("stammdaten-100-mustermann-max.pdf")
         assertThat(result?.bytes?.size).isEqualTo(pdfBytes.size.toLong())
+    }
+
+    @Test
+    fun `generate pdf customer - IDCARD type`() {
+        val testCustomerEntity = mockk<CustomerEntity>(relaxed = true)
+        every { testCustomerEntity.customerId } returns 100
+        every { testCustomerEntity.firstname } returns "max"
+        every { testCustomerEntity.lastname } returns "mustermann"
+
+        val pdfBytes = ByteArray(10)
+        every { customerRepository.findByCustomerId(any()) } returns testCustomerEntity
+        every { customerPdfService.generateIdCardPdf(any()) } returns pdfBytes
+
+        val result = service.generatePdf(1, CustomerPdfType.IDCARD)
+
+        assertThat(result).isNotNull
+        assertThat(result?.filename).isEqualTo("ausweis-100-mustermann-max.pdf")
+        assertThat(result?.bytes?.size).isEqualTo(pdfBytes.size.toLong())
+        verify(exactly = 1) { customerPdfService.generateIdCardPdf(testCustomerEntity) }
+    }
+
+    @Test
+    fun `generate pdf customer - COMBINED type`() {
+        val testCustomerEntity = mockk<CustomerEntity>(relaxed = true)
+        every { testCustomerEntity.customerId } returns 100
+        every { testCustomerEntity.firstname } returns "max"
+        every { testCustomerEntity.lastname } returns "mustermann"
+
+        val pdfBytes = ByteArray(10)
+        every { customerRepository.findByCustomerId(any()) } returns testCustomerEntity
+        every { customerPdfService.generateCombinedPdf(any()) } returns pdfBytes
+
+        val result = service.generatePdf(1, CustomerPdfType.COMBINED)
+
+        assertThat(result).isNotNull
+        assertThat(result?.filename).isEqualTo("stammdaten-ausweis-100-mustermann-max.pdf")
+        assertThat(result?.bytes?.size).isEqualTo(pdfBytes.size.toLong())
+        verify(exactly = 1) { customerPdfService.generateCombinedPdf(testCustomerEntity) }
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
@@ -2,7 +2,9 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
+import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContact
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter1
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter2
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter3
@@ -10,8 +12,10 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
@@ -144,5 +148,97 @@ class ShelterServiceTest {
 
         verify { shelterRepository.save(any()) }
     }
+
+    @Test
+    fun `create shelter with contacts`() {
+        val createInput = Shelter(
+            id = 0L,
+            name = "New Shelter",
+            addressStreet = "New Street",
+            addressHouseNumber = "10",
+            addressStairway = null,
+            addressPostalCode = 11111,
+            addressDoor = null,
+            addressCity = "New City",
+            note = "New note",
+            personsCount = 5,
+            enabled = true,
+            contacts = listOf(
+                ShelterContact(firstname = "Max", lastname = "Mustermann", phone = "0123456789")
+            )
+        )
+
+        every { shelterRepository.save(any()) } answers {
+            val arg = firstArg() as ShelterEntity
+            arg.id = 42
+            arg
+        }
+
+        val result = service.createShelter(createInput)
+
+        assertThat(result.contacts).containsExactly(
+            ShelterContact(firstname = "Max", lastname = "Mustermann", phone = "0123456789")
+        )
+
+        val savedEntitySlot = slot<ShelterEntity>()
+        verify { shelterRepository.save(capture(savedEntitySlot)) }
+        assertThat(savedEntitySlot.captured.contacts).hasSize(1)
+        assertThat(savedEntitySlot.captured.contacts.first().shelter).isSameAs(savedEntitySlot.captured)
+    }
+
+    @Test
+    fun `update shelter with contacts`() {
+        val updated = Shelter(
+            id = testShelter3.id!!,
+            name = "Updated Shelter",
+            addressStreet = testShelter3.addressStreet!!,
+            addressHouseNumber = testShelter3.addressHouseNumber!!,
+            addressStairway = testShelter3.addressStairway,
+            addressPostalCode = testShelter3.addressPostalCode!!,
+            addressCity = testShelter3.addressCity!!,
+            addressDoor = testShelter3.addressDoor,
+            note = "Updated note",
+            personsCount = 5,
+            enabled = false,
+            contacts = listOf(
+                ShelterContact(firstname = "Erika", lastname = "Musterfrau", phone = "0987654321")
+            )
+        )
+
+        every { shelterRepository.findByIdOrNull(testShelter3.id!!) } returns testShelter3
+        every { shelterRepository.save(any()) } answers { firstArg() as ShelterEntity }
+
+        val result = service.updateShelter(testShelter3.id!!, updated)
+
+        assertThat(result).isEqualTo(updated)
+
+        val savedEntitySlot = slot<ShelterEntity>()
+        verify { shelterRepository.save(capture(savedEntitySlot)) }
+        assertThat(savedEntitySlot.captured.contacts.first().shelter).isSameAs(savedEntitySlot.captured)
+    }
+
+    @Test
+    fun `update shelter throws exception when not found`() {
+        every { shelterRepository.findByIdOrNull(99L) } returns null
+
+        assertThatThrownBy { service.updateShelter(99L, testShelter3ShelterModel()) }
+            .isInstanceOf(TafelValidationException::class.java)
+            .hasMessage("Shelter with id 99 not found")
+    }
+
+    private fun testShelter3ShelterModel() = Shelter(
+        id = testShelter3.id!!,
+        name = testShelter3.name!!,
+        addressStreet = testShelter3.addressStreet!!,
+        addressHouseNumber = testShelter3.addressHouseNumber!!,
+        addressStairway = testShelter3.addressStairway,
+        addressPostalCode = testShelter3.addressPostalCode!!,
+        addressCity = testShelter3.addressCity!!,
+        addressDoor = testShelter3.addressDoor,
+        note = testShelter3.note,
+        personsCount = testShelter3.personsCount!!,
+        enabled = testShelter3.enabled!!,
+        contacts = emptyList()
+    )
 
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
@@ -355,6 +355,24 @@ internal class StatisticsServiceTest {
     }
 
     @Test
+    fun `executeStatsQuery defaults to zero when value column is null`() {
+        val fromDate = LocalDate.now().minusDays(7)
+        val toDate = LocalDate.now()
+
+        val mockQuery = mockk<Query>(relaxed = true)
+        every { entityManager.createNativeQuery(any<String>()) } returns mockQuery
+        every { mockQuery.resultList } returns listOf(
+            arrayOf<Any?>("KW1", null)
+        )
+
+        val result = service.averageShelters(fromDate, toDate)
+
+        assertThat(result).containsExactly(
+            StatisticsResult(label = "KW1", value = 0)
+        )
+    }
+
+    @Test
     fun `get data`() {
         val fromDate = LocalDate.now().minusDays(7)
         val toDate = LocalDate.now()

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelUserDetailsManagerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelUserDetailsManagerTest.kt
@@ -32,6 +32,8 @@ import org.passay.FailureValidationResult
 import org.passay.PasswordData
 import org.passay.PasswordValidator
 import org.passay.RuleResult
+import org.passay.RuleResultDetail
+import org.passay.RuleResultMetadata
 import org.passay.SuccessValidationResult
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
@@ -177,6 +179,45 @@ class TafelUserDetailsManagerTest {
                 assertThat(it.passwordChangeRequired).isFalse()
             })
         }
+    }
+
+    @Test
+    fun `changePassword - old password missing throws exception`() {
+        val exception = assertThrows<PasswordChangeException> {
+            manager.changePassword(null, "67890")
+        }
+        assertThat(exception.message).isEqualTo("Aktuelles Passwort ist falsch!")
+
+        verify(exactly = 0) { userRepository.findByUsername(any()) }
+        verify(exactly = 0) { userRepository.save(any()) }
+    }
+
+    @Test
+    fun `changePassword - new password missing throws exception`() {
+        val exception = assertThrows<PasswordChangeException> {
+            manager.changePassword("12345", null)
+        }
+        assertThat(exception.message).isEqualTo("Aktuelles Passwort ist falsch!")
+
+        verify(exactly = 0) { userRepository.findByUsername(any()) }
+        verify(exactly = 0) { userRepository.save(any()) }
+    }
+
+    @Test
+    fun `changePassword - new password invalid with unrecognized error code produces no detail message`() {
+        every { passwordValidator.validate(any()) } returns FailureValidationResult(
+            RuleResultMetadata(),
+            listOf(RuleResultDetail("SOME_UNRECOGNIZED_ERROR_CODE", emptyMap()))
+        )
+
+        val currentPassword = "12345"
+        val newPassword = "67890"
+
+        val exception = assertThrows<PasswordChangeException> {
+            manager.changePassword(currentPassword, newPassword)
+        }
+        assertThat(exception.message).isEqualTo("Das neue Passwort ist ungültig!")
+        assertThat(exception.validationDetails).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes several open code-smell findings from [SonarCloud](https://sonarcloud.io/project/overview?id=wrk-tafel-admin): a redundant null-check, nested-if merge, lifted return statements, two `findAll()` results now typed as read-only `List`, and a rewritten `DailyReportPdfModel.equals()` that cuts cognitive complexity from 22 down to well under the rule's limit of 15.
- Hardens the e2e workflow against the "lifecycle scripts run during package install" security hotspot by adding `--ignore-scripts` to `npm ci`, with an explicit `npx cypress install` step so the Cypress binary still gets downloaded — mirroring the pattern already used in `subflow_lint.yml`.

Out of scope: the `personsInShelterCount` deprecated field/column and 5 informational TODO-comment findings were reviewed but intentionally left as-is (deferred to a follow-up).

## Test plan
- [x] `./gradlew :backend:compileKotlin :backend:compileTestKotlin` — builds clean
- [x] `./gradlew :backend:test` — full backend suite passes
- [ ] CI (lint/build/e2e workflows) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)