### PR TITLE
Re-implement Spring Modulith module boundaries and re-enable ModularityTest

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -14,6 +14,13 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(26)
     }
+
+    sourceSets {
+        main {
+            // package-info.java files (Spring Modulith module boundaries) live next to the Kotlin sources
+            java.srcDir("src/main/kotlin")
+        }
+    }
 }
 
 kotlin {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/TafelApplicationModulesFactory.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/TafelApplicationModulesFactory.kt
@@ -1,0 +1,21 @@
+package at.wrk.tafel.admin.backend.config
+
+import org.springframework.modulith.core.ApplicationModules
+import org.springframework.modulith.core.ApplicationModulesFactory
+
+/**
+ * The application's main class lives in [at.wrk.tafel.admin.backend], but the actual Spring Modulith modules are
+ * nested one level deeper under [at.wrk.tafel.admin.backend.modules] (alongside non-module packages like `common`,
+ * `config` and `database`). Without this, Spring Modulith's runtime bootstrap would scan from the main class's
+ * package and fail to resolve the `allowedDependencies` declared in the modules' package-info.java files.
+ */
+class TafelApplicationModulesFactory : ApplicationModulesFactory {
+
+    override fun of(applicationClass: Class<*>): ApplicationModules {
+        return ApplicationModules.of(MODULES_BASE_PACKAGE)
+    }
+
+    companion object {
+        const val MODULES_BASE_PACKAGE = "at.wrk.tafel.admin.backend.modules"
+    }
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("country")
+package at.wrk.tafel.admin.backend.modules.base.country;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("employee")
+package at.wrk.tafel.admin.backend.modules.base.employee;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("exception")
+package at.wrk.tafel.admin.backend.modules.base.exception;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.checkin;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.dashboard;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"base::exception", "reporting"}
+)
+package at.wrk.tafel.admin.backend.modules.distribution;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"base::country", "base::exception"}
+)
+package at.wrk.tafel.admin.backend.modules.household;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"base::exception", "base::employee"}
+)
+package at.wrk.tafel.admin.backend.modules.logistics;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.reporting;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.settings;

--- a/backend/src/main/resources/META-INF/spring.factories
+++ b/backend/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.modulith.core.ApplicationModulesFactory=at.wrk.tafel.admin.backend.config.TafelApplicationModulesFactory

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ModularityTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ModularityTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.architecture
 
+import at.wrk.tafel.admin.backend.config.TafelApplicationModulesFactory
 import org.junit.jupiter.api.Test
 import org.springframework.modulith.core.ApplicationModules
 import org.springframework.modulith.docs.Documenter
@@ -8,7 +9,7 @@ import org.springframework.modulith.docs.Documenter.DiagramOptions
 
 internal class ModularityTest {
 
-    private val modules = ApplicationModules.of("at.wrk.tafel.admin.backend.modules")
+    private val modules = ApplicationModules.of(TafelApplicationModulesFactory.MODULES_BASE_PACKAGE)
 
     @Test
     fun verifiesModularStructure() {

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ModularityTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ModularityTest.kt
@@ -1,25 +1,21 @@
 package at.wrk.tafel.admin.backend.architecture
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.modulith.core.ApplicationModules
 import org.springframework.modulith.docs.Documenter
 import org.springframework.modulith.docs.Documenter.CanvasOptions
 import org.springframework.modulith.docs.Documenter.DiagramOptions
 
-// TODO re-implement modulith stuff
 internal class ModularityTest {
 
     private val modules = ApplicationModules.of("at.wrk.tafel.admin.backend.modules")
 
     @Test
-    @Disabled
     fun verifiesModularStructure() {
         modules.verify()
     }
 
     @Test
-    @Disabled
     fun createModuleDocumentation() {
         val diagramOptions = DiagramOptions.defaults()
             .withElementsWithoutRelationships(DiagramOptions.ElementsWithoutRelationships.VISIBLE)


### PR DESCRIPTION
## Summary
- The Maven-to-Gradle migration left `compileJava` without a source directory, so `package-info.java` files under `src/main/kotlin` (where Spring Modulith's `@ApplicationModule`/`@NamedInterface` annotations live) were silently never compiled into bytecode — this is why module boundaries were "half-baked" and `ModularityTest` had to be disabled.
- Point the Java source set at `src/main/kotlin` in `backend/build.gradle.kts` so those annotations actually take effect.
- Restore `package-info.java` module boundary declarations for `base` (with `country`/`employee`/`exception` named interfaces), `checkin`, `dashboard`, `distribution`, `household`, `logistics`, `reporting`, `settings`.
- Remove `@Disabled` from `ModularityTest` and drop the stale TODO.

## Test plan
- [x] `./gradlew :backend:test --tests "...ModularityTest"` passes (both `verifiesModularStructure()` and `createModuleDocumentation()`)
- [x] `./gradlew :backend:test` — full backend suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)