### PR TITLE
Replace archived delete-old-workflow-runs action

### DIFF
--- a/.github/workflows/cleanup_workflows.yml
+++ b/.github/workflows/cleanup_workflows.yml
@@ -9,13 +9,22 @@ jobs:
   delete-workflow-runs:
     runs-on: ubuntu-latest
     name: Delete old workflow runs
+    permissions:
+      actions: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Delete workflow runs (keep last 2 weeks)
-        uses: MajorScruffy/delete-old-workflow-runs@78b5af714fefaefdf74862181c467b061782719e # v0.3.0
-        with:
-          repository: wrk-tafel/admin
-          older-than-seconds: 1209600
+      # MajorScruffy/delete-old-workflow-runs is archived/unmaintained (still declares a node12
+      # runtime), so this is inlined via gh api instead of depending on it.
+      - name: Delete workflow runs older than 2 weeks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: wrk-tafel/admin
+        run: |
+          cutoff=$(date -d '14 days ago' +%s)
+          gh api "repos/${REPO}/actions/runs" --paginate --jq '.workflow_runs[] | [.id, .created_at] | @tsv' |
+            while IFS=$'\t' read -r id created_at; do
+              created_ts=$(date -d "$created_at" +%s)
+              if [ "$created_ts" -lt "$cutoff" ]; then
+                echo "Deleting run $id (created $created_at)"
+                gh api -X DELETE "repos/${REPO}/actions/runs/${id}" || true
+              fi
+            done


### PR DESCRIPTION
## Summary
- `MajorScruffy/delete-old-workflow-runs` (used in `cleanup_workflows.yml`) is **archived** (last pushed Jan 2024) and its `action.yml` still declares a `node12` runtime — there is no newer release to pin to, which is why GitHub Actions has to force it onto Node 24 and prints the deprecation warning.
- Replaces it with a small inline script using `gh api` to list and delete workflow runs older than 2 weeks, matching the original behavior (`older-than-seconds: 1209600`) without depending on an unmaintained action.
- Adds an explicit `permissions: actions: write` block, since deleting workflow runs requires that scope.

## Test plan
- [x] YAML validated (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger via `workflow_dispatch` after merge to confirm it deletes old runs as expected (can't run GitHub Actions from here)