### PR TITLE
Fix N+1 queries behind slow customers-above-limit endpoint, add navigation loading bar

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/CacheConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/CacheConfig.kt
@@ -1,0 +1,23 @@
+package at.wrk.tafel.admin.backend.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Static values (income limits, tolerance, family bonus, ...) are only ever changed via a DB
+ * migration shipped with a new deployment, never at runtime - so caching them for the lifetime of
+ * the process is safe and needs no eviction.
+ */
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        return ConcurrentMapCacheManager()
+    }
+
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdRepository.kt
@@ -1,5 +1,7 @@
 package at.wrk.tafel.admin.backend.database.model.household
 
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
@@ -10,6 +12,13 @@ interface HouseholdRepository : JpaRepository<HouseholdEntity, Long>, JpaSpecifi
 
     @Query("SELECT nextval('household_id_sequence')", nativeQuery = true)
     fun getNextHouseholdSequenceValue(): Long
+
+    // overrides the inherited findAll(Specification) with an eager fetch of persons - without this,
+    // HouseholdConverter.mapEntityToHousehold() accessing the lazy persons collection triggers one
+    // extra query per household (only used by getHouseholdsAboveLimit(), which loads every valid
+    // household up front rather than a paginated slice, so the N+1 cost is otherwise unbounded)
+    @EntityGraph(attributePaths = ["persons"])
+    override fun findAll(spec: Specification<HouseholdEntity>): List<HouseholdEntity>
 
     fun existsByHouseholdId(id: Long): Boolean
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/staticdata/StaticValueRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/staticdata/StaticValueRepository.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.database.model.staticdata
 
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -7,6 +8,11 @@ import java.time.LocalDate
 
 interface StaticValueRepository : JpaRepository<StaticValueEntity, Long> {
 
+    // static values only ever change via a DB migration shipped with a new deployment, never at
+    // runtime, so caching for the process lifetime (see CacheConfig) is safe and needs no eviction -
+    // each method gets its own cache name since the default key generator only considers arguments,
+    // not the method itself, and findSingleValueOfType/findValuesOfType share the same argument shape
+    @Cacheable("staticValueLatestForPersonCount")
     @Query("select il from StaticValue il where il.type = :type and il.countAdults = :countAdults and il.countChildren = :countChildren and :currentDate between il.validFrom and il.validTo")
     fun findLatestForPersonCount(
         @Param("type") type: StaticValueType? = StaticValueType.INCOME_LIMIT,
@@ -15,12 +21,14 @@ interface StaticValueRepository : JpaRepository<StaticValueEntity, Long> {
         @Param("countChildren") countChildren: Int? = 0,
     ): StaticValueEntity?
 
+    @Cacheable("staticValueSingle")
     @Query("select il from StaticValue il where il.type = :type and :currentDate between il.validFrom and il.validTo")
     fun findSingleValueOfType(
         @Param("type") type: StaticValueType,
         @Param("currentDate") currentDate: LocalDate,
     ): StaticValueEntity?
 
+    @Cacheable("staticValueList")
     @Query("select il from StaticValue il where il.type = :type and :currentDate between il.validFrom and il.validTo")
     fun findValuesOfType(
         @Param("type") type: StaticValueType,

--- a/frontend/src/main/webapp/cypress/e2e/general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/general.cy.ts
@@ -33,3 +33,34 @@ describe('General', () => {
   });
 
 });
+
+describe('Navigation Progress Bar', () => {
+
+  it('shows a top-level loading bar while a resolver-gated page is loading, and hides it once loaded', () => {
+    cy.loginDefault();
+    cy.visit('/#/uebersicht');
+
+    // navigate once first so the app is fully settled before triggering the navigation under test
+    cy.contains('Kunden suchen').click();
+    cy.url().should('include', '/kunden/suchen');
+
+    // Route resolvers (e.g. the above-limit list's data fetch) block navigation before the target
+    // component even mounts, so delay the response to give the bar time to actually be observed.
+    cy.intercept('GET', '/api/households/above-limit*', (req) => {
+      req.on('response', (res) => {
+        res.setDelay(2000);
+      });
+    }).as('aboveLimit');
+
+    cy.byTestId('nav-progress-bar').should('not.exist');
+    cy.contains('Kunden über Limit').click();
+
+    cy.byTestId('nav-progress-bar').should('be.visible');
+
+    cy.wait('@aboveLimit');
+
+    cy.byTestId('nav-progress-bar').should('not.exist');
+    cy.url().should('include', '/kunden/ueber-limit');
+  });
+
+});

--- a/frontend/src/main/webapp/src/app/app.component.html
+++ b/frontend/src/main/webapp/src/app/app.component.html
@@ -1,5 +1,5 @@
 @if (navigating()) {
-  <mat-progress-bar mode="indeterminate" class="fixed top-0 left-0 right-0 z-50"></mat-progress-bar>
+  <mat-progress-bar testid="nav-progress-bar" mode="indeterminate" class="fixed top-0 left-0 right-0 z-50"></mat-progress-bar>
 }
 <router-outlet></router-outlet>
 <div toastContainer aria-live="polite"></div>

--- a/frontend/src/main/webapp/src/app/app.component.html
+++ b/frontend/src/main/webapp/src/app/app.component.html
@@ -1,2 +1,5 @@
+@if (navigating()) {
+  <mat-progress-bar mode="indeterminate" class="fixed top-0 left-0 right-0 z-50"></mat-progress-bar>
+}
 <router-outlet></router-outlet>
 <div toastContainer aria-live="polite"></div>

--- a/frontend/src/main/webapp/src/app/app.component.html
+++ b/frontend/src/main/webapp/src/app/app.component.html
@@ -1,5 +1,5 @@
 @if (navigating()) {
-  <mat-progress-bar testid="nav-progress-bar" mode="indeterminate" class="fixed top-0 left-0 right-0 z-50"></mat-progress-bar>
+  <mat-progress-bar testid="nav-progress-bar" mode="indeterminate" class="fixed! top-0! left-0! right-0! z-50"></mat-progress-bar>
 }
 <router-outlet></router-outlet>
 <div toastContainer aria-live="polite"></div>

--- a/frontend/src/main/webapp/src/app/app.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ describe('AppComponent', () => {
   let routerEventsSubject: Subject<any>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     routerEventsSubject = new Subject();
 
     TestBed.configureTestingModule({
@@ -21,13 +22,17 @@ describe('AppComponent', () => {
     }).compileComponents();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('sets navigating to true on NavigationStart', () => {
+  it('does not show the bar before the show-delay has elapsed', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.componentInstance;
@@ -35,7 +40,33 @@ describe('AppComponent', () => {
     routerEventsSubject.next(new NavigationStart(1, '/test'));
     fixture.detectChanges();
 
+    expect(app.navigating()).toBe(false);
+  });
+
+  it('sets navigating to true once the show-delay elapses for a still in-flight navigation', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    vi.advanceTimersByTime(500);
+    fixture.detectChanges();
+
     expect(app.navigating()).toBe(true);
+  });
+
+  it('never shows the bar for a navigation that settles before the show-delay elapses', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    routerEventsSubject.next(new NavigationEnd(1, '/test', '/test'));
+    fixture.detectChanges();
+    vi.advanceTimersByTime(500);
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(false);
   });
 
   it('sets navigating to false on NavigationEnd', () => {
@@ -44,6 +75,7 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
 
     routerEventsSubject.next(new NavigationStart(1, '/test'));
+    vi.advanceTimersByTime(500);
     fixture.detectChanges();
     routerEventsSubject.next(new NavigationEnd(1, '/test', '/test'));
     fixture.detectChanges();
@@ -57,6 +89,7 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
 
     routerEventsSubject.next(new NavigationStart(1, '/test'));
+    vi.advanceTimersByTime(500);
     fixture.detectChanges();
     routerEventsSubject.next(new NavigationCancel(1, '/test', 'test'));
     fixture.detectChanges();
@@ -70,6 +103,7 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
 
     routerEventsSubject.next(new NavigationStart(1, '/test'));
+    vi.advanceTimersByTime(500);
     fixture.detectChanges();
     routerEventsSubject.next(new NavigationError(1, '/test', new Error('test')));
     fixture.detectChanges();
@@ -85,6 +119,7 @@ describe('AppComponent', () => {
     // navigation 1 starts, then navigation 2 starts and supersedes it before 1 settles
     routerEventsSubject.next(new NavigationStart(1, '/test'));
     routerEventsSubject.next(new NavigationStart(2, '/test-2'));
+    vi.advanceTimersByTime(500);
     fixture.detectChanges();
 
     // a late/stale End for the superseded navigation 1 must not clear the bar for navigation 2

--- a/frontend/src/main/webapp/src/app/app.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/app.component.spec.ts
@@ -1,16 +1,93 @@
 import {TestBed} from '@angular/core/testing';
 import {AppComponent} from './app.component';
+import {NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router} from '@angular/router';
+import {Subject} from 'rxjs';
 
 describe('AppComponent', () => {
+  let routerEventsSubject: Subject<any>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({}).compileComponents();
+    routerEventsSubject = new Subject();
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            events: routerEventsSubject.asObservable()
+          }
+        }
+      ]
+    }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('sets navigating to true on NavigationStart', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(true);
+  });
+
+  it('sets navigating to false on NavigationEnd', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    fixture.detectChanges();
+    routerEventsSubject.next(new NavigationEnd(1, '/test', '/test'));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(false);
+  });
+
+  it('sets navigating to false on NavigationCancel', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    fixture.detectChanges();
+    routerEventsSubject.next(new NavigationCancel(1, '/test', 'test'));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(false);
+  });
+
+  it('sets navigating to false on NavigationError', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    fixture.detectChanges();
+    routerEventsSubject.next(new NavigationError(1, '/test', new Error('test')));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(false);
+  });
+
+  it('scrolls to top on NavigationEnd', () => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
+    });
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    routerEventsSubject.next(new NavigationEnd(1, '/test', '/test'));
+    fixture.detectChanges();
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
   });
 
 });

--- a/frontend/src/main/webapp/src/app/app.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/app.component.spec.ts
@@ -77,6 +77,28 @@ describe('AppComponent', () => {
     expect(app.navigating()).toBe(false);
   });
 
+  it('ignores a stale End event from a navigation already superseded by a newer one', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const app = fixture.componentInstance;
+
+    // navigation 1 starts, then navigation 2 starts and supersedes it before 1 settles
+    routerEventsSubject.next(new NavigationStart(1, '/test'));
+    routerEventsSubject.next(new NavigationStart(2, '/test-2'));
+    fixture.detectChanges();
+
+    // a late/stale End for the superseded navigation 1 must not clear the bar for navigation 2
+    routerEventsSubject.next(new NavigationEnd(1, '/test', '/test'));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(true);
+
+    routerEventsSubject.next(new NavigationEnd(2, '/test-2', '/test-2'));
+    fixture.detectChanges();
+
+    expect(app.navigating()).toBe(false);
+  });
+
   it('scrolls to top on NavigationEnd', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {
     });

--- a/frontend/src/main/webapp/src/app/app.component.ts
+++ b/frontend/src/main/webapp/src/app/app.component.ts
@@ -1,8 +1,7 @@
-import {Component, effect, inject, signal} from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router, RouterOutlet} from '@angular/router';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
-
-import {toSignal} from '@angular/core/rxjs-interop';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -17,20 +16,32 @@ import {toSignal} from '@angular/core/rxjs-interop';
 export class AppComponent {
   private readonly router = inject(Router);
 
-  private readonly routerEvents = toSignal(this.router.events);
-
   // Route resolvers (e.g. list-page data fetches) block navigation before the target component
   // even mounts, so a component-level spinner can't cover that window - this shows a top-level
   // bar for the whole navigation instead, from NavigationStart until it settles either way.
+  //
+  // Subscribes directly to router.events rather than going through toSignal()/effect(): a single
+  // navigation fires many events synchronously in quick succession (NavigationStart,
+  // RouteConfigLoadStart, ResolveStart, ...), and toSignal() only guarantees the latest value to
+  // its consumers - effect() can and does miss an intermediate event (verified: NavigationStart
+  // was silently dropped this way when a slow resolver was involved), where a plain subscription
+  // processes every emission.
   readonly navigating = signal(false);
 
+  // Tracks which navigation the bar is currently shown for, so an End/Cancel/Error belonging to
+  // an unrelated, already-superseded navigation can't clear the bar while the navigation the user
+  // actually triggered is still in flight.
+  private currentNavigationId: number | null = null;
+
   constructor() {
-    effect(() => {
-      const evt = this.routerEvents();
+    this.router.events.pipe(takeUntilDestroyed()).subscribe(evt => {
       if (evt instanceof NavigationStart) {
+        this.currentNavigationId = evt.id;
         this.navigating.set(true);
       } else if (evt instanceof NavigationEnd || evt instanceof NavigationCancel || evt instanceof NavigationError) {
-        this.navigating.set(false);
+        if (evt.id === this.currentNavigationId) {
+          this.navigating.set(false);
+        }
       }
 
       if (evt instanceof NavigationEnd) {

--- a/frontend/src/main/webapp/src/app/app.component.ts
+++ b/frontend/src/main/webapp/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import {Component, effect, inject} from '@angular/core';
-import {NavigationEnd, Router, RouterOutlet} from '@angular/router';
+import {Component, effect, inject, signal} from '@angular/core';
+import {NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router, RouterOutlet} from '@angular/router';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 
 import {toSignal} from '@angular/core/rxjs-interop';
 
@@ -8,7 +9,8 @@ import {toSignal} from '@angular/core/rxjs-interop';
   selector: 'body',
   templateUrl: 'app.component.html',
   imports: [
-    RouterOutlet
+    RouterOutlet,
+    MatProgressBarModule
   ]
 })
 
@@ -17,9 +19,20 @@ export class AppComponent {
 
   private readonly routerEvents = toSignal(this.router.events);
 
+  // Route resolvers (e.g. list-page data fetches) block navigation before the target component
+  // even mounts, so a component-level spinner can't cover that window - this shows a top-level
+  // bar for the whole navigation instead, from NavigationStart until it settles either way.
+  readonly navigating = signal(false);
+
   constructor() {
     effect(() => {
       const evt = this.routerEvents();
+      if (evt instanceof NavigationStart) {
+        this.navigating.set(true);
+      } else if (evt instanceof NavigationEnd || evt instanceof NavigationCancel || evt instanceof NavigationError) {
+        this.navigating.set(false);
+      }
+
       if (evt instanceof NavigationEnd) {
         window.scrollTo(0, 0);
       }

--- a/frontend/src/main/webapp/src/app/app.component.ts
+++ b/frontend/src/main/webapp/src/app/app.component.ts
@@ -28,18 +28,32 @@ export class AppComponent {
   // processes every emission.
   readonly navigating = signal(false);
 
+  // Most navigations settle well under this, so showing the bar immediately would just flicker -
+  // only surface it once a navigation has actually been in flight long enough to be noticeable.
+  private static readonly SHOW_DELAY_MS = 500;
+
   // Tracks which navigation the bar is currently shown for, so an End/Cancel/Error belonging to
   // an unrelated, already-superseded navigation can't clear the bar while the navigation the user
   // actually triggered is still in flight.
   private currentNavigationId: number | null = null;
 
+  private showDelayTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
   constructor() {
     this.router.events.pipe(takeUntilDestroyed()).subscribe(evt => {
       if (evt instanceof NavigationStart) {
         this.currentNavigationId = evt.id;
-        this.navigating.set(true);
+        this.showDelayTimeoutId = setTimeout(() => {
+          if (evt.id === this.currentNavigationId) {
+            this.navigating.set(true);
+          }
+        }, AppComponent.SHOW_DELAY_MS);
       } else if (evt instanceof NavigationEnd || evt instanceof NavigationCancel || evt instanceof NavigationError) {
         if (evt.id === this.currentNavigationId) {
+          if (this.showDelayTimeoutId !== null) {
+            clearTimeout(this.showDelayTimeoutId);
+            this.showDelayTimeoutId = null;
+          }
           this.navigating.set(false);
         }
       }


### PR DESCRIPTION
## Summary
`getHouseholdsAboveLimit()` was reported taking 2.28s in production. Root cause was two compounding N+1 problems:
- `HouseholdConverter.mapEntityToHousehold()` accesses the lazy `persons` collection, so every household triggered its own extra query (the endpoint loads *every* valid household up front, not a paginated slice, so this was unbounded).
- `IncomeValidatorService` re-queries `static_values` (tolerance, family bonus, additional-adult/child, ...) from scratch for every household, even though these rows are identical across the whole batch.

## Changes
- `HouseholdRepository.findAll(Specification)` is now overridden with `@EntityGraph(attributePaths = ["persons"])` so households + persons load in one query instead of N.
- `StaticValueRepository`'s three query methods are now `@Cacheable`. Static values only ever change via a DB migration shipped with a new deploy, never at runtime, so caching for the process lifetime (new `CacheConfig`, `ConcurrentMapCacheManager`) is safe with no eviction needed. Each method has its own cache name since `findSingleValueOfType`/`findValuesOfType` share the same argument shape and would otherwise collide on the same cache.
- Added a top-level navigation loading bar (`AppComponent`, driven by `NavigationStart`/`End`/`Cancel`/`Error`) regardless, since route resolvers block navigation before the target component even mounts — a component-level spinner can't cover that window, so this makes any future slow resolver-driven page load visibly transparent instead of looking hung.

## Verified locally (SQL logging against `local,testdata`)
- households+persons: N separate lazy-load queries → 1 query with a join.
- static_values: ~9 queries on the first request (cold cache) → 0 queries on a repeat request.
- Response time on the tiny local testdata set: ~220ms → ~28ms. Should scale much further on a production-sized household count, since the fix specifically targets the per-household multiplier.

## Test plan
- [x] Backend: full test suite passes (`./gradlew :backend:test`)
- [x] Frontend: full test suite passes (528 tests), lint clean, build clean
- [x] Manually verified in browser: page still renders correct data after the query changes