### PR TITLE
Fix R__00059 dashboard trigger migration referencing a renamed table

### DIFF
--- a/backend/src/main/resources/db-migration/R__00059_dashboard_add_notification_trigger.sql
+++ b/backend/src/main/resources/db-migration/R__00059_dashboard_add_notification_trigger.sql
@@ -27,11 +27,26 @@ CREATE OR REPLACE TRIGGER trigger_dashboard_update_notification
     FOR EACH ROW
 EXECUTE FUNCTION insert_dashboard_update_to_sse_outbox();
 
-CREATE OR REPLACE TRIGGER trigger_dashboard_update_notification
-    AFTER INSERT OR UPDATE OR DELETE
-    ON distributions_customers
-    FOR EACH ROW
-EXECUTE FUNCTION insert_dashboard_update_to_sse_outbox();
+-- distributions_customers was renamed to distributions_households in R__00067; on a fresh
+-- database this migration runs before that rename, so the table can still exist under either name
+DO
+$$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'distributions_households') THEN
+        EXECUTE 'CREATE OR REPLACE TRIGGER trigger_dashboard_update_notification
+            AFTER INSERT OR UPDATE OR DELETE
+            ON distributions_households
+            FOR EACH ROW
+            EXECUTE FUNCTION insert_dashboard_update_to_sse_outbox()';
+    ELSIF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'distributions_customers') THEN
+        EXECUTE 'CREATE OR REPLACE TRIGGER trigger_dashboard_update_notification
+            AFTER INSERT OR UPDATE OR DELETE
+            ON distributions_customers
+            FOR EACH ROW
+            EXECUTE FUNCTION insert_dashboard_update_to_sse_outbox()';
+    END IF;
+END
+$$;
 
 CREATE OR REPLACE TRIGGER trigger_dashboard_update_notification
     AFTER INSERT OR UPDATE OR DELETE


### PR DESCRIPTION
## Summary
Fixes the current prod deploy failure:

```
Migration of schema "public" with repeatable migration "00059 dashboard add notification trigger" failed!
ERROR: relation "distributions_customers" does not exist
```

- `R__00059` (repeatable) creates a dashboard-update trigger `ON distributions_customers`. That table was renamed to `distributions_households` by `R__00067`, but since nothing had touched `R__00059` afterwards, Flyway never re-ran it against the renamed schema — the stale reference was dormant.
- Today's Hibernate id-sequence migration (`9e7e9a1d`) edited `R__00059`'s `nextval()` call, changing its checksum. Flyway re-executes repeatable migrations whenever their checksum changes, so on deploy it tried to recreate the trigger on `distributions_customers`, which no longer exists — crashing prod on startup.
- Fix: guard the trigger creation to target whichever table name is actually present — `distributions_customers` during a from-scratch install (before `R__00067`'s rename runs), or `distributions_households` when re-run against an already-migrated database.

## Test plan
- [x] Testcontainers IT (`UserEntitySpecsIT`) replays the full fresh-install migration ordering — passes
- [x] Manually replayed the actual pre-existing migration history against a real Postgres container, then re-ran only the fixed `R__00059` (mirroring the checksum-triggered rerun Flyway performs on an already-migrated database) — trigger correctly lands on `distributions_households` on all 6 target tables, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)