### PR TITLE
Replace toastr with MatSnackBar for notifications

### DIFF
--- a/DEPENDENCY_MAINTENANCE_PLAN.md
+++ b/DEPENDENCY_MAINTENANCE_PLAN.md
@@ -82,37 +82,63 @@ Five dependencies are stale/abandoned. Ordered below by recommended priority
 
 ---
 
-## 2. `toastr` (frontend) — HIGH PRIORITY
+## 2. `toastr` (frontend) — HIGH PRIORITY — ✅ RESOLVED (2026-07-27)
 
 - **Status:** Last released 2022-06-27 (v2.1.4). 122 open issues, no visible
   recent commits, jQuery-era library. Already surfaces as a build warning
   ("Module 'toastr' used by ... is not ESM").
 - **Used in:** `src/app/common/components/tafel-toastr/tafel-toastr.service.ts`
   (wraps toastr), called app-wide for success/error/info/warning messages.
-- **Replacement:** `MatSnackBar` (`@angular/material`) — **already a
-  dependency**, so this removes a dependency rather than adding one, and
-  clears the CommonJS/ESM build warning.
-  - Alternative if toastr's specific stacked/colored toast visual style is
-    important to keep: `ngx-toastr` (actively maintained Angular-native
-    reimplementation, same visual behavior, easy near-drop-in for the
-    `.success()/.error()/.info()/.warning()` API).
-- **Steps (MatSnackBar path):**
-  1. Find all call sites of `TafelToastrService` (`success`/`error`/`info`/`warning`).
-  2. Rewrite `tafel-toastr.service.ts` internals to use `MatSnackBar.open(...)`
-     with a custom `panelClass` per severity (success/error/info/warning) for
-     styling, keeping the existing public method signatures so call sites
-     don't need to change.
-  3. Add SCSS for the 4 severity panel classes (color/icon) to roughly match
-     current toastr look, or accept Material's default snackbar look.
-  4. Remove `toastr` + `@types/toastr` from `package.json`, remove the now
-     redundant `toastr` entry from `angular.json`'s `allowedCommonJsDependencies`.
-  5. Update/adjust any Cypress e2e assertions that check for toastr-specific
-     DOM structure/classes (grep `cypress/` for `toast`).
-  6. `npm run lint && npm run test-ci && npm run build-prod` + a full Cypress
-     run.
-- **Risk:** Medium — touches a widely-used shared service; visual regression
-  risk is the main concern, functional risk is low since the service's public
-  API can stay the same.
+- **Resolution:** Replaced with `MatSnackBar` (`@angular/material`), which
+  was already a dependency — this removed a dependency (plus its transitive
+  `jquery`/`@types/jquery`) rather than adding one, and cleared the
+  CommonJS/ESM build warning.
+- **Changes made:**
+  1. Added `TafelSnackbarComponent`
+     (`src/app/common/components/tafel-snackbar/`) — a small standalone
+     component (icon + title + message + close button) rendered via
+     `MatSnackBar.openFromComponent(...)`, driven by a
+     `{message, title?, severity}` payload injected through
+     `MAT_SNACK_BAR_DATA`.
+  2. Rewrote `tafel-toastr.service.ts` to inject `MatSnackBar` instead of the
+     `toastr` module/`TOASTR_TOKEN`, keeping the public
+     `success/error/info/warning(message, title?)` method signatures
+     unchanged so none of the ~30 call sites needed to change. Each call
+     opens the snack bar with a 5s duration (matching toastr's old
+     `timeOut`), top-right position, and a `panelClass` of
+     `['tafel-snackbar-panel', 'tafel-snackbar-panel-<severity>']`.
+  3. Added `src/scss/components/tafel-snackbar.scss` (imported from
+     `angular-material-theme.scss`) that recolors the snack bar surface per
+     severity via Angular Material's own CSS custom properties
+     (`--mat-snack-bar-container-color`, `--mat-snack-bar-supporting-text-color`,
+     `--mat-snack-bar-container-shape`), using toastr's original palette
+     (`#51a351` success / `#bd362f` error / `#2f96b4` info / `#f89406`
+     warning, white text, 3px corners) so the visual look matches the old
+     toastr notifications. Removed the `@import "toastr"` line (and its
+     bundled CSS) from `styles.scss`.
+  4. Kept the `.toast-message` class name on the message element in
+     `TafelSnackbarComponent`'s template specifically so the existing
+     Cypress `cy.get('.toast-message')` assertions (7 spec files) keep
+     passing unmodified.
+  5. Removed `toastr` + `@types/toastr` from `package.json`; ran
+     `npm install`, which also pruned the now-unused transitive `jquery` +
+     `@types/jquery`. Removed the now-dead
+     `"scripts": ["node_modules/jquery/dist/jquery.min.js"]` entry from
+     `angular.json` (jquery was only ever loaded for toastr).
+  6. `npm run lint`, `npm run test-ci` (511/511 passing, including a
+     rewritten `tafel-toastr.service.spec.ts` that mocks `MatSnackBar`), and
+     `npm run build-prod` all pass cleanly with no CommonJS warning.
+- **Verification note:** Manually exercised the real
+  interceptor → `TafelToastrService.error()` → `MatSnackBar.openFromComponent()`
+  path in a running `ng serve` session (via a genuine UI-triggered HTTP 500)
+  and confirmed via instrumentation that it's invoked with the correct
+  data/panelClass/config every time. Rendering a live snack bar to a
+  screenshot inside the browser-automation session was inconclusive — no
+  Angular CDK overlay (including a pre-existing `MatDialog`, used as a
+  control) would attach to the DOM in that specific automated session,
+  which points to a dev-server/automation environment quirk rather than a
+  code issue. Recommend a quick manual/Cypress check in a normal browser
+  session before merging to eyeball the actual colors.
 
 ---
 
@@ -213,7 +239,7 @@ Five dependencies are stale/abandoned. Ordered below by recommended priority
 ## Suggested execution order
 
 1. ✅ `logback-jackson`/`logback-json-classic` → Spring Boot built-in structured logging (prod-facing, low risk, quick win) — done
-2. `toastr` → `MatSnackBar` (removes a dependency, clears a build warning)
+2. ✅ `toastr` → `MatSnackBar` (removes a dependency, clears a build warning) — done
 3. `cypress-browser-permissions` (check if even still needed — might be a pure deletion)
 4. `image-comparison` → in-house utility (contained, test-only)
 5. `html5-qrcode` → `qr-scanner` (needs physical hardware testing — schedule accordingly, don't rush)

--- a/frontend/src/main/webapp/angular.json
+++ b/frontend/src/main/webapp/angular.json
@@ -27,9 +27,6 @@
               "node_modules/@fontsource/roboto/500.css",
               "src/scss/styles.scss"
             ],
-            "scripts": [
-              "node_modules/jquery/dist/jquery.min.js"
-            ],
             "allowedCommonJsDependencies": [
               "chart.js",
               "angular2-uuid",

--- a/frontend/src/main/webapp/package-lock.json
+++ b/frontend/src/main/webapp/package-lock.json
@@ -35,7 +35,6 @@
         "postcss": "8.5.23",
         "rxjs": "7.8.2",
         "tailwindcss": "4.3.3",
-        "toastr": "2.1.4",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -50,7 +49,6 @@
         "@angular/language-service": "22.0.8",
         "@eslint/js": "10.0.1",
         "@types/node": "26.1.1",
-        "@types/toastr": "2.1.43",
         "@typescript-eslint/eslint-plugin": "8.65.0",
         "@typescript-eslint/parser": "8.65.0",
         "@vitest/browser-playwright": "4.1.10",
@@ -4750,13 +4748,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/jquery": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-4.0.1.tgz",
-      "integrity": "sha512-9a59A/tycXgYuPABcp6/3spSShn0NT2UOM4EfHvMumjYi4lJWTsK5SZWjhx3yRm9IHGCeWXdV2YfNsrWrft/CA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4794,16 +4785,6 @@
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/toastr": {
-      "version": "2.1.43",
-      "resolved": "https://registry.npmjs.org/@types/toastr/-/toastr-2.1.43.tgz",
-      "integrity": "sha512-sLC2fr2OXeE1iyhUixpQ64wQ2tA26awmLidn4tXTLBz4yP/VhtYUKHpmiIyDtztKkHjucdiTLH8F5uRRyhNi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jquery": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
@@ -8456,12 +8437,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/jquery": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11523,14 +11498,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/toastr": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.1.4.tgz",
-      "integrity": "sha512-LIy77F5n+sz4tefMmFOntcJ6HL0Fv3k1TDnNmFZ0bU/GcvIIfy6eG2v7zQmMiYgaalAiUv75ttFrPn5s0gyqlA==",
-      "dependencies": {
-        "jquery": ">=1.12.0"
       }
     },
     "node_modules/toidentifier": {

--- a/frontend/src/main/webapp/package.json
+++ b/frontend/src/main/webapp/package.json
@@ -49,7 +49,6 @@
     "postcss": "8.5.23",
     "rxjs": "7.8.2",
     "tailwindcss": "4.3.3",
-    "toastr": "2.1.4",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -64,7 +63,6 @@
     "@angular/language-service": "22.0.8",
     "@eslint/js": "10.0.1",
     "@types/node": "26.1.1",
-    "@types/toastr": "2.1.43",
     "@typescript-eslint/eslint-plugin": "8.65.0",
     "@typescript-eslint/parser": "8.65.0",
     "@vitest/browser-playwright": "4.1.10",

--- a/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.html
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.html
@@ -1,0 +1,10 @@
+<fa-icon [icon]="icon" class="tafel-snackbar-icon" aria-hidden="true"></fa-icon>
+<div class="tafel-snackbar-text">
+  @if (data.title) {
+    <div class="toast-title">{{ data.title }}</div>
+  }
+  <div class="toast-message">{{ data.message }}</div>
+</div>
+<button mat-icon-button class="tafel-snackbar-close" (click)="dismiss()" aria-label="Schließen">
+  <fa-icon [icon]="faXmark"></fa-icon>
+</button>

--- a/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.scss
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.scss
@@ -1,0 +1,31 @@
+:host {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  color: inherit;
+}
+
+.tafel-snackbar-icon {
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+  font-size: 1.1rem;
+}
+
+.tafel-snackbar-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.toast-title {
+  font-weight: bold;
+}
+
+.tafel-snackbar-close {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  color: inherit;
+}

--- a/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.ts
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-snackbar/tafel-snackbar.component.ts
@@ -1,0 +1,38 @@
+import {Component, inject} from '@angular/core';
+import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
+import {MatIconButton} from '@angular/material/button';
+import {FaIconComponent} from '@fortawesome/angular-fontawesome';
+import {faCircleCheck, faCircleExclamation, faCircleInfo, faTriangleExclamation, faXmark} from '@fortawesome/free-solid-svg-icons';
+
+export type TafelSnackbarSeverity = 'success' | 'error' | 'info' | 'warning';
+
+export interface TafelSnackbarData {
+  message: string;
+  title?: string;
+  severity: TafelSnackbarSeverity;
+}
+
+const SEVERITY_ICONS = {
+  success: faCircleCheck,
+  error: faCircleExclamation,
+  info: faCircleInfo,
+  warning: faTriangleExclamation,
+};
+
+@Component({
+  selector: 'tafel-snackbar',
+  templateUrl: 'tafel-snackbar.component.html',
+  styleUrls: ['tafel-snackbar.component.scss'],
+  imports: [FaIconComponent, MatIconButton],
+})
+export class TafelSnackbarComponent {
+  readonly data: TafelSnackbarData = inject(MAT_SNACK_BAR_DATA);
+  private readonly snackBarRef = inject(MatSnackBarRef<TafelSnackbarComponent>);
+
+  protected readonly icon = SEVERITY_ICONS[this.data.severity];
+  protected readonly faXmark = faXmark;
+
+  dismiss() {
+    this.snackBarRef.dismiss();
+  }
+}

--- a/frontend/src/main/webapp/src/app/common/components/tafel-toastr/tafel-toastr.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-toastr/tafel-toastr.service.spec.ts
@@ -1,36 +1,41 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {TafelToastrService, TOASTR_TOKEN} from './tafel-toastr.service';
+import {TafelToastrService} from './tafel-toastr.service';
 import {TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {TafelSnackbarComponent} from '../tafel-snackbar/tafel-snackbar.component';
 
 describe('TafelToastrService', () => {
   let service: TafelToastrService;
-  let mockToastr: any;
+  let mockSnackBar: {openFromComponent: ReturnType<typeof vi.fn>};
 
   beforeEach(() => {
-    mockToastr = {
-      success: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      warning: vi.fn(),
-      options: {} // Empty container for the constructor to populate
-    };
+    mockSnackBar = {openFromComponent: vi.fn()};
 
     TestBed.configureTestingModule({
       providers: [
-        {provide: TOASTR_TOKEN, useValue: mockToastr}
+        {provide: MatSnackBar, useValue: mockSnackBar}
       ]
     });
     service = TestBed.runInInjectionContext(() => new TafelToastrService());
   });
 
-  it('should initialize default toastr options correctly', () => {
-    expect(mockToastr.options.timeOut).toBe(5000);
-    expect(mockToastr.options.progressBar).toBe(true);
+  it('should open a snack bar with the success severity and default duration', () => {
+    service.success('Msg', 'Title');
+
+    expect(mockSnackBar.openFromComponent).toHaveBeenCalledWith(TafelSnackbarComponent, expect.objectContaining({
+      data: {message: 'Msg', title: 'Title', severity: 'success'},
+      duration: 5000,
+      panelClass: ['tafel-snackbar-panel', 'tafel-snackbar-panel-success'],
+    }));
   });
 
-  it('should call toastr.success with the provided arguments', () => {
-    service.success('Msg', 'Title');
-    expect(mockToastr.success).toHaveBeenCalledWith('Msg', 'Title');
+  it('should open a snack bar with the error severity', () => {
+    service.error('Failed');
+
+    expect(mockSnackBar.openFromComponent).toHaveBeenCalledWith(TafelSnackbarComponent, expect.objectContaining({
+      data: {message: 'Failed', title: undefined, severity: 'error'},
+      panelClass: ['tafel-snackbar-panel', 'tafel-snackbar-panel-error'],
+    }));
   });
 
 });

--- a/frontend/src/main/webapp/src/app/common/components/tafel-toastr/tafel-toastr.service.ts
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-toastr/tafel-toastr.service.ts
@@ -1,41 +1,38 @@
-import {Injectable, InjectionToken, inject} from '@angular/core';
-import * as toastr from 'toastr';
+import {Injectable, inject} from '@angular/core';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {TafelSnackbarComponent, TafelSnackbarSeverity} from '../tafel-snackbar/tafel-snackbar.component';
 
-// 1. Define an Injection Token for toastr
-export const TOASTR_TOKEN = new InjectionToken<any>('toastr');
+const DURATION_MS = 5000;
 
 @Injectable({
   providedIn: 'root',
-  // @Service()'s typed factory option requires the return type to match the class shape,
-  // which doesn't hold here (the factory substitutes the raw toastr module instead of an instance)
-  useFactory: () => toastr,
 })
 export class TafelToastrService {
-  private readonly toastrInstance = inject(TOASTR_TOKEN);
-
-  constructor() {
-    // Configure default options
-    this.toastrInstance.options.timeOut = 5000;
-    this.toastrInstance.options.closeButton = true;
-    this.toastrInstance.options.preventDuplicates = true;
-    this.toastrInstance.options.tapToDismiss = true;
-    this.toastrInstance.options.progressBar = true;
-    this.toastrInstance.options.positionClass = 'toast-top-right';
-  }
+  private readonly snackBar = inject(MatSnackBar);
 
   success(message: string, title?: string) {
-    this.toastrInstance.success(message, title);
+    this.show('success', message, title);
   }
 
   error(message: string, title?: string) {
-    this.toastrInstance.error(message, title);
+    this.show('error', message, title);
   }
 
   info(message: string, title?: string) {
-    this.toastrInstance.info(message, title);
+    this.show('info', message, title);
   }
 
   warning(message: string, title?: string) {
-    this.toastrInstance.warning(message, title);
+    this.show('warning', message, title);
+  }
+
+  private show(severity: TafelSnackbarSeverity, message: string, title?: string) {
+    this.snackBar.openFromComponent(TafelSnackbarComponent, {
+      data: {message, title, severity},
+      duration: DURATION_MS,
+      panelClass: ['tafel-snackbar-panel', `tafel-snackbar-panel-${severity}`],
+      horizontalPosition: 'right',
+      verticalPosition: 'top',
+    });
   }
 }

--- a/frontend/src/main/webapp/src/scss/angular-material-theme.scss
+++ b/frontend/src/main/webapp/src/scss/angular-material-theme.scss
@@ -9,6 +9,7 @@
 @import "components/mat-card";
 @import "components/mat-button";
 @import "components/mat-paginator";
+@import "components/tafel-snackbar";
 
 // Custom styles
 @import "components/tafel-banner";

--- a/frontend/src/main/webapp/src/scss/components/tafel-snackbar.scss
+++ b/frontend/src/main/webapp/src/scss/components/tafel-snackbar.scss
@@ -1,0 +1,25 @@
+// Recolor the Material snack bar surface per severity to match the previous
+// toastr look (see tafel-snackbar.component.ts for the matching panelClass).
+.mat-mdc-snack-bar-container.tafel-snackbar-panel {
+  --mat-snack-bar-container-shape: 3px;
+
+  &-success {
+    --mat-snack-bar-container-color: #51a351;
+    --mat-snack-bar-supporting-text-color: #ffffff;
+  }
+
+  &-error {
+    --mat-snack-bar-container-color: #bd362f;
+    --mat-snack-bar-supporting-text-color: #ffffff;
+  }
+
+  &-info {
+    --mat-snack-bar-container-color: #2f96b4;
+    --mat-snack-bar-supporting-text-color: #ffffff;
+  }
+
+  &-warning {
+    --mat-snack-bar-container-color: #f89406;
+    --mat-snack-bar-supporting-text-color: #ffffff;
+  }
+}

--- a/frontend/src/main/webapp/src/scss/styles.scss
+++ b/frontend/src/main/webapp/src/scss/styles.scss
@@ -5,9 +5,6 @@
 // Angular Material theme
 @import "angular-material-theme";
 
-// Toastr
-@import "toastr";
-
 // Custom styles
 @import "theme";
 


### PR DESCRIPTION
## Summary
- Dependency maintenance item #2 from `DEPENDENCY_MAINTENANCE_PLAN.md`: `toastr` is stale (last release 2022, jQuery-era, CommonJS/ESM build warning). Replaces it with `MatSnackBar`, which was already an `@angular/material` dependency, so this net-removes a dependency (`toastr` + transitive `jquery`).
- `TafelToastrService` keeps its exact public `success/error/info/warning(message, title?)` API, so none of the ~30 call sites across the app needed to change.
- New `TafelSnackbarComponent` renders via `MatSnackBar.openFromComponent`, recolored per severity to match toastr's original palette (green/red/blue/orange, white text, rounded corners) so the visual look is close to the previous toasts.
- Kept the `.toast-message` class name on the message element so existing Cypress assertions (`cy.get('.toast-message')`, 7 spec files) keep passing unmodified.
- Removed the now-dead jquery `<script>` entry from `angular.json` (it was only ever loaded for toastr).

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test-ci` passes (511/511, including a rewritten `tafel-toastr.service.spec.ts` mocking `MatSnackBar`)
- [x] `npm run build-prod` passes, CommonJS/ESM toastr warning is gone
- [x] Manually confirmed via instrumentation in a running `ng serve` session that a real HTTP error triggers the interceptor → `TafelToastrService.error()` → `MatSnackBar.openFromComponent()` with correct data/config
- [ ] Visual check of snack bar colors in a real browser (blocked in automated session by a CDK overlay attachment quirk unrelated to this change — recommend a quick manual/Cypress look before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)