### PR TITLE
Restore colored background on statistics chart panels

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full h-full">
+<mat-card class="w-full h-full mat-card-primary">
   <mat-card-content>
     <div class="text-sm">{{ $safeNavigationMigration(data()?.subTitle) }}</div>
     <div class="text-2xl font-bold">{{ data()?.title }}</div>

--- a/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.ts
@@ -61,8 +61,8 @@ export class StatisticsPanelComponent {
   private datasetOptionsDefault = {
     backgroundColor: 'transparent',
     borderColor: 'rgba(255,255,255,.55)',
-    pointBackgroundColor: '#1976d2',
-    pointHoverBorderColor: '#1976d2',
+    pointBackgroundColor: '#ffffff',
+    pointHoverBorderColor: '#ffffff',
   };
 
   chartData = computed(() => {


### PR DESCRIPTION
## Summary
- The statistics module's CoreUI → Angular Material migration (`02e5ae0e`) replaced `<c-widget-stat-a color="primary">` with a bare `<mat-card>`, dropping the purple colored background the panels used to have — they now render plain white.
- Re-applies the `mat-card-primary` class (already used by equivalent dashboard stat tiles) to restore the purple background.
- Switches the chart's point color from blue (`#1976d2`) to white to keep contrast against the purple background, matching the existing white line color.

## Test plan
- [ ] `npm run lint` / `npm test` in `frontend/src/main/webapp`
- [ ] Visually confirm the statistics page chart panels render purple with visible white chart lines/points