### PR TITLE
Add persons count column to customer search table

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
@@ -97,6 +97,11 @@
                 <td mat-cell *matCellDef="let customer; let i = index" [attr.testid]="'searchresult-address-' + i" class="px-4 py-2">{{customer.address | formatCustomerAddress}}</td>
               </ng-container>
 
+              <ng-container matColumnDef="personsCount">
+                <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Personen</th>
+                <td mat-cell *matCellDef="let customer; let i = index" [attr.testid]="'searchresult-personsCount-' + i" class="px-4 py-2">{{1 + (customer.additionalPersons?.length ?? 0)}}</td>
+              </ng-container>
+
               <ng-container matColumnDef="issuedAt">
                 <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Ausgestellt am</th>
                 <td mat-cell *matCellDef="let customer; let i = index" [attr.testid]="'searchresult-issuedAt-' + i" class="px-4 py-2">{{!customer.issuedAt ? '-' : customer.issuedAt | date : 'dd.MM.yyyy'}}</td>
@@ -143,6 +148,8 @@
                       <div>{{customer.birthDate | date : 'dd.MM.yyyy'}}</div>
                       <div class="font-bold">Adresse:</div>
                       <div>{{customer.address | formatCustomerAddress}}</div>
+                      <div class="font-bold">Personen:</div>
+                      <div>{{1 + (customer.additionalPersons?.length ?? 0)}}</div>
                       <div class="font-bold">Gültig bis:</div>
                       <div>{{customer.validUntil | date : 'dd.MM.yyyy'}}</div>
                     </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.spec.ts
@@ -31,6 +31,9 @@ describe('CustomerSearchComponent', () => {
                     postalCode: 1010,
                     city: 'city'
                 },
+                additionalPersons: [
+                    { key: 1, id: 1, firstname: 'child', lastname: 'last', excludeFromHousehold: false, receivesFamilyBonus: false }
+                ],
             }
         ],
         totalCount: 1,
@@ -115,6 +118,7 @@ describe('CustomerSearchComponent', () => {
         expect(fixture.debugElement.query(By.css('[testid="searchresult-birthDate-0"]')).nativeElement.textContent).toBe('10.05.2000');
         expect(fixture.debugElement.query(By.css('[testid="searchresult-address-0"]')).nativeElement.textContent)
             .toBe('street 1, Stiege stairway1, Top 20, 1010 city');
+        expect(fixture.debugElement.query(By.css('[testid="searchresult-personsCount-0"]')).nativeElement.textContent).toBe('2');
     });
 
     it('search with firstname only', () => {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
@@ -106,7 +106,7 @@ export class CustomerSearchComponent {
   }
 
   // columns for mat-table
-  displayedColumns = ['icon', 'id', 'name', 'birthDate', 'address', 'issuedAt', 'validUntil', 'actions'];
+  displayedColumns = ['icon', 'id', 'name', 'birthDate', 'address', 'personsCount', 'issuedAt', 'validUntil', 'actions'];
 
   get customerId() {
     return this.form.get('customerId')!;


### PR DESCRIPTION
## Summary
- Adds a "Personen" column to the customer search results table, positioned right after "Adresse" (both desktop table and mobile card view)
- Count is `1 (main person) + additionalPersons.length`, using data already returned by the existing `/households` search endpoint — no backend changes required

## Test plan
- [x] `ng test` — updated `customer-search.component.spec.ts` to assert the new column value; all 11 tests pass
- [ ] Manual check in browser: search customers and confirm the "Personen" column shows correct counts for households with additional members

🤖 Generated with [Claude Code](https://claude.com/claude-code)