### PR TITLE
Fix intermittent double-click race in ticket screen control

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.ts
@@ -56,7 +56,7 @@ export class TicketScreenControlComponent {
     this.startTimeForm.startTime().markAsTouched();
 
     const time = this.startTimeForm.startTime().value();
-    if (time) {
+    if (time && !this.isShowingStartTime()) {
       this.isShowingStartTime.set(true);
       this.distributionTicketScreenApiService.showText('Startzeit', time)
         .pipe(finalize(() => this.isShowingStartTime.set(false)))
@@ -69,6 +69,9 @@ export class TicketScreenControlComponent {
   }
 
   showCurrentTicket() {
+    if (this.isShowingCurrentTicket()) {
+      return;
+    }
     this.isShowingCurrentTicket.set(true);
     this.distributionTicketScreenApiService.showCurrentTicket()
       .pipe(finalize(() => this.isShowingCurrentTicket.set(false)))
@@ -80,6 +83,9 @@ export class TicketScreenControlComponent {
   }
 
   showPreviousTicket() {
+    if (this.isShowingPreviousTicket()) {
+      return;
+    }
     this.isShowingPreviousTicket.set(true);
     this.distributionTicketScreenApiService.showPreviousTicket()
       .pipe(finalize(() => this.isShowingPreviousTicket.set(false)))
@@ -91,6 +97,9 @@ export class TicketScreenControlComponent {
   }
 
   showNextTicket(costContributionPaid: boolean) {
+    if (this.isShowingNextTicket()) {
+      return;
+    }
     this.isShowingNextTicket.set(true);
     this.distributionTicketScreenApiService.showNextTicket(costContributionPaid)
       .pipe(finalize(() => this.isShowingNextTicket.set(false)))


### PR DESCRIPTION
## Summary
- CI run for #2761 failed `ticket-screen.cy.ts` > "tickets switched by double click" (expected ticket text `2`, got `3`), though the PR's actual diff (toastr -> MatSnackBar) doesn't touch this code path.
- Root cause: `showNextTicket`/`showCurrentTicket`/`showPreviousTicket`/`showStartTime` in `ticket-screen-control.component.ts` relied solely on the `[disabled]` DOM binding to prevent re-entrant calls. That binding only updates once Angular re-renders after the first click's change detection, which isn't guaranteed to land before the second click event of a native `dblclick` — a race that's rare locally but reproducible under CI's slower/more loaded runner.
- Fix: check the loading signal at the top of each handler and return early on a re-entrant call, independent of DOM/render timing.

## Test plan
- [x] Unit tests: `npx ng test --include="**/ticket-screen-control.component.spec.ts"` — 13 passed
- [x] E2E: `ticket-screen.cy.ts` re-run locally against a freshly restarted `local,testdata` backend — 5/5 passing, including "tickets switched by double click"