### PR TITLE
Use Spring Boot's layered jar structure in the Docker image build

### DIFF
--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -2,6 +2,7 @@ FROM amazoncorretto:26-alpine AS builder
 WORKDIR /builder
 COPY ./artifact/admin-backend.jar app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+RUN find extracted -exec touch -d @0 {} \+
 
 FROM amazoncorretto:26-alpine
 VOLUME /app/config

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -1,3 +1,8 @@
+FROM amazoncorretto:26-alpine AS builder
+WORKDIR /builder
+COPY ./artifact/admin-backend.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
 FROM amazoncorretto:26-alpine
 VOLUME /app/config
 VOLUME /app/logs
@@ -6,7 +11,10 @@ RUN mkdir /app
 RUN mkdir /app/config
 RUN mkdir /app/logs
 
-COPY ./artifact/admin-backend.jar /app/app.jar
-
 WORKDIR /app
-ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Dspring.config.additional-location=file:/app/config/config.yml","-jar","app.jar"]
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+
+ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Dspring.config.additional-location=file:/app/config/config.yml","org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## Summary
- `bootJar` already produces a layered jar (`dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application`) via the Spring Boot Gradle plugin default, but the Dockerfile copied it as a single `COPY ./artifact/admin-backend.jar /app/app.jar` — one 108MB Docker layer that any code change fully invalidated.
- Switches to a multi-stage build: extract the jar's layers via `java -Djarmode=tools ... extract --layers`, then `COPY` each layer separately, ordered least-to-most frequently changing.
- Normalizes extracted file timestamps (`touch -d @0`) before the final-stage `COPY`s so the resulting layers are actually byte-reproducible (see "Correction" below).

## Correction from the original version of this PR
The first version of this PR claimed the split alone would let the ~105MB `dependencies` layer stay cache-hit/deduped across most commits. I verified that empirically and it was wrong: the `layertools extract` step stamps files with the current build time, so two independent builds of the *identical* jar produced different digests for every extracted layer. That defeats both BuildKit's build cache and the registry's push-side layer dedup — the `dependencies` layer would get re-uploaded on every push regardless of whether any dependency actually changed.

Added `RUN find extracted -exec touch -d @0 {} \+` after extraction to normalize timestamps. Verified with two independent `--no-cache` builds of the same jar: the `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, and `application` layer digests now match exactly. (Three trivial `RUN mkdir` layers still differ build-to-build — each is an empty directory, doesn't affect the layers that actually carry the size.)

## Why
CI already uses Docker layer caching (`cache-from/cache-to: type=gha`) in `subflow_docker_image.yml`. With reproducible extraction, the `dependencies` layer (~105MB) now stays byte-identical across commits that don't change the dependency set, so both the GHA build cache and GHCR's registry-side dedup can skip re-processing/re-uploading it — only the small `application` layer (~6.4MB, own classes + frontend static assets) needs to be rebuilt and pushed for a typical code change.

## Test plan
- [x] `docker build` completes cleanly with the multi-stage Dockerfile
- [x] Full end-to-end boot verified against a real Postgres container: 71 Flyway migrations applied, Hibernate/JPA initialized, Spring Security configured, Tomcat started — same behavior as the previous single-layer image
- [x] Confirmed via `docker history` that layers split as expected (105MB / 0.4MB / 0 / 6.4MB)
- [x] Confirmed via `docker inspect --format '{{json .RootFS.Layers}}'` that two independent `--no-cache` builds of the same jar produce identical digests for all four extracted layers after the timestamp-normalization fix