### PR TITLE
Prepare households/persons cleanup migration (do not merge yet)

### DIFF
--- a/HOUSEHOLD_PERSON_REFACTORING_PLAN.md
+++ b/HOUSEHOLD_PERSON_REFACTORING_PLAN.md
@@ -395,9 +395,16 @@ Rename/rework in lockstep with the schema (grouped by concern; file paths from c
 4. Smoke-test manually: search a household, view detail, edit (add/remove a household member),
    create a note, assign to a distribution, generate a PDF, run a statistics export.
 5. Observe for **1–2 weeks** (decision D) with the old tables left in place, unused.
-6. Ship the **cleanup migration**: drop `customers`, `customers_addpersons`, drop
-   `customer_id_sequence` if unused (or repurpose it for `households.household_id` generation
-   instead of introducing a new sequence — simpler, avoids gaps), drop now-dead code paths.
+6. Ship the **cleanup migration** — ✅ **prepared**, on branch `household-person-cleanup`, as
+   `backend/src/main/resources/db-migration/R__00068_household_person_cleanup.sql`: drops
+   `customers`/`customers_addpersons` (guarded by an abort-if-any-row-is-unmigrated check; no
+   `customer_id_sequence` drop needed, it was renamed to `household_id_sequence` in R__00067 step
+   7, not left behind). Validated against throwaway Postgres containers: fresh install, fresh
+   install + real `testdata.sql`, idempotent re-run after the tables are already gone, and an
+   explicit orphan-row case confirming the migration aborts (does not drop) instead of losing
+   data. **Deliberately not merged into `main` yet** — merge only after the 1–2 week production
+   observation window (step 5) has passed and the Phase 2 verification queries have been
+   re-checked against production, per Guiding principle 5 ("old tables stay until proven safe").
 
 ## 6. Risk register
 

--- a/backend/src/main/resources/db-migration/R__00068_household_person_cleanup.sql
+++ b/backend/src/main/resources/db-migration/R__00068_household_person_cleanup.sql
@@ -1,0 +1,55 @@
+-- Cleanup migration for the households/persons refactor (see
+-- HOUSEHOLD_PERSON_REFACTORING_PLAN.md, Phase 8 step 6, and R__00067).
+--
+-- customers/customers_addpersons were kept read-only/unused after R__00067 migrated their data
+-- into households/persons, specifically so production could run on the new tables for a 1-2 week
+-- observation window before this drop. DO NOT MERGE/DEPLOY THIS FILE until that observation
+-- window has passed and the Phase 2 verification queries have been re-checked against production.
+--
+-- Safe to drop without cascade: no DB-level FK references either table any more -
+-- customers_notes/distributions_customers were renamed and redirected to households in R__00067
+-- (rename table + rename column + drop/add constraint), and customers_addpersons.customer_id was
+-- never an enforced FK to begin with (see R__00004_customer_tables.sql). The indexes added in
+-- R__00066 (idx_customers_valid_until, idx_customers_addpersons_customer_id) live on these tables
+-- and are dropped automatically along with them.
+--
+-- Guarded so a partial failure (or an unexpectedly-stale households/persons copy) can't silently
+-- destroy data: aborts instead of dropping if either table is missing rows that were never
+-- carried over, or if the tables are already gone (nothing left to verify, nothing to drop).
+do $$
+declare
+    missing_households bigint;
+    missing_persons bigint;
+begin
+    if not exists (select 1 from information_schema.tables where table_name = 'customers')
+        and not exists (select 1 from information_schema.tables where table_name = 'customers_addpersons') then
+        return;
+    end if;
+
+    select count(*) into missing_households
+    from customers c
+    where not exists (select 1 from households h where h.id = c.id);
+
+    if missing_households > 0 then
+        raise exception 'household_person_cleanup: % row(s) in customers have no matching households row, aborting drop', missing_households;
+    end if;
+
+    select count(*) into missing_persons
+    from customers c
+    where not exists (select 1 from persons p where p.id = c.id and p.is_main_person = true);
+
+    if missing_persons > 0 then
+        raise exception 'household_person_cleanup: % row(s) in customers have no matching main person in persons, aborting drop', missing_persons;
+    end if;
+
+    select count(*) into missing_persons
+    from customers_addpersons cap
+    where not exists (select 1 from persons p where p.id = cap.id);
+
+    if missing_persons > 0 then
+        raise exception 'household_person_cleanup: % row(s) in customers_addpersons have no matching persons row, aborting drop', missing_persons;
+    end if;
+end $$;
+
+drop table if exists customers_addpersons;
+drop table if exists customers;


### PR DESCRIPTION
## Summary
- Adds `R__00068_household_person_cleanup.sql`, Phase 8 step 6 of `HOUSEHOLD_PERSON_REFACTORING_PLAN.md`: drops the legacy `customers`/`customers_addpersons` tables now that #2736 has migrated everything onto `households`/`persons`.
- Guarded with a check that **aborts instead of dropping** if any row wasn't carried over — validated against a throwaway Postgres container with an explicit orphan-row case.
- Updates the plan doc to record this as prepared.

## ⚠️ Do not merge yet
Per the plan's Guiding principle 5 / Decision D, `customers`/`customers_addpersons` must stay in place, unused, for a **1–2 week production observation window** after #2736 is deployed, before this drop ships. This PR exists so the cleanup is ready to go, reviewed in advance, and merged as its own small change once that window has passed and the Phase 2 verification queries have been re-checked against production.

## Test plan
- [x] Fresh install (empty DB) through R__00067 + R__00068 — no errors
- [x] Fresh install + real `testdata.sql` + R__00068 — tables drop cleanly, `households`/`persons` untouched
- [x] Idempotent re-run of R__00068 after tables are already gone — no-op, no error
- [x] Orphan row in `customers` with no matching `households` row — migration aborts, tables NOT dropped
- [x] `./gradlew :backend:compileKotlin :backend:compileTestKotlin` — no references to removed tables/entities remain
- [x] `HouseholdServiceIT` / `HouseholdEntitySpecsIT` (Testcontainers, full migration chain incl. R__00068) — pass
- [ ] Merge only after the production observation window for #2736 has passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)