### PR TITLE
Fix intermittent frontend/backend test flakiness in CI

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -145,6 +145,12 @@ tasks.jacocoTestReport {
 
 tasks.test {
     finalizedBy(tasks.jacocoTestReport)
+
+    // Avoid running at the same time as the frontend's headless-browser test run: on shared CI
+    // runners the combined load (JVM + Testcontainers Postgres + Chromium + Vite dev server) has
+    // intermittently starved the frontend's Vite dev server, causing spurious
+    // "Failed to fetch dynamically imported module" failures.
+    mustRunAfter(":frontend:npmTest")
 }
 
 sonar {

--- a/frontend/src/main/webapp/src/tsconfig.spec.json
+++ b/frontend/src/main/webapp/src/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": []
   },
   "include": [
-    "../vitest.config.ts",
+    "../vitest-base.config.ts",
     "vitest-globals.d.ts",
     "test-providers.ts",
     "**/*.spec.ts",

--- a/frontend/src/main/webapp/vitest-base.config.ts
+++ b/frontend/src/main/webapp/vitest-base.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // Default (5s) is too tight on loaded CI runners and can compound into cascading
+    // "Failed to fetch dynamically imported module" failures once the dev server falls behind.
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/frontend/src/main/webapp/vitest.config.ts
+++ b/frontend/src/main/webapp/vitest.config.ts
@@ -1,9 +1,0 @@
-/// <reference types="vitest" />
-import {defineConfig} from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    globals: true,
-    include: ['src/**/*.spec.ts'],
-  },
-});


### PR DESCRIPTION
## Summary
- Investigated https://github.com/wrk-tafel/admin/actions/runs/30207709654/job/89808563050, where 72/97 frontend spec files failed with `Failed to fetch dynamically imported module` and the backend hit a Postgres I/O error during shutdown.
- Root cause: `org.gradle.parallel=true` lets `:frontend:npmTest` (headless Chromium + Vite dev server) and `:backend:test` (JVM + Testcontainers Postgres) run concurrently on the same shared CI runner. Under load this intermittently starves the frontend's Vite dev server, cascading into failures for every subsequent test file in that sequential run.
- `backend/build.gradle.kts`: `:backend:test` now `mustRunAfter(":frontend:npmTest")` to remove the contention.
- Also found `vitest.config.ts` was silently dead — Angular's `unit-test` builder only looks for `vitest-base.config.ts` — so it (and any tuning in it) was never applied. Renamed it and bumped `testTimeout`/`hookTimeout` to 30s, since the 5s default is tight on loaded CI runners.

## Test plan
- [x] `npm run test-ci` locally — confirmed the config file is now actually picked up ("Automatically searching for and using Vitest configuration file"), 96 passed / 1 skipped
- [x] `./gradlew :backend:test --dry-run` — confirms the Gradle task graph is still valid with `mustRunAfter`
- [ ] Watch next few CI runs for recurrence of the flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)