### PR TITLE
Add initial bundle size budget for Angular production build

### DIFF
--- a/frontend/src/main/webapp/angular.json
+++ b/frontend/src/main/webapp/angular.json
@@ -50,6 +50,11 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kb"
+                },
+                {
+                  "type": "initial",
+                  "maximumWarning": "1.3mb",
+                  "maximumError": "2mb"
                 }
               ],
               "optimization": {


### PR DESCRIPTION
## Summary
- Adds an `initial` bundle budget (warning 1.3mb / error 2mb) to the production build config, alongside the existing 6kb `anyComponentStyle` budget.
- Current initial bundle is 1.21MB raw / 277KB gzipped, so this passes today and only flags future regressions.

## Context
Ran a bundle size analysis (`ng build --configuration=production` + `source-map-explorer`): Angular Material/CDK account for ~36% of the main bundle and core framework ~15%, which is expected for a Material-heavy admin app. No budget existed to catch future growth, so this adds a guardrail without changing any runtime behavior.

## Test plan
- [x] `ng build --configuration=production` completes cleanly with no budget warnings/errors