### PR TITLE
Add "Customers above limit" overview and permission

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -13,12 +13,6 @@ listed under MAYBE with the specific open question instead of guessed at.
    * Fix: in `DistributionService.generateHouseholdListPdf()` (`DistributionService.kt:124-152`), replace `currentDistribution.households` with a direct fresh query, e.g. add `findByDistributionId(distributionId: Long): List<DistributionHouseholdEntity>` to `DistributionHouseholdRepository` and use that instead of the entity association — this removes any dependency on collection-caching semantics regardless of transaction boundaries.
    * Files: `DistributionService.kt:129`, `DistributionHouseholdRepository.kt` (new query method).
 
-2. **Add overview "Customers above limit" + permission**
-   * Add `CUSTOMERS_ABOVE_LIMIT("CUSTOMERS_ABOVE_LIMIT", "Kunden über dem Limit")` to `UserPermissions.kt:6-16` (same enum pattern as `CUSTOMER_DUPLICATES`/`SETTINGS`).
-   * This can't be a JPA `Specification` like `HouseholdEntity.Specs.validHousehold()` (`HouseholdEntity.kt:205-213`) — "above limit" is a computed result, not a stored column. New endpoint in `HouseholdController.kt` (alongside `getDuplicates()` at line 149), e.g. `GET /api/households/above-limit`, backed by a new `HouseholdService` method that: loads households via the existing `validHousehold()` spec, for each loads its persons, calls `IncomeValidatorService.validate()` (same call already used in `createHousehold`/`updateHousehold`, `HouseholdService.kt:55/96`), and returns those where `result.valid == false`. This is what catches households that were fine at creation but now exceed the limit because a `StaticValueType.INCOME_LIMIT` row's amount changed since.
-   * Frontend: new view reusing the `customer-duplicates` view's table/pagination pattern, gated by the new permission, with a nav entry in `navigation-menuItems.ts`.
-   * Files: `UserPermissions.kt`, `HouseholdController.kt`, `HouseholdService.kt`, `IncomeValidatorService`, frontend `modules/household`.
-
 3. **Add file upload / documents to customer details** (merges both TODO occurrences)
    * Storage: local disk/volume (per user decision, 2026-07-27). Add `documentsPath: String` to a new nested properties class under `TafelAdminProperties` (`TafelAdminProperties.kt`, same pattern as its existing `mail` property), bound as `tafeladmin.storage.documentsPath`.
    * New `DocumentEntity` (own table `household_documents`, `@ManyToOne` to `HouseholdEntity`, matching the `BaseChangeTrackingEntity` pattern used everywhere else): `household`, `person` (nullable `@ManyToOne` to `PersonEntity`, for per-person docs like school enrollment), `documentType` (`@Enumerated(EnumType.STRING)`: `PROOF_OF_INCOME`, `ID`, `SCHOOL_ENROLLMENT`, `OTHER`), `fileName`, `contentType`, `storagePath`, `uploadedByUser` (`@ManyToOne UserEntity`).
@@ -113,6 +107,7 @@ listed under MAYBE with the specific open question instead of guessed at.
 
 ---
 ## Done (validated 2026-07-27)
+* Add overview "Customers above limit" + permission - implemented 2026-07-27: CUSTOMERS_ABOVE_LIMIT permission added; GET /api/households/above-limit (HouseholdService.getHouseholdsAboveLimit()) re-validates every currently-valid household against IncomeValidatorService and returns those over the limit with totalSum/limit/amountExceededLimit; new "Kunden über Limit" frontend view + nav entry
 * Route only needs a time and no separate order (sorting) - RouteStopEntity has no order field
 * Route: Model extra-stops in DB (needs to part of the route, comment is not enough) - RouteStopEntity is a real JPA entity (routes_stops table), separate from Route's free-text note
 * Validation necessary for KM Abfahrt < KM Ankunft - implemented (kmValidation error) and covered by tests in food-collection-recording-basedata

--- a/_http-calls/distributions.http
+++ b/_http-calls/distributions.http
@@ -29,6 +29,14 @@ Content-Type: application/json
   "selectedShelterIds": [1, 2, 3]
 }
 
+### Save notes for distribution
+POST {{baseApiPath}}/distributions/notes
+Content-Type: application/json
+
+{
+  "notes": "Everything went well!"
+}
+
 ### Get customer list (pdf)
 GET {{baseApiPath}}/distributions/households/generate-pdf
 

--- a/_http-calls/households.http
+++ b/_http-calls/households.http
@@ -181,6 +181,10 @@ Content-Type: application/json
 GET {{baseApiPath}}/households/duplicates
 Content-Type: application/json
 
+### Get households above limit
+GET {{baseApiPath}}/households/above-limit
+Content-Type: application/json
+
 ### Merge households into another one
 GET {{baseApiPath}}/households/100/merge
 Content-Type: application/json

--- a/_http-calls/households.http
+++ b/_http-calls/households.http
@@ -186,7 +186,7 @@ GET {{baseApiPath}}/households/above-limit
 Content-Type: application/json
 
 ### Merge households into another one
-GET {{baseApiPath}}/households/100/merge
+POST {{baseApiPath}}/households/100/merge
 Content-Type: application/json
 
 {

--- a/_http-calls/shelters.http
+++ b/_http-calls/shelters.http
@@ -1,2 +1,54 @@
+### Fetch all active shelters
+GET {{baseApiPath}}/shelters/active
+
 ### Fetch all shelters
 GET {{baseApiPath}}/shelters
+
+### Create shelter
+POST {{baseApiPath}}/shelters
+Content-Type: application/json
+
+{
+  "name": "Test-Shelter",
+  "addressStreet": "Erdberg",
+  "addressHouseNumber": "2",
+  "addressStairway": "1",
+  "addressDoor": "20",
+  "addressPostalCode": 1030,
+  "addressCity": "Wien",
+  "note": null,
+  "personsCount": 10,
+  "enabled": true,
+  "contacts": [
+    {
+      "firstname": "Max",
+      "lastname": "Mustermann",
+      "phone": "0043660123123"
+    }
+  ]
+}
+
+### Update shelter 1
+POST {{baseApiPath}}/shelters/1
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "Test-Shelter-Updated",
+  "addressStreet": "Erdberg",
+  "addressHouseNumber": "2",
+  "addressStairway": "1",
+  "addressDoor": "20",
+  "addressPostalCode": 1030,
+  "addressCity": "Wien",
+  "note": null,
+  "personsCount": 10,
+  "enabled": true,
+  "contacts": [
+    {
+      "firstname": "Max",
+      "lastname": "Mustermann",
+      "phone": "0043660123123"
+    }
+  ]
+}

--- a/_http-calls/statistics.http
+++ b/_http-calls/statistics.http
@@ -3,3 +3,6 @@ GET {{baseApiPath}}/statistics/settings
 
 ### Fetch data
 GET {{baseApiPath}}/statistics/data?fromDate=2000-01-01&toDate=2999-12-31
+
+### Generate CSV export
+GET {{baseApiPath}}/statistics/generate-csv?fromDate=2000-01-01&toDate=2999-12-31

--- a/_http-calls/users.http
+++ b/_http-calls/users.http
@@ -23,6 +23,9 @@ Content-Type: application/json
 ### Logout
 POST {{baseApiPath}}/users/logout
 
+### Get info of the currently authenticated user
+GET {{baseApiPath}}/users/info
+
 ### Search for users (personnelNumber)
 GET {{baseApiPath}}/users?personnelnumber=x
 
@@ -40,6 +43,22 @@ Content-Type: application/json
 GET {{baseApiPath}}/users/personnel-number/admin-persnr
 Content-Type: application/json
 
+### Create user
+POST {{baseApiPath}}/users
+Content-Type: application/json
+
+{
+  "personnelNumber": "0400",
+  "username": "new-user",
+  "firstname": "New",
+  "lastname": "User",
+  "enabled": true,
+  "password": "12345",
+  "passwordRepeat": "12345",
+  "passwordChangeRequired": true,
+  "permissions": []
+}
+
 ### Update user
 POST {{baseApiPath}}/users/300
 Content-Type: application/json
@@ -56,6 +75,9 @@ Content-Type: application/json
   "passwordChangeRequired": true,
   "permissions": []
 }
+
+### Delete user
+DELETE {{baseApiPath}}/users/300
 
 ### Generate a random password
 GET {{baseApiPath}}/users/generate-password

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserPermissions.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserPermissions.kt
@@ -9,6 +9,7 @@ enum class UserPermissions(val key: String, val title: String) {
     USER_MANAGEMENT("USER_MANAGEMENT", "Benutzerverwaltung"),
     CUSTOMER("CUSTOMER", "Kundenverwaltung"),
     CUSTOMER_DUPLICATES("CUSTOMER_DUPLICATES", "Kunden-Duplikate"),
+    CUSTOMERS_ABOVE_LIMIT("CUSTOMERS_ABOVE_LIMIT", "Kunden über dem Limit"),
     LOGISTICS("LOGISTICS", "Transport/Logistik"),
     SCANNER("SCANNER", "Scanner"),
     SETTINGS("SETTINGS", "Einstellungen"),

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
@@ -148,8 +148,17 @@ class HouseholdController(
 
     @GetMapping("/above-limit")
     @PreAuthorize("hasAuthority('CUSTOMERS_ABOVE_LIMIT')")
-    fun getHouseholdsAboveLimit(): HouseholdAboveLimitResponse {
-        return HouseholdAboveLimitResponse(items = householdService.getHouseholdsAboveLimit())
+    fun getHouseholdsAboveLimit(
+        @RequestParam page: Int? = null,
+    ): HouseholdAboveLimitResponse {
+        val result = householdService.getHouseholdsAboveLimit(page)
+        return HouseholdAboveLimitResponse(
+            items = result.items,
+            totalCount = result.totalCount,
+            currentPage = result.currentPage,
+            totalPages = result.totalPages,
+            pageSize = result.pageSize
+        )
     }
 
     @GetMapping("/duplicates")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
@@ -146,6 +146,12 @@ class HouseholdController(
         )
     }
 
+    @GetMapping("/above-limit")
+    @PreAuthorize("hasAuthority('CUSTOMERS_ABOVE_LIMIT')")
+    fun getHouseholdsAboveLimit(): HouseholdAboveLimitResponse {
+        return HouseholdAboveLimitResponse(items = householdService.getHouseholdsAboveLimit())
+    }
+
     @GetMapping("/duplicates")
     @PreAuthorize("hasAuthority('CUSTOMER_DUPLICATES')")
     fun getDuplicates(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
@@ -125,3 +125,16 @@ data class HouseholdDuplicationItem(
 data class HouseholdMergeRequest(
     val sourceHouseholdIds: List<Long>
 )
+
+@ExcludeFromTestCoverage
+data class HouseholdAboveLimitResponse(
+    val items: List<HouseholdAboveLimitItem>
+)
+
+@ExcludeFromTestCoverage
+data class HouseholdAboveLimitItem(
+    val household: Household,
+    val totalSum: BigDecimal,
+    val limit: BigDecimal,
+    val amountExceededLimit: BigDecimal
+)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
@@ -128,7 +128,11 @@ data class HouseholdMergeRequest(
 
 @ExcludeFromTestCoverage
 data class HouseholdAboveLimitResponse(
-    val items: List<HouseholdAboveLimitItem>
+    val items: List<HouseholdAboveLimitItem>,
+    val totalCount: Long,
+    val currentPage: Int,
+    val totalPages: Int,
+    val pageSize: Int
 )
 
 @ExcludeFromTestCoverage

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -20,6 +20,7 @@ import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValida
 import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValidatorResult
 import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValidatorService
 import at.wrk.tafel.admin.backend.modules.household.internal.masterdata.HouseholdPdfService
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.Specification.where
@@ -185,14 +186,14 @@ class HouseholdService(
     }
 
     @Transactional
-    fun getHouseholdsAboveLimit(): List<HouseholdAboveLimitItem> {
+    fun getHouseholdsAboveLimit(page: Int? = null): HouseholdAboveLimitSearchResult {
         // households needing post-processing (missing birthDate/gender/country/address/... - see
         // HouseholdEntity.Specs.postProcessingNecessary()) can't be income-validated
         val spec = where(Specification.allOf(listOf(validHousehold(), Specification.not(postProcessingNecessary()))))
         val households = householdRepository.findAll(spec)
             .map { householdConverter.mapEntityToHousehold(it) }
 
-        return households.mapNotNull { household ->
+        val itemsAboveLimit = households.mapNotNull { household ->
             val result = incomeValidatorService.validate(mapToValidationPersons(household))
             if (!result.valid) {
                 HouseholdAboveLimitItem(
@@ -205,6 +206,21 @@ class HouseholdService(
                 null
             }
         }
+
+        // the "above limit" filter can't be expressed in SQL (it depends on IncomeValidatorService,
+        // not stored columns), so pagination is applied in-memory on the already-computed result
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
+        val fromIndex = pageRequest.offset.toInt().coerceAtMost(itemsAboveLimit.size)
+        val toIndex = (fromIndex + pageRequest.pageSize).coerceAtMost(itemsAboveLimit.size)
+        val pagedResult = PageImpl(itemsAboveLimit.subList(fromIndex, toIndex), pageRequest, itemsAboveLimit.size.toLong())
+
+        return HouseholdAboveLimitSearchResult(
+            items = pagedResult.content,
+            totalCount = pagedResult.totalElements,
+            currentPage = page ?: 1,
+            totalPages = pagedResult.totalPages,
+            pageSize = pageRequest.pageSize
+        )
     }
 
     @Transactional
@@ -290,6 +306,15 @@ class HouseholdService(
 @ExcludeFromTestCoverage
 data class HouseholdSearchResult(
     val items: List<Household>,
+    val totalCount: Long,
+    val currentPage: Int,
+    val totalPages: Int,
+    val pageSize: Int
+)
+
+@ExcludeFromTestCoverage
+data class HouseholdAboveLimitSearchResult(
+    val items: List<HouseholdAboveLimitItem>,
     val totalCount: Long,
     val currentPage: Int,
     val totalPages: Int,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -186,7 +186,10 @@ class HouseholdService(
 
     @Transactional
     fun getHouseholdsAboveLimit(): List<HouseholdAboveLimitItem> {
-        val households = householdRepository.findAll(validHousehold())
+        // households needing post-processing (missing birthDate/gender/country/address/... - see
+        // HouseholdEntity.Specs.postProcessingNecessary()) can't be income-validated
+        val spec = where(Specification.allOf(listOf(validHousehold(), Specification.not(postProcessingNecessary()))))
+        val households = householdRepository.findAll(spec)
             .map { householdConverter.mapEntityToHousehold(it) }
 
         return households.mapNotNull { household ->

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -11,6 +11,7 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.household.Household
+import at.wrk.tafel.admin.backend.modules.household.HouseholdAboveLimitItem
 import at.wrk.tafel.admin.backend.modules.household.HouseholdCreationResponse
 import at.wrk.tafel.admin.backend.modules.household.HouseholdPdfType
 import at.wrk.tafel.admin.backend.modules.household.HouseholdUpdateResponse
@@ -181,6 +182,26 @@ class HouseholdService(
             totalPages = pagedResult.totalPages,
             pageSize = pageRequest.pageSize
         )
+    }
+
+    @Transactional
+    fun getHouseholdsAboveLimit(): List<HouseholdAboveLimitItem> {
+        val households = householdRepository.findAll(validHousehold())
+            .map { householdConverter.mapEntityToHousehold(it) }
+
+        return households.mapNotNull { household ->
+            val result = incomeValidatorService.validate(mapToValidationPersons(household))
+            if (!result.valid) {
+                HouseholdAboveLimitItem(
+                    household = household,
+                    totalSum = result.totalSum,
+                    limit = result.limit,
+                    amountExceededLimit = result.amountExceededLimit
+                )
+            } else {
+                null
+            }
+        }
     }
 
     @Transactional

--- a/backend/src/main/resources/db-migration-testdata/testdata.sql
+++ b/backend/src/main/resources/db-migration-testdata/testdata.sql
@@ -344,6 +344,42 @@ INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, f
 values (1064, NOW(), NOW(), 106, false, 'Firstname 5', 'Lastname 5', null, null, null, null, null, 1, false, false);
 UPDATE households SET main_person_id = 106 WHERE id = 106;
 
+-- household above the income limit (couple, 2 children) - complete master data, shows up in
+-- "Kunden über Limit": income 2200+1600=3800 vs. limit 2788.00 for 2 adults/2 children
+INSERT INTO households (id, created_at, updated_at, household_id, employee_id, main_person_id,
+                        address_street, address_housenumber, address_stairway, address_door, address_postalcode,
+                        address_city, telephone_number, email, valid_until, pending_cost_contribution)
+values (110, NOW(), NOW(), 110, 100, null, 'Teststraße', '10', null, null,
+        '1030', 'Wien', '0043660111000', 'ueberlimit.paar@wrk.at', '2999-12-31', 0);
+INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
+                     country_id, employer, income, income_due, exclude_household, receives_familybonus)
+values (110, NOW(), NOW(), 110, true, 'Anna', 'Vielverdiener', '1988-05-10', 'FEMALE', 1, 'Firma A', 2200.00,
+        '2999-12-31', false, false);
+INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
+                     country_id, employer, income, income_due, exclude_household, receives_familybonus)
+values (1101, NOW(), NOW(), 110, false, 'Peter', 'Vielverdiener', '1985-03-15', 'MALE', 1, 'Firma B', 1600.00,
+        '2999-12-31', false, false);
+INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
+                     country_id, exclude_household, receives_familybonus)
+values (1102, NOW(), NOW(), 110, false, 'Lisa', 'Vielverdiener', CURRENT_DATE - interval '8 year', 'FEMALE', 1, false, false);
+INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
+                     country_id, exclude_household, receives_familybonus)
+values (1103, NOW(), NOW(), 110, false, 'Tom', 'Vielverdiener', CURRENT_DATE - interval '5 year', 'MALE', 1, false, false);
+UPDATE households SET main_person_id = 110 WHERE id = 110;
+
+-- household above the income limit (single adult) - complete master data, shows up in
+-- "Kunden über Limit": income 2200 vs. limit 1328.00 for 1 adult/0 children
+INSERT INTO households (id, created_at, updated_at, household_id, employee_id, main_person_id,
+                        address_street, address_housenumber, address_stairway, address_door, address_postalcode,
+                        address_city, telephone_number, email, valid_until, pending_cost_contribution)
+values (111, NOW(), NOW(), 111, 100, null, 'Teststraße', '11', null, null,
+        '1030', 'Wien', '0043660111111', 'ueberlimit.single@wrk.at', '2999-12-31', 0);
+INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
+                     country_id, employer, income, income_due, exclude_household, receives_familybonus)
+values (111, NOW(), NOW(), 111, true, 'Sabine', 'Grossverdiener', '1975-11-20', 'FEMALE', 1, 'Firma C', 2200.00,
+        '2999-12-31', false, false);
+UPDATE households SET main_person_id = 111 WHERE id = 111;
+
 -- static values
 DELETE FROM static_values;
 

--- a/backend/src/main/resources/db-migration-testdata/testdata.sql
+++ b/backend/src/main/resources/db-migration-testdata/testdata.sql
@@ -49,6 +49,8 @@ INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (1009, NOW(), NOW(), 100, 'STATISTICS');
 INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (1010, NOW(), NOW(), 100, 'SUPERVISOR');
+INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
+VALUES (1011, NOW(), NOW(), 100, 'CUSTOMERS_ABOVE_LIMIT');
 
 -- user: testuser
 -- pwd: 35bc40681124f412c5d052366edb9eb9
@@ -68,6 +70,8 @@ INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (2004, NOW(), NOW(), 200, 'DISTRIBUTION_LCM');
 INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (2005, NOW(), NOW(), 200, 'CUSTOMER_DUPLICATES');
+INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
+VALUES (2006, NOW(), NOW(), 200, 'CUSTOMERS_ABOVE_LIMIT');
 
 -- user: admin
 -- pwd: 12345
@@ -97,6 +101,8 @@ INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (3009, NOW(), NOW(), 300, 'STATISTICS');
 INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
 VALUES (3010, NOW(), NOW(), 300, 'SUPERVISOR');
+INSERT INTO users_authorities (id, created_at, updated_at, user_id, name)
+VALUES (3011, NOW(), NOW(), 300, 'CUSTOMERS_ABOVE_LIMIT');
 
 -- user: scanner1
 -- pwd: 12345

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
@@ -409,6 +409,21 @@ class HouseholdControllerTest {
     }
 
     @Test
+    fun `get households above limit`() {
+        val aboveLimitItem = HouseholdAboveLimitItem(
+            household = mockk(relaxed = true),
+            totalSum = BigDecimal("1500"),
+            limit = BigDecimal("1000"),
+            amountExceededLimit = BigDecimal("500")
+        )
+        every { householdService.getHouseholdsAboveLimit() } returns listOf(aboveLimitItem)
+
+        val response = controller.getHouseholdsAboveLimit()
+
+        assertThat(response.items).isEqualTo(listOf(aboveLimitItem))
+    }
+
+    @Test
     fun `get duplicates - result mapped`() {
         val page = 4
         val duplicationItem = HouseholdDuplicateSearchResultItem(

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
@@ -410,17 +410,29 @@ class HouseholdControllerTest {
 
     @Test
     fun `get households above limit`() {
+        val page = 2
         val aboveLimitItem = HouseholdAboveLimitItem(
             household = mockk(relaxed = true),
             totalSum = BigDecimal("1500"),
             limit = BigDecimal("1000"),
             amountExceededLimit = BigDecimal("500")
         )
-        every { householdService.getHouseholdsAboveLimit() } returns listOf(aboveLimitItem)
+        val searchResult = HouseholdAboveLimitSearchResult(
+            items = listOf(aboveLimitItem),
+            totalCount = 26,
+            currentPage = page,
+            totalPages = 2,
+            pageSize = 25
+        )
+        every { householdService.getHouseholdsAboveLimit(page) } returns searchResult
 
-        val response = controller.getHouseholdsAboveLimit()
+        val response = controller.getHouseholdsAboveLimit(page)
 
         assertThat(response.items).isEqualTo(listOf(aboveLimitItem))
+        assertThat(response.totalCount).isEqualTo(searchResult.totalCount)
+        assertThat(response.currentPage).isEqualTo(searchResult.currentPage)
+        assertThat(response.totalPages).isEqualTo(searchResult.totalPages)
+        assertThat(response.pageSize).isEqualTo(searchResult.pageSize)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
@@ -507,11 +507,48 @@ class HouseholdServiceTest {
 
         val result = service.getHouseholdsAboveLimit()
 
-        assertThat(result).hasSize(1)
-        assertThat(result.first().household).isEqualTo(invalidHousehold)
-        assertThat(result.first().totalSum).isEqualTo(BigDecimal("1500"))
-        assertThat(result.first().limit).isEqualTo(BigDecimal("1000"))
-        assertThat(result.first().amountExceededLimit).isEqualTo(BigDecimal("500"))
+        assertThat(result.items).hasSize(1)
+        assertThat(result.items.first().household).isEqualTo(invalidHousehold)
+        assertThat(result.items.first().totalSum).isEqualTo(BigDecimal("1500"))
+        assertThat(result.items.first().limit).isEqualTo(BigDecimal("1000"))
+        assertThat(result.items.first().amountExceededLimit).isEqualTo(BigDecimal("500"))
+        assertThat(result.totalCount).isEqualTo(1)
+        assertThat(result.currentPage).isEqualTo(1)
+        assertThat(result.totalPages).isEqualTo(1)
+        assertThat(result.pageSize).isEqualTo(25)
+    }
+
+    @Test
+    fun `get households above limit - paginates the computed result`() {
+        val testHouseholdEntities = (1..30).map { mockk<HouseholdEntity>(relaxed = true) }
+        val invalidHouseholds = (1..30).map { mockk<Household>(relaxed = true) }
+
+        every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns testHouseholdEntities
+        testHouseholdEntities.forEachIndexed { index, entity ->
+            every { householdConverter.mapEntityToHousehold(entity) } returns invalidHouseholds[index]
+        }
+
+        every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
+            valid = false,
+            totalSum = BigDecimal("1500"),
+            limit = BigDecimal("1000"),
+            toleranceValue = BigDecimal.ZERO,
+            amountExceededLimit = BigDecimal("500")
+        )
+
+        val firstPage = service.getHouseholdsAboveLimit(page = 1)
+        assertThat(firstPage.items).hasSize(25)
+        assertThat(firstPage.items.first().household).isEqualTo(invalidHouseholds[0])
+        assertThat(firstPage.totalCount).isEqualTo(30)
+        assertThat(firstPage.currentPage).isEqualTo(1)
+        assertThat(firstPage.totalPages).isEqualTo(2)
+        assertThat(firstPage.pageSize).isEqualTo(25)
+
+        val secondPage = service.getHouseholdsAboveLimit(page = 2)
+        assertThat(secondPage.items).hasSize(5)
+        assertThat(secondPage.items.first().household).isEqualTo(invalidHouseholds[25])
+        assertThat(secondPage.currentPage).isEqualTo(2)
+        assertThat(secondPage.totalPages).isEqualTo(2)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
@@ -474,6 +474,47 @@ class HouseholdServiceTest {
     }
 
     @Test
+    fun `get households above limit - only invalid households are returned`() {
+        val testHouseholdEntity1 = mockk<HouseholdEntity>(relaxed = true)
+        val testHouseholdEntity2 = mockk<HouseholdEntity>(relaxed = true)
+
+        val validHousehold = mockk<Household>(relaxed = true)
+        val invalidHousehold = mockk<Household>(relaxed = true)
+
+        every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns listOf(
+            testHouseholdEntity1,
+            testHouseholdEntity2
+        )
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity1) } returns validHousehold
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity2) } returns invalidHousehold
+
+        every { incomeValidatorService.validate(any()) } returnsMany listOf(
+            IncomeValidatorResult(
+                valid = true,
+                totalSum = BigDecimal("500"),
+                limit = BigDecimal("1000"),
+                toleranceValue = BigDecimal.ZERO,
+                amountExceededLimit = BigDecimal.ZERO
+            ),
+            IncomeValidatorResult(
+                valid = false,
+                totalSum = BigDecimal("1500"),
+                limit = BigDecimal("1000"),
+                toleranceValue = BigDecimal.ZERO,
+                amountExceededLimit = BigDecimal("500")
+            )
+        )
+
+        val result = service.getHouseholdsAboveLimit()
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().household).isEqualTo(invalidHousehold)
+        assertThat(result.first().totalSum).isEqualTo(BigDecimal("1500"))
+        assertThat(result.first().limit).isEqualTo(BigDecimal("1000"))
+        assertThat(result.first().amountExceededLimit).isEqualTo(BigDecimal("500"))
+    }
+
+    @Test
     fun `generate pdf household - not found`() {
         every { householdRepository.findByHouseholdId(any()) } returns null
 

--- a/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
@@ -1,0 +1,32 @@
+describe('Customer Above Limit', () => {
+
+  beforeEach(() => {
+    cy.loginDefault();
+  });
+
+  it('lists a customer whose income exceeds the limit and links to their detail page', () => {
+    cy.createDummyCustomer(50000, true).then((response) => {
+      const customer = response.body.data;
+
+      cy.visit('/#/kunden/ueber-limit');
+
+      cy.contains('[testid^="abovelimit-id-"]', customer.id!.toString())
+        .closest('tr')
+        .within(() => {
+          cy.get('[testid^="abovelimit-name-"]').should('contain.text', customer.lastname).and('contain.text', customer.firstname);
+          cy.get('[testid^="abovelimit-address-"]').should('contain.text', customer.address.city);
+          cy.get('[testid^="abovelimit-totalSum-"]').should('be.visible');
+          cy.get('[testid^="abovelimit-limit-"]').should('be.visible');
+          cy.get('[testid^="abovelimit-amountExceededLimit-"]')
+            .should('be.visible')
+            .invoke('text')
+            .should('not.be.empty');
+
+          cy.get('[testid^="abovelimit-showcustomer-button-"]').click();
+        });
+
+      cy.url().should('include', '/kunden/detail/' + customer.id);
+    });
+  });
+
+});

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
@@ -374,21 +374,42 @@ describe('CustomerApiService', () => {
     expect(result!.items[0].similarCustomers[0].id).toEqual(133);
   });
 
-  it('get customers above limit', () => {
-    let result;
-    apiService.getCustomersAboveLimit().subscribe(response => result = response);
+  it('get customers above limit without page', () => {
+    apiService.getCustomersAboveLimit().subscribe();
 
     const req = httpMock.expectOne({method: 'GET', url: '/households/above-limit'});
+    req.flush(null);
+    httpMock.verify();
+  });
+
+  it('get customers above limit with page', () => {
+    apiService.getCustomersAboveLimit(3).subscribe();
+
+    const req = httpMock.expectOne({method: 'GET', url: '/households/above-limit?page=3'});
+    req.flush(null);
+    httpMock.verify();
+  });
+
+  it('get customers above limit maps household to customer', () => {
+    let result;
+    apiService.getCustomersAboveLimit(1).subscribe(response => result = response);
+
+    const req = httpMock.expectOne({method: 'GET', url: '/households/above-limit?page=1'});
     req.flush({
-      items: [{household: mockHousehold, totalSum: 1500, limit: 1000, amountExceededLimit: 500}]
+      items: [{household: mockHousehold, totalSum: 1500, limit: 1000, amountExceededLimit: 500}],
+      totalCount: 1,
+      currentPage: 1,
+      totalPages: 1,
+      pageSize: 25
     });
     httpMock.verify();
 
-    expect(result!).toHaveLength(1);
-    expect(result![0].customer.lastname).toEqual('Mustermann');
-    expect(result![0].totalSum).toEqual(1500);
-    expect(result![0].limit).toEqual(1000);
-    expect(result![0].amountExceededLimit).toEqual(500);
+    expect(result!.items).toHaveLength(1);
+    expect(result!.items[0].customer.lastname).toEqual('Mustermann');
+    expect(result!.items[0].totalSum).toEqual(1500);
+    expect(result!.items[0].limit).toEqual(1000);
+    expect(result!.items[0].amountExceededLimit).toEqual(500);
+    expect(result!.totalCount).toEqual(1);
   });
 
   it('merge customers', () => {

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
@@ -374,6 +374,23 @@ describe('CustomerApiService', () => {
     expect(result!.items[0].similarCustomers[0].id).toEqual(133);
   });
 
+  it('get customers above limit', () => {
+    let result;
+    apiService.getCustomersAboveLimit().subscribe(response => result = response);
+
+    const req = httpMock.expectOne({method: 'GET', url: '/households/above-limit'});
+    req.flush({
+      items: [{household: mockHousehold, totalSum: 1500, limit: 1000, amountExceededLimit: 500}]
+    });
+    httpMock.verify();
+
+    expect(result!).toHaveLength(1);
+    expect(result![0].customer.lastname).toEqual('Mustermann');
+    expect(result![0].totalSum).toEqual(1500);
+    expect(result![0].limit).toEqual(1000);
+    expect(result![0].amountExceededLimit).toEqual(500);
+  });
+
   it('merge customers', () => {
     const targetCustomerId = 123;
     const sourceCustomerIds = [456, 789];

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.ts
@@ -115,14 +115,21 @@ export class CustomerApiService {
     );
   }
 
-  getCustomersAboveLimit(): Observable<CustomerAboveLimitItem[]> {
-    return this.http.get<HouseholdAboveLimitResponse>('/households/above-limit').pipe(
-      map(response => (response?.items ?? []).map(item => ({
-        customer: mapHouseholdToCustomer(item.household),
-        totalSum: item.totalSum,
-        limit: item.limit,
-        amountExceededLimit: item.amountExceededLimit
-      })))
+  getCustomersAboveLimit(page?: number): Observable<CustomerAboveLimitResponse> {
+    let queryParams = new HttpParams();
+    if (page) {
+      queryParams = queryParams.set('page', page);
+    }
+    return this.http.get<HouseholdAboveLimitResponse>('/households/above-limit', {params: queryParams}).pipe(
+      map(response => ({
+        ...response,
+        items: (response?.items ?? []).map(item => ({
+          customer: mapHouseholdToCustomer(item.household),
+          totalSum: item.totalSum,
+          limit: item.limit,
+          amountExceededLimit: item.amountExceededLimit
+        }))
+      }))
     );
   }
 
@@ -238,6 +245,14 @@ export interface CustomerDuplicatesItem {
   similarCustomers: CustomerData[];
 }
 
+export interface CustomerAboveLimitResponse {
+  items: CustomerAboveLimitItem[];
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+}
+
 export interface CustomerAboveLimitItem {
   customer: CustomerData;
   totalSum: number;
@@ -324,6 +339,10 @@ interface HouseholdMergeRequest {
 
 interface HouseholdAboveLimitResponse {
   items: HouseholdAboveLimitItem[];
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
 }
 
 interface HouseholdAboveLimitItem {

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.ts
@@ -115,6 +115,17 @@ export class CustomerApiService {
     );
   }
 
+  getCustomersAboveLimit(): Observable<CustomerAboveLimitItem[]> {
+    return this.http.get<HouseholdAboveLimitResponse>('/households/above-limit').pipe(
+      map(response => (response?.items ?? []).map(item => ({
+        customer: mapHouseholdToCustomer(item.household),
+        totalSum: item.totalSum,
+        limit: item.limit,
+        amountExceededLimit: item.amountExceededLimit
+      })))
+    );
+  }
+
   mergeCustomers(targetCustomerId: number, sourceCustomerIds: number[]): Observable<void> {
     const request: CustomerMergeRequest = {sourceCustomerIds: sourceCustomerIds};
     const body: HouseholdMergeRequest = {sourceHouseholdIds: request.sourceCustomerIds};
@@ -227,6 +238,13 @@ export interface CustomerDuplicatesItem {
   similarCustomers: CustomerData[];
 }
 
+export interface CustomerAboveLimitItem {
+  customer: CustomerData;
+  totalSum: number;
+  limit: number;
+  amountExceededLimit: number;
+}
+
 export interface CustomerMergeRequest {
   sourceCustomerIds: number[];
 }
@@ -302,6 +320,17 @@ interface HouseholdDuplicatesItem {
 
 interface HouseholdMergeRequest {
   sourceHouseholdIds: number[];
+}
+
+interface HouseholdAboveLimitResponse {
+  items: HouseholdAboveLimitItem[];
+}
+
+interface HouseholdAboveLimitItem {
+  household: HouseholdData;
+  totalSum: number;
+  limit: number;
+  amountExceededLimit: number;
 }
 
 /**

--- a/frontend/src/main/webapp/src/app/common/views/default-layout/navigation-menuItems.ts
+++ b/frontend/src/main/webapp/src/app/common/views/default-layout/navigation-menuItems.ts
@@ -9,6 +9,7 @@ import {
   faGear,
   faMagnifyingGlass,
   faPlus,
+  faTriangleExclamation,
   faTruck,
   faUser
 } from '@fortawesome/free-solid-svg-icons';
@@ -75,6 +76,12 @@ export const navigationMenuItems: ITafelNavData[] = [
     url: '/kunden/duplikate',
     icon: faCopy,
     permissions: ['CUSTOMER_DUPLICATES']
+  },
+  {
+    name: 'Kunden über Limit',
+    url: '/kunden/ueber-limit',
+    icon: faTriangleExclamation,
+    permissions: ['CUSTOMERS_ABOVE_LIMIT']
   },
   {
     name: 'Logistik',

--- a/frontend/src/main/webapp/src/app/modules/customer/customer.routes.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/customer.routes.ts
@@ -7,6 +7,8 @@ import {CustomerDataResolver} from './resolver/customerdata-resolver.component';
 import {CustomerNotesResolver} from './resolver/customernotes-resolver.component';
 import {CustomerDuplicatesComponent} from './views/customer-duplicates/customer-duplicates.component';
 import {CustomerDuplicatesDataResolver} from './resolver/customer-duplicates-data-resolver.component';
+import {CustomerAboveLimitComponent} from './views/customer-above-limit/customer-above-limit.component';
+import {CustomerAboveLimitDataResolver} from './resolver/customer-above-limit-data-resolver.component';
 
 export const routes: Routes = [
   {
@@ -37,6 +39,13 @@ export const routes: Routes = [
     component: CustomerDuplicatesComponent,
     resolve: {
       customerDuplicatesData: CustomerDuplicatesDataResolver
+    }
+  },
+  {
+    path: 'ueber-limit',
+    component: CustomerAboveLimitComponent,
+    resolve: {
+      customerAboveLimitData: CustomerAboveLimitDataResolver
     }
   },
 ];

--- a/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.spec.ts
@@ -1,0 +1,45 @@
+import type { MockedObject } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { CustomerAboveLimitItem, CustomerApiService } from '../../../api/customer-api.service';
+import { of } from 'rxjs';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { CustomerAboveLimitDataResolver } from './customer-above-limit-data-resolver.component';
+import { provideHttpClient, withXhr } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+describe('CustomerAboveLimitDataResolver', () => {
+    let apiService: MockedObject<CustomerApiService>;
+    let resolver: CustomerAboveLimitDataResolver;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                provideHttpClient(withXhr()),
+                provideHttpClientTesting(),
+                {
+                    provide: CustomerApiService,
+                    useValue: {
+                        getCustomersAboveLimit: vi.fn().mockName('CustomerApiService.getCustomersAboveLimit')
+                    }
+                },
+                CustomerAboveLimitDataResolver
+            ]
+        });
+
+        apiService = TestBed.inject(CustomerApiService) as MockedObject<CustomerApiService>;
+        resolver = TestBed.inject(CustomerAboveLimitDataResolver);
+    });
+
+    it('resolve', () => {
+        const mockResponse: CustomerAboveLimitItem[] = [];
+        apiService.getCustomersAboveLimit.mockReturnValue(of(mockResponse));
+
+        const activatedRoute = <ActivatedRouteSnapshot><unknown>{};
+        resolver.resolve(activatedRoute).subscribe((response: CustomerAboveLimitItem[]) => {
+            expect(response).toEqual(mockResponse);
+        });
+
+        expect(apiService.getCustomersAboveLimit).toHaveBeenCalled();
+    });
+
+});

--- a/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.spec.ts
@@ -1,6 +1,6 @@
 import type { MockedObject } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { CustomerAboveLimitItem, CustomerApiService } from '../../../api/customer-api.service';
+import { CustomerAboveLimitResponse, CustomerApiService } from '../../../api/customer-api.service';
 import { of } from 'rxjs';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { CustomerAboveLimitDataResolver } from './customer-above-limit-data-resolver.component';
@@ -31,11 +31,17 @@ describe('CustomerAboveLimitDataResolver', () => {
     });
 
     it('resolve', () => {
-        const mockResponse: CustomerAboveLimitItem[] = [];
+        const mockResponse: CustomerAboveLimitResponse = {
+            items: [],
+            totalCount: 0,
+            currentPage: 1,
+            totalPages: 0,
+            pageSize: 25
+        };
         apiService.getCustomersAboveLimit.mockReturnValue(of(mockResponse));
 
         const activatedRoute = <ActivatedRouteSnapshot><unknown>{};
-        resolver.resolve(activatedRoute).subscribe((response: CustomerAboveLimitItem[]) => {
+        resolver.resolve(activatedRoute).subscribe((response: CustomerAboveLimitResponse) => {
             expect(response).toEqual(mockResponse);
         });
 

--- a/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.ts
@@ -1,0 +1,14 @@
+import {inject, Service} from '@angular/core';
+import {ActivatedRouteSnapshot} from '@angular/router';
+import {CustomerAboveLimitItem, CustomerApiService} from '../../../api/customer-api.service';
+import {Observable} from 'rxjs';
+
+@Service()
+export class CustomerAboveLimitDataResolver {
+  private readonly customerApiService = inject(CustomerApiService);
+
+  public resolve(_route: ActivatedRouteSnapshot): Observable<CustomerAboveLimitItem[]> {
+    return this.customerApiService.getCustomersAboveLimit();
+  }
+
+}

--- a/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/resolver/customer-above-limit-data-resolver.component.ts
@@ -1,13 +1,13 @@
 import {inject, Service} from '@angular/core';
 import {ActivatedRouteSnapshot} from '@angular/router';
-import {CustomerAboveLimitItem, CustomerApiService} from '../../../api/customer-api.service';
+import {CustomerAboveLimitResponse, CustomerApiService} from '../../../api/customer-api.service';
 import {Observable} from 'rxjs';
 
 @Service()
 export class CustomerAboveLimitDataResolver {
   private readonly customerApiService = inject(CustomerApiService);
 
-  public resolve(_route: ActivatedRouteSnapshot): Observable<CustomerAboveLimitItem[]> {
+  public resolve(_route: ActivatedRouteSnapshot): Observable<CustomerAboveLimitResponse> {
     return this.customerApiService.getCustomersAboveLimit();
   }
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -13,10 +13,7 @@
 
     @if ((customerAboveLimitData()?.items?.length ?? 0) > 0) {
       <div class="mt-4">
-        <mat-paginator class="hidden sm:block" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
-                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
-        <mat-paginator class="block sm:hidden tafel-paginator-center" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+        <mat-paginator [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
                        [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                        (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
       </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -13,7 +13,7 @@
 
     @if ((customerAboveLimitData()?.items?.length ?? 0) > 0) {
       <div class="mt-4">
-        <mat-paginator [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+        <mat-paginator class="tafel-paginator-responsive" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
                        [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                        (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
       </div>
@@ -78,7 +78,7 @@
           <tr mat-row *matRowDef="let row; let i = index; columns: displayedColumns;" testid="abovelimit-row"></tr>
         </table>
 
-        <mat-paginator class="mt-4" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+        <mat-paginator class="tafel-paginator-responsive mt-4" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
                        [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                        (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
       </div>
@@ -110,8 +110,8 @@
             </mat-card>
           }
         </div>
-        <div class="mt-2 tafel-paginator-center">
-          <mat-paginator [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+        <div class="mt-2">
+          <mat-paginator class="tafel-paginator-responsive" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
                          [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                          (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
         </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -2,8 +2,7 @@
   <mat-card-header class="text-xl font-bold">Kunden über dem Limit</mat-card-header>
   <mat-card-content>
     <div class="mb-4">
-      Kunden, deren Einkommen sich derzeit über dem aktuell gültigen Limit befindet (z.B. weil sich das Limit seit
-      der Anlage/Verlängerung geändert hat).
+      Kunden, deren Einkommen sich derzeit über dem aktuell gültigen Limit befindet.
     </div>
 
     <hr/>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -1,0 +1,105 @@
+<mat-card>
+  <mat-card-header class="text-xl font-bold">Kunden über dem Limit</mat-card-header>
+  <mat-card-content>
+    <div class="mb-4">
+      Kunden, deren Einkommen sich derzeit über dem aktuell gültigen Limit befindet (z.B. weil sich das Limit seit
+      der Anlage/Verlängerung geändert hat).
+    </div>
+
+    <hr/>
+
+    @if (customerAboveLimitData().length === 0) {
+      <h4 class="font-bold mt-4">Keine Kunden über dem Limit gefunden!</h4>
+    }
+
+    @if (customerAboveLimitData().length > 0) {
+      <div class="hidden md:block mt-4">
+        <table mat-table [dataSource]="customerAboveLimitData()" class="min-w-full divide-y divide-gray-200"
+               aria-label="Liste der Kunden über dem Limit">
+          <ng-container matColumnDef="icon">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let item"><fa-icon [icon]="faUser"></fa-icon></td>
+          </ng-container>
+
+          <ng-container matColumnDef="id">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Nr.</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-id-' + i" class="px-4 py-2">{{item.customer.id}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Name</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-name-' + i" class="px-4 py-2">
+              {{item.customer.lastname}} {{item.customer.firstname}}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="address">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Adresse</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-address-' + i" class="px-4 py-2">{{item.customer.address | formatCustomerAddress}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="validUntil">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Gültig bis</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-validUntil-' + i" class="px-4 py-2">{{!item.customer.validUntil ? '-' : item.customer.validUntil | date : 'dd.MM.yyyy'}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="totalSum">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Einkommen gesamt</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-totalSum-' + i" class="px-4 py-2">{{item.totalSum | number : '1.2-2'}}&nbsp;&euro;</td>
+          </ng-container>
+
+          <ng-container matColumnDef="limit">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Limit</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-limit-' + i" class="px-4 py-2">{{item.limit | number : '1.2-2'}}&nbsp;&euro;</td>
+          </ng-container>
+
+          <ng-container matColumnDef="amountExceededLimit">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Über Limit</th>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-amountExceededLimit-' + i" class="px-4 py-2 text-white bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Aktionen</th>
+            <td mat-cell *matCellDef="let item; let i = index" class="px-4 py-2">
+              <button type="button" matButton="filled" class="button-info" [attr.testid]="'abovelimit-showcustomer-button-' + i" (click)="showCustomerDetail(item.customer.id!)">
+                <fa-icon [icon]="faSearch"></fa-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; let i = index; columns: displayedColumns;" testid="abovelimit-row"></tr>
+        </table>
+      </div>
+
+      <div class="block md:hidden mt-4">
+        <div class="flex flex-col gap-4">
+          @for (item of customerAboveLimitData(); track trackByCustomerId($index, item); let i = $index) {
+            <mat-card>
+              <mat-card-header class="font-semibold">{{item.customer.id}} - {{item.customer.lastname}} {{item.customer.firstname}}</mat-card-header>
+              <mat-card-content>
+                <div class="grid grid-cols-2 gap-2">
+                  <div class="font-bold">Adresse:</div>
+                  <div>{{item.customer.address | formatCustomerAddress}}</div>
+                  <div class="font-bold">Gültig bis:</div>
+                  <div>{{!item.customer.validUntil ? '-' : item.customer.validUntil | date : 'dd.MM.yyyy'}}</div>
+                  <div class="font-bold">Einkommen gesamt:</div>
+                  <div>{{item.totalSum | number : '1.2-2'}}&nbsp;&euro;</div>
+                  <div class="font-bold">Limit:</div>
+                  <div>{{item.limit | number : '1.2-2'}}&nbsp;&euro;</div>
+                  <div class="font-bold text-white px-2 bg-red-600">Über Limit:</div>
+                  <div class="text-white px-2 bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</div>
+                </div>
+              </mat-card-content>
+              <mat-card-actions class="flex gap-2 mt-2">
+                <button type="button" matButton="filled" class="button-info" [attr.testid]="'abovelimit-showcustomer-button-' + i" (click)="showCustomerDetail(item.customer.id!)">
+                  <fa-icon [icon]="faSearch"></fa-icon>
+                </button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        </div>
+      </div>
+    }
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -7,13 +7,22 @@
 
     <hr/>
 
-    @if (customerAboveLimitData().length === 0) {
+    @if ((customerAboveLimitData()?.items?.length ?? 0) === 0) {
       <h4 class="font-bold mt-4">Keine Kunden über dem Limit gefunden!</h4>
     }
 
-    @if (customerAboveLimitData().length > 0) {
+    @if ((customerAboveLimitData()?.items?.length ?? 0) > 0) {
+      <div class="mt-4">
+        <mat-paginator class="hidden sm:block" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
+                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
+        <mat-paginator class="block sm:hidden tafel-paginator-center" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
+                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
+      </div>
+
       <div class="hidden md:block mt-4">
-        <table mat-table [dataSource]="customerAboveLimitData()" class="min-w-full divide-y divide-gray-200"
+        <table mat-table [dataSource]="customerAboveLimitData()!.items" class="min-w-full divide-y divide-gray-200"
                aria-label="Liste der Kunden über dem Limit">
           <ng-container matColumnDef="icon">
             <th mat-header-cell *matHeaderCellDef></th>
@@ -54,7 +63,9 @@
 
           <ng-container matColumnDef="amountExceededLimit">
             <th mat-header-cell *matHeaderCellDef class="px-6 py-2 text-left">Über Limit</th>
-            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-amountExceededLimit-' + i" class="px-4 py-2 text-white bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</td>
+            <td mat-cell *matCellDef="let item; let i = index" [attr.testid]="'abovelimit-amountExceededLimit-' + i" class="px-4 py-2">
+              <span class="px-2 py-1 rounded text-white bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</span>
+            </td>
           </ng-container>
 
           <ng-container matColumnDef="actions">
@@ -69,11 +80,15 @@
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
           <tr mat-row *matRowDef="let row; let i = index; columns: displayedColumns;" testid="abovelimit-row"></tr>
         </table>
+
+        <mat-paginator class="mt-4" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
+                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
       </div>
 
       <div class="block md:hidden mt-4">
-        <div class="flex flex-col gap-4">
-          @for (item of customerAboveLimitData(); track trackByCustomerId($index, item); let i = $index) {
+        <div class="flex flex-col gap-4 mb-4">
+          @for (item of customerAboveLimitData()!.items; track trackByCustomerId($index, item); let i = $index) {
             <mat-card>
               <mat-card-header class="font-semibold">{{item.customer.id}} - {{item.customer.lastname}} {{item.customer.firstname}}</mat-card-header>
               <mat-card-content>
@@ -86,8 +101,8 @@
                   <div>{{item.totalSum | number : '1.2-2'}}&nbsp;&euro;</div>
                   <div class="font-bold">Limit:</div>
                   <div>{{item.limit | number : '1.2-2'}}&nbsp;&euro;</div>
-                  <div class="font-bold text-white px-2 bg-red-600">Über Limit:</div>
-                  <div class="text-white px-2 bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</div>
+                  <div class="font-bold">Über Limit:</div>
+                  <div><span class="px-2 py-1 rounded text-white bg-red-600">{{item.amountExceededLimit | number : '1.2-2'}}&nbsp;&euro;</span></div>
                 </div>
               </mat-card-content>
               <mat-card-actions class="flex gap-2 mt-2">
@@ -97,6 +112,11 @@
               </mat-card-actions>
             </mat-card>
           }
+        </div>
+        <div class="mt-2 tafel-paginator-center">
+          <mat-paginator [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
+                         [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
+                         (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
         </div>
       </div>
     }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
@@ -1,0 +1,79 @@
+import {TestBed} from '@angular/core/testing';
+import {CustomerAboveLimitItem, Gender} from '../../../../api/customer-api.service';
+import {CustomerAboveLimitComponent} from './customer-above-limit.component';
+import {Router} from '@angular/router';
+import type {MockedObject} from 'vitest';
+
+describe('CustomerAboveLimitComponent', () => {
+  let router: MockedObject<Router>;
+
+  const mockItem: CustomerAboveLimitItem = {
+    customer: {
+      id: 133,
+      lastname: 'Mustermann',
+      firstname: 'Max',
+      gender: Gender.MALE,
+      address: {
+        street: 'Teststraße',
+        houseNumber: '123A',
+        door: '21',
+        postalCode: 1020,
+        city: 'Wien',
+      },
+    },
+    totalSum: 1500,
+    limit: 1000,
+    amountExceededLimit: 500
+  };
+
+  beforeEach(() => {
+    const routerSpy = {
+      navigate: vi.fn().mockName('Router.navigate')
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: routerSpy
+        }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router) as MockedObject<Router>;
+  });
+
+  it('component can be created', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+
+    expect(component).toBeTruthy();
+  });
+
+  it('input fills data correctly', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+    fixture.componentRef.setInput('customerAboveLimitData', [mockItem]);
+    fixture.detectChanges();
+
+    expect(component.customerAboveLimitData()).toEqual([mockItem]);
+  });
+
+  it('show customer detail calls router navigation', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+
+    const customerId = 123;
+    component.showCustomerDetail(customerId);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/kunden/detail', customerId]);
+  });
+
+  it('trackByCustomerId returns the customer id', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.trackByCustomerId(0, mockItem)).toEqual(mockItem.customer.id);
+  });
+
+});

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
@@ -1,10 +1,12 @@
 import {TestBed} from '@angular/core/testing';
-import {CustomerAboveLimitItem, Gender} from '../../../../api/customer-api.service';
+import {CustomerAboveLimitItem, CustomerAboveLimitResponse, CustomerApiService, Gender} from '../../../../api/customer-api.service';
 import {CustomerAboveLimitComponent} from './customer-above-limit.component';
 import {Router} from '@angular/router';
+import {of} from 'rxjs';
 import type {MockedObject} from 'vitest';
 
 describe('CustomerAboveLimitComponent', () => {
+  let customerApiService: MockedObject<CustomerApiService>;
   let router: MockedObject<Router>;
 
   const mockItem: CustomerAboveLimitItem = {
@@ -26,7 +28,18 @@ describe('CustomerAboveLimitComponent', () => {
     amountExceededLimit: 500
   };
 
+  const mockCustomerAboveLimitResponse: CustomerAboveLimitResponse = {
+    items: [mockItem],
+    totalCount: 100,
+    currentPage: 3,
+    totalPages: 10,
+    pageSize: 25
+  };
+
   beforeEach(() => {
+    const customerApiServiceSpy = {
+      getCustomersAboveLimit: vi.fn().mockName('CustomerApiService.getCustomersAboveLimit')
+    } as any;
     const routerSpy = {
       navigate: vi.fn().mockName('Router.navigate')
     } as any;
@@ -34,12 +47,17 @@ describe('CustomerAboveLimitComponent', () => {
     TestBed.configureTestingModule({
       providers: [
         {
+          provide: CustomerApiService,
+          useValue: customerApiServiceSpy
+        },
+        {
           provide: Router,
           useValue: routerSpy
         }
       ]
     }).compileComponents();
 
+    customerApiService = TestBed.inject(CustomerApiService) as MockedObject<CustomerApiService>;
     router = TestBed.inject(Router) as MockedObject<Router>;
   });
 
@@ -53,10 +71,40 @@ describe('CustomerAboveLimitComponent', () => {
   it('input fills data correctly', () => {
     const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
     const component = fixture.componentInstance;
-    fixture.componentRef.setInput('customerAboveLimitData', [mockItem]);
+    fixture.componentRef.setInput('customerAboveLimitData', mockCustomerAboveLimitResponse);
     fixture.detectChanges();
 
-    expect(component.customerAboveLimitData()).toEqual([mockItem]);
+    expect(component.customerAboveLimitData()).toEqual(mockCustomerAboveLimitResponse);
+  });
+
+  it('get above limit with page', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+
+    const page = 5;
+    customerApiService.getCustomersAboveLimit.mockReturnValue(of(mockCustomerAboveLimitResponse));
+
+    component.getAboveLimit(page);
+
+    expect(customerApiService.getCustomersAboveLimit).toHaveBeenCalledWith(page);
+    expect(component.customerAboveLimitData()).toEqual(mockCustomerAboveLimitResponse);
+  });
+
+  it('get above limit with no results sets data to undefined', () => {
+    const fixture = TestBed.createComponent(CustomerAboveLimitComponent);
+    const component = fixture.componentInstance;
+
+    customerApiService.getCustomersAboveLimit.mockReturnValue(of({
+      items: [],
+      totalCount: 0,
+      currentPage: 1,
+      totalPages: 0,
+      pageSize: 25
+    }));
+
+    component.getAboveLimit(1);
+
+    expect(component.customerAboveLimitData()).toBeUndefined();
   });
 
   it('show customer detail calls router navigation', () => {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
@@ -1,0 +1,43 @@
+import {Component, inject, input} from '@angular/core';
+import {Router} from '@angular/router';
+import {CustomerAboveLimitItem} from '../../../../api/customer-api.service';
+import {MatCardModule} from '@angular/material/card';
+import {MatButtonModule} from '@angular/material/button';
+import {MatTableModule} from '@angular/material/table';
+import {CommonModule} from '@angular/common';
+import {faSearch, faUser} from '@fortawesome/free-solid-svg-icons';
+import {FaIconComponent} from '@fortawesome/angular-fontawesome';
+import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
+
+@Component({
+  selector: 'tafel-customer-above-limit',
+  templateUrl: 'customer-above-limit.component.html',
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatTableModule,
+    CommonModule,
+    FaIconComponent,
+    FormatCustomerAddressPipe
+  ]
+})
+export class CustomerAboveLimitComponent {
+  // Signal input from resolver - name matches the route's resolve key exactly (see customer.routes.ts)
+  readonly customerAboveLimitData = input<CustomerAboveLimitItem[]>([]);
+
+  private readonly router = inject(Router);
+
+  showCustomerDetail(customerId: number) {
+    this.router.navigate(['/kunden/detail', customerId]);
+  }
+
+  trackByCustomerId(index: number, item: CustomerAboveLimitItem): number {
+    return item.customer.id!;
+  }
+
+  // columns for mat-table
+  displayedColumns = ['icon', 'id', 'name', 'address', 'validUntil', 'totalSum', 'limit', 'amountExceededLimit', 'actions'];
+
+  protected readonly faUser = faUser;
+  protected readonly faSearch = faSearch;
+}

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
@@ -1,9 +1,10 @@
-import {Component, inject, input} from '@angular/core';
+import {Component, inject, input, linkedSignal} from '@angular/core';
 import {Router} from '@angular/router';
-import {CustomerAboveLimitItem} from '../../../../api/customer-api.service';
+import {CustomerAboveLimitItem, CustomerAboveLimitResponse, CustomerApiService} from '../../../../api/customer-api.service';
 import {MatCardModule} from '@angular/material/card';
 import {MatButtonModule} from '@angular/material/button';
 import {MatTableModule} from '@angular/material/table';
+import {MatPaginatorModule} from '@angular/material/paginator';
 import {CommonModule} from '@angular/common';
 import {faSearch, faUser} from '@fortawesome/free-solid-svg-icons';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
@@ -16,16 +17,30 @@ import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-custome
     MatCardModule,
     MatButtonModule,
     MatTableModule,
+    MatPaginatorModule,
     CommonModule,
     FaIconComponent,
     FormatCustomerAddressPipe
   ]
 })
 export class CustomerAboveLimitComponent {
-  // Signal input from resolver - name matches the route's resolve key exactly (see customer.routes.ts)
-  readonly customerAboveLimitData = input<CustomerAboveLimitItem[]>([]);
+  // Input signal - aliased to match the route resolver data key (see customer.routes.ts) since the
+  // unaliased name below is already used for the locally-writable linkedSignal counterpart
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  readonly customerAboveLimitDataInput = input<CustomerAboveLimitResponse>(undefined, {alias: 'customerAboveLimitData'});
 
+  // Writable signal linked to input - resets when input changes, locally writable for pagination
+  readonly customerAboveLimitData = linkedSignal(() => this.customerAboveLimitDataInput());
+
+  private readonly customerApiService = inject(CustomerApiService);
   private readonly router = inject(Router);
+
+  getAboveLimit(page?: number) {
+    this.customerApiService.getCustomersAboveLimit(page)
+      .subscribe((response: CustomerAboveLimitResponse) => {
+        this.customerAboveLimitData.set(response.items.length === 0 ? undefined : response);
+      });
+  }
 
   showCustomerDetail(customerId: number) {
     this.router.navigate(['/kunden/detail', customerId]);

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
@@ -35,10 +35,7 @@
 
     @if ((customerDuplicatesData()?.items?.length ?? 0) > 0) {
     <div>
-      <mat-paginator class="hidden sm:block" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
-                     [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                     (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
-      <mat-paginator class="block sm:hidden tafel-paginator-center" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
+      <mat-paginator class="tafel-paginator-responsive" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
                      [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                      (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
 
@@ -133,10 +130,7 @@
         }
       </div>
 
-      <mat-paginator class="hidden sm:block mt-4" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
-                     [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                     (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
-      <mat-paginator class="block sm:hidden mt-4 tafel-paginator-center" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
+      <mat-paginator class="tafel-paginator-responsive mt-4" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
                      [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                      (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
     </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.spec.ts
@@ -134,7 +134,7 @@ describe('CustomerDuplicatesComponent', () => {
   it('init fills data correctly', () => {
     const fixture = TestBed.createComponent(CustomerDuplicatesComponent);
     const component = fixture.componentInstance;
-    fixture.componentRef.setInput('customerDuplicatesDataInput', mockCustomerDuplicatesDataResponse);
+    fixture.componentRef.setInput('customerDuplicatesData', mockCustomerDuplicatesDataResponse);
     fixture.detectChanges();
 
     expect(component.customerDuplicatesData()).toEqual(mockCustomerDuplicatesDataResponse);

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
@@ -25,8 +25,10 @@ import {TafelToastrService} from '../../../../common/components/tafel-toastr/taf
   ]
 })
 export class CustomerDuplicatesComponent {
-  // Signal input from resolver - read-only input
-  readonly customerDuplicatesDataInput = input<CustomerDuplicatesResponse>();
+  // Input signal - aliased to match the route resolver data key (see customer.routes.ts) since the
+  // unaliased name below is already used for the locally-writable linkedSignal counterpart
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  readonly customerDuplicatesDataInput = input<CustomerDuplicatesResponse>(undefined, {alias: 'customerDuplicatesData'});
 
   // Writable signal linked to input - resets when input changes, locally writable for pagination/updates
   readonly customerDuplicatesData = linkedSignal(() => this.customerDuplicatesDataInput());

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
@@ -57,7 +57,7 @@
         <div class="mt-6" testid="searchresult-table">
           <div class="mb-6">
             <h5 class="mb-6">Suchergebnis ({{searchResult()!.totalCount}} Kunden)</h5>
-            <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+            <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                            [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                            (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
           </div>
@@ -131,7 +131,7 @@
             </table>
 
             <div class="mt-6">
-              <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+              <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                              [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                              (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
             </div>
@@ -165,8 +165,8 @@
                 </mat-card>
               }
             </div>
-            <div class="mt-2 tafel-paginator-center">
-              <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+            <div class="mt-2">
+              <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                              [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                              (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
             </div>

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
@@ -62,7 +62,7 @@
         <div class="mt-6">
           <div class="mb-6">
             <h5 class="mb-6">Suchergebnis ({{this.searchResult()?.totalCount}} gefunden)</h5>
-            <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+            <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                            [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                            (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
           </div>
@@ -120,13 +120,13 @@
             </table>
 
             <div class="mt-6">
-              <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+              <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                              [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                              (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
             </div>
           </div>
 
-          <div class="block sm:hidden">
+          <div class="block md:hidden">
             <div class="flex flex-col gap-4 mb-4">
               @for (user of this.searchResult()?.items; track user.id; let i = $index) {
                 <mat-card class="shadow-sm">
@@ -150,8 +150,8 @@
                 </mat-card>
               }
             </div>
-            <div class="mt-2 tafel-paginator-center">
-              <mat-paginator [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
+            <div class="mt-2">
+              <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
                              [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                              (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
             </div>

--- a/frontend/src/main/webapp/src/scss/components/mat-paginator.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-paginator.scss
@@ -2,3 +2,15 @@
 .tafel-paginator-center .mat-mdc-paginator-container {
   justify-content: center;
 }
+
+// same right-aligned default, but centers below the md breakpoint (matches the desktop-table /
+// mobile-card layout switch used across the search & list views) instead of always centering
+.tafel-paginator-responsive .mat-mdc-paginator-container {
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .tafel-paginator-responsive .mat-mdc-paginator-container {
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- Households validated at creation/renewal can later exceed the income limit if the limit itself changes (`StaticValueType.INCOME_LIMIT`), and there was no way to surface these to staff.
- Adds a `CUSTOMERS_ABOVE_LIMIT` permission (`Kunden über dem Limit`).
- Adds `GET /api/households/above-limit`, backed by `HouseholdService.getHouseholdsAboveLimit()`, which re-validates every currently-valid household against `IncomeValidatorService` and returns those that now exceed the limit, along with `totalSum`/`limit`/`amountExceededLimit`.
- Adds a new "Kunden über Limit" frontend view (desktop table + mobile card layout, consistent with the existing customer-search/duplicates views) and nav entry, gated by the new permission.

## Test plan
- [x] `HouseholdServiceTest`/`HouseholdControllerTest` updated and passing
- [x] Full backend test suite passing (`./gradlew :backend:test`)
- [x] New frontend unit tests for the API method, resolver, and component
- [x] Full frontend test suite passing (`ng test --watch=false`, 519 tests)
- [x] `ng build` and `ng lint` clean