### PR TITLE
Decouple the frontend build from the backend Gradle build

### DIFF
--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -53,3 +53,9 @@ jobs:
           path: ./backend/build/libs/admin-backend.jar
           if-no-files-found: error
           retention-days: 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: frontend-dist
+          path: ./frontend/src/main/webapp/dist/browser
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/subflow_docker_image.yml
+++ b/.github/workflows/subflow_docker_image.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           name: admin-jarfile
           path: ./artifact
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: frontend-dist
+          path: ./frontend-dist
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to the Container registry

--- a/.github/workflows/subflow_e2e_test.yml
+++ b/.github/workflows/subflow_e2e_test.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           name: admin-jarfile
           path: ./artifact
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: frontend-dist
+          path: ./static
       - run: npm ci --ignore-scripts
         working-directory: frontend/src/main/webapp
       - name: Install cypress binary

--- a/README.md
+++ b/README.md
@@ -101,8 +101,13 @@ The frontend dev server starts on http://localhost:4200 and proxies API requests
 
 ### Docker Image
 
+The backend jar and frontend build are independent artifacts, combined only at image-build time:
+
 ```bash
-./gradlew :backend:bootJar
+./gradlew build
+mkdir -p artifact frontend-dist
+cp backend/build/libs/admin-backend.jar artifact/
+cp -r frontend/src/main/webapp/dist/browser/* frontend-dist/
 docker build -t wrk-tafel-admin:local -f _build/Dockerfile .
 ```
 

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -2,6 +2,7 @@ FROM amazoncorretto:26-alpine AS builder
 WORKDIR /builder
 COPY ./artifact/admin-backend.jar app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+RUN find extracted -exec touch -d @0 {} \+
 
 FROM amazoncorretto:26-alpine
 VOLUME /app/config

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -1,3 +1,8 @@
+FROM amazoncorretto:26-alpine AS builder
+WORKDIR /builder
+COPY ./artifact/admin-backend.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
 FROM amazoncorretto:26-alpine
 VOLUME /app/config
 VOLUME /app/logs
@@ -6,7 +11,10 @@ RUN mkdir /app
 RUN mkdir /app/config
 RUN mkdir /app/logs
 
-COPY ./artifact/admin-backend.jar /app/app.jar
-
 WORKDIR /app
-ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Dspring.config.additional-location=file:/app/config/config.yml","-jar","app.jar"]
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+
+ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Dspring.config.additional-location=file:/app/config/config.yml","org.springframework.boot.loader.launch.JarLauncher"]

--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -17,5 +17,6 @@ COPY --from=builder /builder/extracted/dependencies/ ./
 COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
 COPY --from=builder /builder/extracted/application/ ./
+COPY ./frontend-dist/ ./static/
 
 ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Dspring.config.additional-location=file:/app/config/config.yml","org.springframework.boot.loader.launch.JarLauncher"]

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -108,18 +108,6 @@ tasks.named<Jar>("jar") {
     enabled = false
 }
 
-val copyFrontend = tasks.register<Copy>("copyFrontend") {
-    group = "build"
-    description = "Copy frontend build output into backend static resources"
-    from("${project.rootDir}/frontend/src/main/webapp/dist/browser")
-    into("${layout.buildDirectory.get().asFile}/resources/main/static")
-    dependsOn(":frontend:npmBuild")
-}
-
-tasks.named("processResources") {
-    dependsOn(copyFrontend)
-}
-
 tasks.withType<Test> {
     useJUnitPlatform()
     include("**/*Test.class", "**/*IT.class")

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,6 +33,10 @@ spring:
     error:
       include-message: always
       include-stacktrace: never
+    resources:
+      # frontend is built and deployed independently of the backend jar (see _build/Dockerfile);
+      # this is where its static output is expected to be placed at runtime
+      static-locations: file:${user.dir}/static/
   datasource:
     driverClassName: org.postgresql.Driver
     hikari:


### PR DESCRIPTION
## Summary
- Removed `backend/build.gradle.kts`'s `copyFrontend` task, which depended on `:frontend:npmBuild` and bundled the Angular `dist/` output into `BOOT-INF/classes/static` before packaging. `:backend:build`/`:backend:bootJar` now run with zero npm/node involvement and produce a jar with no bundled frontend assets.
- Static content is now served from an external directory instead: `spring.web.resources.static-locations: file:${user.dir}/static/` in `application.yml`.
- `_build/Dockerfile` gets a new `COPY ./frontend-dist/ ./static/` step (its own layer, separate from the backend's `application` layer), populated from an independently-built frontend artifact.
- CI: `subflow_build.yml` now uploads the frontend `dist/browser` output as its own `frontend-dist` artifact (alongside the existing jar artifact). `subflow_docker_image.yml` downloads it into `./frontend-dist` for the Dockerfile. `subflow_e2e_test.yml` downloads it into `./static` so the jar (run directly on the runner for Cypress) picks it up via the same `${user.dir}/static/` convention.
- Updated the README's local Docker build instructions to reflect the two independent artifacts.

## Why
Backend builds/tests no longer require the frontend toolchain at all, and a frontend-only commit no longer changes the backend jar's bytes (or its Docker layers). This also lines up with the layered-jar Docker work in #2757: frontend assets are now their own Docker layer, so a frontend-only change doesn't touch the backend's `application` layer and vice versa.

## Test plan
- [x] `./gradlew :backend:clean :backend:bootJar` — builds cleanly, zero npm invoked, jar contains no `BOOT-INF/classes/static` content (confirmed via `unzip -l`)
- [x] `./gradlew :backend:test` — full backend test suite passes unaffected
- [x] Ran the jar with an external `static/` directory next to it (mirroring the Docker/e2e layout): `WelcomePageHandlerMapping` correctly logs `Adding welcome page: URL [file:.../static/index.html]`, and both `/` (index.html) and a JS chunk serve correctly over HTTP with the right content type
- [x] Built the full Docker image with both artifacts staged as CI would provide them, ran it end-to-end against a real Postgres container: Flyway migrations, Hibernate/JPA, Spring Security, Tomcat all start as before, frontend served correctly from its own layer (`docker history` confirms it as a separate ~3MB layer)