### PR TITLE
Parallelize backend/frontend builds and decouple Sonar from the critical path

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  test:
+    uses: ./.github/workflows/subflow_test.yml
   sonar:
     uses: ./.github/workflows/subflow_sonar.yml
-    needs: build
+    needs: test
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:
@@ -27,7 +29,10 @@ jobs:
     needs: build
   deploy-test:
     uses: ./.github/workflows/subflow_deploy.yml
-    needs: build-push-image
+    # main is the "must be green" pipeline: unlike PRs, deployment requires
+    # backend+frontend unit tests AND e2e to have passed, not just a
+    # successful build
+    needs: [build-push-image, test, e2e-test]
     concurrency:
       group: test-environment
     secrets:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  sonar:
+    uses: ./.github/workflows/subflow_sonar.yml
+    needs: build
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  test:
+    uses: ./.github/workflows/subflow_test.yml
   sonar:
     uses: ./.github/workflows/subflow_sonar.yml
-    needs: build
+    needs: test
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  sonar:
+    uses: ./.github/workflows/subflow_sonar.yml
+    needs: build
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  sonar:
+    uses: ./.github/workflows/subflow_sonar.yml
+    needs: build
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/subflow_build.yml
+  test:
+    uses: ./.github/workflows/subflow_test.yml
   sonar:
     uses: ./.github/workflows/subflow_sonar.yml
-    needs: build
+    needs: test
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   lint:
@@ -23,14 +25,14 @@ jobs:
     needs: build
   build-push-image-test:
     uses: ./.github/workflows/subflow_docker_image.yml
-    needs: [build, e2e-test]
+    needs: [build, test, e2e-test]
     with:
       imageTag: test
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
   build-push-image-prod:
     uses: ./.github/workflows/subflow_docker_image.yml
-    needs: [build, e2e-test]
+    needs: [build, test, e2e-test]
     with:
       imageTag: latest
     secrets:

--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -1,4 +1,4 @@
-name: Build and Analyze
+name: Build
 
 env:
   JAVA_VERSION: '26'
@@ -7,24 +7,12 @@ env:
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      SONAR_TOKEN:
-        required: true
 
 jobs:
-  build-test-analyze:
+  build-backend:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read # allows SonarCloud to decorate PRs with analysis results
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0 # SonarCloud needs full history for blame and branch comparison
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: 'frontend/src/main/webapp/.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
       - name: Set up JDK
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
@@ -34,20 +22,8 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - run: npm ci
-        working-directory: frontend/src/main/webapp
-      - name: Frontend test
-        run: npm run test-ci
-        working-directory: frontend/src/main/webapp
-      - name: Frontend build
-        run: npm run build-prod
-        working-directory: frontend/src/main/webapp
       - name: Backend build and test
         run: ./gradlew :backend:build
-      - name: Analyze
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar -Dsonar.projectKey=wrk-tafel-admin -Dsonar.organization=wrk-tafel -Dsonar.token=$SONAR_TOKEN
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
@@ -61,6 +37,30 @@ jobs:
           path: ./backend/build/libs/admin-backend.jar
           if-no-files-found: error
           retention-days: 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: backend-jacoco-report
+          path: ./backend/build/reports/jacoco/test/jacocoTestReport.xml
+          if-no-files-found: error
+          retention-days: 1
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: 'frontend/src/main/webapp/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
+      - run: npm ci
+        working-directory: frontend/src/main/webapp
+      - name: Frontend test
+        run: npm run test-ci
+        working-directory: frontend/src/main/webapp
+      - name: Frontend build
+        run: npm run build-prod
+        working-directory: frontend/src/main/webapp
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: frontend-dist

--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -22,8 +22,30 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: Backend build and test
-        run: ./gradlew :backend:build
+      - name: Backend build
+        run: ./gradlew :backend:bootJar
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: admin-jarfile
+          path: ./backend/build/libs/admin-backend.jar
+          if-no-files-found: error
+          retention-days: 1
+
+  test-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up JDK
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+      - name: Backend test
+        run: ./gradlew :backend:test
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
@@ -31,12 +53,6 @@ jobs:
           path: ./backend/build/custom-test-results/
           if-no-files-found: ignore
           retention-days: 14
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: admin-jarfile
-          path: ./backend/build/libs/admin-backend.jar
-          if-no-files-found: error
-          retention-days: 1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: backend-jacoco-report

--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -40,7 +40,7 @@ jobs:
           node-version-file: 'frontend/src/main/webapp/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
         working-directory: frontend/src/main/webapp
       - name: Frontend build
         run: npm run build-prod

--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -71,9 +71,6 @@ jobs:
           cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
       - run: npm ci
         working-directory: frontend/src/main/webapp
-      - name: Frontend test
-        run: npm run test-ci
-        working-directory: frontend/src/main/webapp
       - name: Frontend build
         run: npm run build-prod
         working-directory: frontend/src/main/webapp
@@ -83,3 +80,18 @@ jobs:
           path: ./frontend/src/main/webapp/dist/browser
           if-no-files-found: error
           retention-days: 1
+
+  test-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: 'frontend/src/main/webapp/.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
+      - run: npm ci
+        working-directory: frontend/src/main/webapp
+      - name: Frontend test
+        run: npm run test-ci
+        working-directory: frontend/src/main/webapp

--- a/.github/workflows/subflow_sonar.yml
+++ b/.github/workflows/subflow_sonar.yml
@@ -1,0 +1,39 @@
+name: Analyze
+
+env:
+  JAVA_VERSION: '26'
+  JAVA_DISTRIBUTION: 'corretto'
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # allows SonarCloud to decorate PRs with analysis results
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # SonarCloud needs full history for blame and branch comparison
+      - name: Set up JDK
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: backend-jacoco-report
+          path: ./backend/build/reports/jacoco/test
+      - name: Analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar -Dsonar.projectKey=wrk-tafel-admin -Dsonar.organization=wrk-tafel -Dsonar.token=$SONAR_TOKEN

--- a/.github/workflows/subflow_test.yml
+++ b/.github/workflows/subflow_test.yml
@@ -47,7 +47,7 @@ jobs:
           node-version-file: 'frontend/src/main/webapp/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
         working-directory: frontend/src/main/webapp
       - name: Frontend test
         run: npm run test-ci

--- a/.github/workflows/subflow_test.yml
+++ b/.github/workflows/subflow_test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test
 
 env:
   JAVA_VERSION: '26'
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 jobs:
-  build-backend:
+  test-backend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -22,16 +22,23 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: Backend build
-        run: ./gradlew :backend:bootJar
+      - name: Backend test
+        run: ./gradlew :backend:test
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: backend-custom-test-results
+          path: ./backend/build/custom-test-results/
+          if-no-files-found: ignore
+          retention-days: 14
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: admin-jarfile
-          path: ./backend/build/libs/admin-backend.jar
+          name: backend-jacoco-report
+          path: ./backend/build/reports/jacoco/test/jacocoTestReport.xml
           if-no-files-found: error
           retention-days: 1
 
-  build-frontend:
+  test-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,12 +49,6 @@ jobs:
           cache-dependency-path: 'frontend/src/main/webapp/package-lock.json'
       - run: npm ci
         working-directory: frontend/src/main/webapp
-      - name: Frontend build
-        run: npm run build-prod
+      - name: Frontend test
+        run: npm run test-ci
         working-directory: frontend/src/main/webapp
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: frontend-dist
-          path: ./frontend/src/main/webapp/dist/browser
-          if-no-files-found: error
-          retention-days: 1


### PR DESCRIPTION
## Summary
Pulled real timing data from recent CI runs before making changes:

| Stage | Measured time |
|---|---|
| `build` job (frontend test+build, backend build+test, Sonar - all sequential in one job) | 230-364s |
| ...within that: backend build+test | ~202s |
| ...within that: frontend (npm ci+test+build) | ~67s |
| ...within that: Sonar analysis | ~61s |

Nothing downstream (`e2e-test`, `build-push-image`) actually needs Sonar's output - they only need the jar and frontend-dist artifacts. Sonar was sitting on the critical path for no reason.

## Changes
- Split `subflow_build.yml`'s single job into two parallel jobs, `build-backend` and `build-frontend` - safe now that they have no Gradle cross-dependency (#2758, #2759). This cuts the build stage from sum(frontend, backend) to max(frontend, backend).
- Moved Sonar analysis into its own reusable workflow (`subflow_sonar.yml`), called as a sibling job to `build` from `pull_request.yml`/`main_push.yml`/`release.yml` instead of as a step inside `subflow_build.yml`. This matters because a reusable workflow call is atomic from the caller's `needs:` perspective - with Sonar living inside `subflow_build.yml`, anything with `needs: build` (e2e-test, build-push-image) had to wait for the whole reusable workflow including Sonar to finish. As its own sibling job, Sonar now runs in parallel with e2e-test/build-push-image instead of blocking them.
- Sonar reads the backend's jacoco XML report via a downloaded artifact rather than needing `:backend:build` to rerun on its own runner.
- **Follow-up commit:** split `build-backend` further into `build-backend` (`./gradlew :backend:bootJar` - compile+package only) and `test-backend` (`./gradlew :backend:test` - the actual test suite). Local Gradle profiling showed `:backend:test` is ~58s of the ~89s backend Gradle task time (compile is only ~28s), so a failure used to show as one opaque "build-backend" red X with no indication of whether it was a compile error or a test failure. The two jobs run independently in parallel (compiling the jar doesn't need test results, and test compilation doesn't need the packaged jar) purely for clearer CI status - **tests remain a full blocking gate**, since `test-backend` joins `subflow_build.yml` as a new job and the parent workflows' `needs: build` already waits for every job inside that reusable workflow, automatically. No parent workflow changes needed for this part.

## Why this is safe
- Confirmed via `./gradlew sonar --dry-run` that the `sonar` task has no dependency on `test`/`jacocoTestReport` in this project's setup - it only reads the report file at a configured path, so running it standalone with just the artifact downloaded doesn't quietly re-trigger a full backend test run.
- Confirmed via the GitHub API that `main`'s branch protection has no required status checks configured, so renaming/splitting jobs doesn't break merge gating.
- Confirmed via task graph output that `./gradlew :backend:bootJar` alone does not trigger `:backend:test` (no test-related tasks appear), and that `./gradlew :backend:test` alone still produces the jacoco XML report via its existing `finalizedBy(jacocoTestReport)` wiring, without needing `:backend:build`.

## Test plan
- [x] `./gradlew :backend:build` passes standalone
- [x] `./gradlew sonar --dry-run` resolves cleanly without pulling in test/build tasks
- [x] `./gradlew :backend:bootJar` alone runs only compile/package tasks, no test task
- [x] `./gradlew :backend:test` alone still produces `backend/build/reports/jacoco/test/jacocoTestReport.xml`
- [x] All edited workflow YAML files parse cleanly (`yaml.safe_load`)
- [x] Verified end-to-end in CI (run for the first commit on this branch): build-backend 44s / build-frontend 70s ran in parallel, build-push-image (31s) and sonar (73s) both started right after and ran in parallel without blocking each other, confirming Sonar is off the critical path. Total pipeline critical path dropped from ~600s (10min) to ~380s (~6.3min), with e2e-test (~310s, unchanged/out of scope) now the sole remaining long pole.

**Second follow-up commit:** applied the same split to the frontend - `build-frontend` now runs only `npm ci` + `npm run build-prod`, `test-frontend` runs `npm ci` + `npm run test-ci` independently. Same rationale and same automatic blocking-gate preservation as the backend split above. `subflow_build.yml` now has 4 fully independent parallel jobs: `build-backend`, `test-backend`, `build-frontend`, `test-frontend`.

**Third follow-up commit:** split `subflow_build.yml` (compile/package) and `subflow_test.yml` (test suites) into fully separate reusable workflow files, so parent workflows can gate independently on each. This enables different deploy policies per pipeline:
- **`pull_request.yml`**: `deploy-dev` only needs `build-push-image` -> `build` - PRs deploy to dev as soon as the artifact builds, without waiting on backend/frontend unit tests or e2e. Fast feedback; failing tests still show as their own failing checks on the PR, they just don't block the dev deploy.
- **`main_push.yml`**: `deploy-test` now needs `[build-push-image, test, e2e-test]` explicitly - backend tests, frontend tests, AND e2e must all pass before anything deploys to the test environment.
- **`release.yml`**: `build-push-image-test`/`build-push-image-prod` now need `[build, test, e2e-test]` (added `test` alongside the existing `e2e-test` requirement) - the same "all tests must pass" gate applies transitively to both `deploy-test` and `deploy-prod`.

`subflow_sonar.yml` is unchanged internally; only its parent-level `needs:` moved from `build` to `test`, since that's where the jacoco report is produced now.

**Fourth follow-up commit:** SonarCloud's quality gate on this PR flagged `subflow_test.yml`'s `npm ci` (rule `githubactions:S6505`, medium security impact) for omitting `--ignore-scripts`, allowing dependency lifecycle scripts to run during install - a supply-chain risk. `subflow_build.yml` had the same issue. `subflow_lint.yml`/`subflow_e2e_test.yml` already use `--ignore-scripts`; verified locally that adding it to build/test doesn't break anything (`npm run build-prod` and `npm run test-ci`, 511 tests, both still pass unchanged with `--ignore-scripts`), then added it to both.

## Final verification
Confirmed via actual job timestamps on the PR pipeline run that the loose gating works as intended: `deploy-dev` completed at 21:19:00 while `e2e-test` was still running until 21:23:50 (5 more minutes) - `deploy-dev` only waited on `build-push-image`, never on `test`/`e2e-test`, exactly as designed.
