### PR TITLE
Migrate Hibernate id generation to per-table sequences

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -44,10 +44,6 @@ spring:
       auth: true
       starttls.enable: true
   jpa:
-    properties:
-      hibernate:
-        id:
-          db_structure_naming_strategy: single # TODO migrate to new default strategy (sequence per table)
     open-in-view: false
   thymeleaf:
     prefix: classpath:/mail-templates/

--- a/backend/src/main/resources/db-migration-testdata/testdata.sql
+++ b/backend/src/main/resources/db-migration-testdata/testdata.sql
@@ -1,6 +1,25 @@
 -- adapt sequences
 SELECT setval('household_id_sequence', 10000, false);
-SELECT setval('hibernate_sequence', 10000, false);
+SELECT setval('employees_seq', 10000, false);
+SELECT setval('users_seq', 10000, false);
+SELECT setval('users_authorities_seq', 10000, false);
+SELECT setval('households_seq', 10000, false);
+SELECT setval('persons_seq', 10000, false);
+SELECT setval('household_notes_seq', 10000, false);
+SELECT setval('static_values_seq', 10000, false);
+SELECT setval('distributions_seq', 10000, false);
+SELECT setval('distributions_statistics_seq', 10000, false);
+SELECT setval('distributions_households_seq', 10000, false);
+SELECT setval('shops_seq', 10000, false);
+SELECT setval('routes_seq', 10000, false);
+SELECT setval('routes_stops_seq', 10000, false);
+SELECT setval('food_categories_seq', 10000, false);
+SELECT setval('cars_seq', 10000, false);
+SELECT setval('food_collections_seq', 10000, false);
+SELECT setval('shelters_seq', 10000, false);
+SELECT setval('shelters_contacts_seq', 10000, false);
+SELECT setval('distributions_statistics_shelters_seq', 10000, false);
+SELECT setval('mail_recipients_seq', 10000, false);
 
 -- user e2etest for cypress tests
 -- pwd: e2etest

--- a/backend/src/main/resources/db-migration/R__00059_dashboard_add_notification_trigger.sql
+++ b/backend/src/main/resources/db-migration/R__00059_dashboard_add_notification_trigger.sql
@@ -8,7 +8,7 @@ BEGIN
     current_second := date_trunc('second', NOW());
 
     INSERT INTO sse_outbox (id, event_time, notification_name, payload)
-    VALUES (nextval('hibernate_sequence'), current_second, 'dashboard_update', null)
+    VALUES (nextval('sse_outbox_seq'), current_second, 'dashboard_update', null)
     ON CONFLICT (notification_name, event_time) DO NOTHING;
 
     RETURN NEW;

--- a/backend/src/main/resources/db-migration/R__00070_migrate_id_sequences.sql
+++ b/backend/src/main/resources/db-migration/R__00070_migrate_id_sequences.sql
@@ -1,0 +1,51 @@
+-- Hibernate's "single" id.db_structure_naming_strategy makes every entity share one sequence
+-- (hibernate_sequence). Switching to the new default ("standard") gives every entity table its
+-- own sequence, named "<table>_seq". Each new sequence is seeded above the table's current max
+-- id (with a safety gap) so it can never collide with rows already inserted through the old
+-- shared sequence. Increment is 50 to match the JPA/Hibernate default allocationSize that
+-- "standard" implies (Hibernate validates the two match, see MappingSettings#ID_DB_STRUCTURE_NAMING_STRATEGY).
+DO
+$$
+    DECLARE
+        tbl  text;
+        max_id bigint;
+    BEGIN
+        FOR tbl IN SELECT unnest(ARRAY [
+            'static_values',
+            'static_countries',
+            'login_attempts',
+            'scanner_registrations',
+            'users_authorities',
+            'persons',
+            'distributions_statistics_shelters',
+            'users',
+            'employees',
+            'distributions',
+            'households',
+            'distributions_statistics',
+            'cars',
+            'household_notes',
+            'distributions_households',
+            'mail_recipients',
+            'food_categories',
+            'food_collections',
+            'routes',
+            'shelters',
+            'routes_stops',
+            'shelters_contacts',
+            'shops',
+            'sse_outbox'
+            ])
+            LOOP
+                EXECUTE format('SELECT coalesce(max(id), 0) FROM %I', tbl) INTO max_id;
+                EXECUTE format(
+                        'CREATE SEQUENCE IF NOT EXISTS %I START WITH %s INCREMENT BY 50 OWNED BY %I.id',
+                        tbl || '_seq', max_id + 1000, tbl
+                        );
+            END LOOP;
+    END
+$$;
+
+-- hibernate_sequence is retired once every entity has its own sequence (see R__00059 for the
+-- last remaining manual user, updated in lockstep with this migration).
+drop sequence if exists hibernate_sequence;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -10,10 +10,6 @@ spring:
     baseline-on-migrate: true
     clean-disabled: false
   jpa:
-    properties:
-      hibernate:
-        id:
-          db_structure_naming_strategy: single # TODO migrate to new default strategy (sequence per table)
     open-in-view: false
 
 security:


### PR DESCRIPTION
## Summary
- Replaces the shared `hibernate_sequence` (`hibernate.id.db_structure_naming_strategy: single`) with a dedicated `<table>_seq` sequence per entity, matching Hibernate's new default naming strategy.
- Each new sequence is seeded above the table's current max id with a safety gap (`MAX(id) + 1000`), computed live per table, so it can never collide with rows already inserted through the old shared sequence in production.
- Sequences use `INCREMENT BY 50` to match the `allocationSize` Hibernate now assumes once the naming strategy is no longer `single`/`legacy` (Hibernate validates this and throws at boot otherwise).
- Updates the dashboard-notification trigger (`R__00059`) and `testdata.sql` to use the new sequences instead of the retired `hibernate_sequence`.

## Test plan
- [x] Full backend test suite passes (Testcontainers Postgres, real Flyway migrations)
- [x] Ran the app with the `e2e` profile against the docker-compose Postgres (clean + migrate + testdata) — booted cleanly
- [x] Verified all 24 `_seq` sequences created with correct start values via `psql`
- [x] Verified `hibernate_sequence` is gone and `household_id_sequence` (unrelated business-number sequence) is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)