### PR TITLE
Merge statistics date-range dropdowns into one Zeitraum control

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/statistics/statistics.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/statistics.component.html
@@ -5,62 +5,60 @@
         <h5>Statistik</h5>
       </mat-card-header>
       <mat-card-content>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <div class="font-bold mb-2">Schnellauswahl</div>
-            <div>
-              <button matButton="filled" class="mt-2 md:mt-0" (click)="onSelectCurrentYear()">Aktuelles Jahr</button>
-              <button matButton="filled" class="ms-2 md:ms-0 lg:ms-2 mt-2 lg:mt-0" (click)="onSelectCurrentMonth()">Aktuelles Monat</button>
-            </div>
-            <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mt-4">
+        <div class="font-bold mb-2">Zeitraum</div>
+        <mat-button-toggle-group testid="dateRangeModeInput" [value]="selectedMode()"
+                                  (change)="onModeChange($event.value)">
+          <mat-button-toggle value="year">Jahr</mat-button-toggle>
+          <mat-button-toggle value="currentMonth">Aktuelles Monat</mat-button-toggle>
+          <mat-button-toggle value="distribution">Ausgabe</mat-button-toggle>
+          <mat-button-toggle value="custom">Benutzerdefiniert</mat-button-toggle>
+        </mat-button-toggle-group>
+
+        <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mt-4">
+          @switch (selectedMode()) {
+            @case ('year') {
               <div class="sm:col-span-2">
                 <label class="form-label">Jahr</label>
               </div>
               <div class="sm:col-span-5">
-                <select testid="yearInput" #yearSelect class="form-control" [ngModel]="undefined"
-                        (ngModelChange)="onYearSelected($event); yearSelect.value = '';">
-                  <option [ngValue]="undefined"></option>
-                  @for (year of settings()?.availableYears; track year) {
+                <select testid="yearInput" class="form-control" [ngModel]="selectedYear()"
+                        (ngModelChange)="onYearSelected($event)">
+                  @for (year of yearOptions(); track year) {
                     <option [ngValue]="year">{{ year }}</option>
                   }
                 </select>
               </div>
-            </div>
-            <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mt-2">
+            }
+            @case ('distribution') {
               <div class="sm:col-span-2">
                 <label class="form-label">Ausgabe</label>
               </div>
               <div class="sm:col-span-5">
-                <select testid="distributionDateInput" #distributionSelect class="form-control"
-                        [ngModel]="undefined"
-                        (ngModelChange)="onDistributionSelected($event); distributionSelect.value = '';">
+                <select testid="distributionDateInput" class="form-control"
+                        [ngModel]="selectedDistribution()"
+                        (ngModelChange)="onDistributionSelected($event)">
                   <option [ngValue]="undefined"></option>
                   @for (distribution of settings()?.distributions; track distribution.startDate) {
                     <option [ngValue]="distribution">{{ distribution.startDate | date : 'dd.MM.yyyy' }}</option>
                   }
                 </select>
               </div>
-            </div>
-          </div>
-          <div>
-            <div class="font-bold mb-2 mt-4 md:mt-0">Zeitraum</div>
-            <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center">
+            }
+            @case ('custom') {
               <div class="sm:col-span-2">
                 <label class="form-label">von</label>
               </div>
               <div class="sm:col-span-5">
                 <input testid="dataRangeFromInput" type="date" class="form-control" [(ngModel)]="dateRangeFrom">
               </div>
-            </div>
-            <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mt-2">
-              <div class="sm:col-span-2">
+              <div class="sm:col-span-2 mt-2 sm:mt-0">
                 <label class="form-label">bis</label>
               </div>
-              <div class="sm:col-span-5">
+              <div class="sm:col-span-5 mt-2 sm:mt-0">
                 <input testid="dataRangeToInput" type="date" class="form-control" [(ngModel)]="dateRangeTo">
               </div>
-            </div>
-          </div>
+            }
+          }
         </div>
       </mat-card-content>
     </mat-card>

--- a/frontend/src/main/webapp/src/app/modules/statistics/statistics.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/statistics/statistics.component.ts
@@ -1,6 +1,7 @@
 import {Component, computed, inject, input, signal} from '@angular/core';
 import {MatCardModule} from '@angular/material/card';
 import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {StatisticsApiService, StatisticsDistribution, StatisticsSettings} from '../../api/statistics-api.service';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import dayjs from 'dayjs';
@@ -22,6 +23,7 @@ import {faSave} from '@fortawesome/free-solid-svg-icons';
     FormsModule,
     ReactiveFormsModule,
     MatButtonModule,
+    MatButtonToggleModule,
     StatisticsPanelComponent,
     FaIconComponent
   ]
@@ -43,28 +45,43 @@ export class StatisticsComponent {
     )
   );
 
-  onYearSelected(year: number | undefined) {
-    if (year) {
-      this._dateRangeFrom.set(dayjs().year(year).startOf('year').toDate());
-      this._dateRangeTo.set(dayjs().year(year).endOf('year').toDate());
+  selectedMode = signal<DateRangeMode>('year');
+  selectedYear = signal<number>(dayjs().year());
+  selectedDistribution = signal<StatisticsDistribution | undefined>(undefined);
+
+  yearOptions = computed(() => {
+    const years = new Set(this.settings()?.availableYears ?? []);
+    years.add(dayjs().year());
+    return Array.from(years).sort((a, b) => b - a);
+  });
+
+  onModeChange(mode: DateRangeMode): void {
+    this.selectedMode.set(mode);
+    if (mode === 'year') {
+      this.applyYear(this.selectedYear());
+    } else if (mode === 'currentMonth') {
+      this._dateRangeFrom.set(dayjs().startOf('month').toDate());
+      this._dateRangeTo.set(dayjs().toDate());
     }
   }
 
+  onYearSelected(year: number): void {
+    this.selectedYear.set(year);
+    this.applyYear(year);
+  }
+
+  private applyYear(year: number): void {
+    const isCurrentYear = year === dayjs().year();
+    this._dateRangeFrom.set(dayjs().year(year).startOf('year').toDate());
+    this._dateRangeTo.set(isCurrentYear ? dayjs().toDate() : dayjs().year(year).endOf('year').toDate());
+  }
+
   onDistributionSelected(distribution: StatisticsDistribution | undefined): void {
+    this.selectedDistribution.set(distribution);
     if (distribution) {
       this._dateRangeFrom.set(distribution.startDate);
       this._dateRangeTo.set(distribution.endDate);
     }
-  }
-
-  onSelectCurrentYear(): void {
-    this._dateRangeFrom.set(dayjs().startOf('year').toDate());
-    this._dateRangeTo.set(dayjs().toDate());
-  }
-
-  onSelectCurrentMonth(): void {
-    this._dateRangeFrom.set(dayjs().startOf('month').toDate());
-    this._dateRangeTo.set(dayjs().toDate());
   }
 
   get dateRangeFrom(): string {
@@ -96,3 +113,5 @@ export class StatisticsComponent {
 
   protected readonly faSave = faSave;
 }
+
+type DateRangeMode = 'year' | 'currentMonth' | 'distribution' | 'custom';


### PR DESCRIPTION
## Summary
- The statistics page's "Jahr" and "Ausgabe" `<select>` dropdowns always reset themselves to blank right after a selection (`[ngModel]="undefined"` + manually clearing `select.value` in the change handler). This masked the fact that picking a year/distribution is just a shortcut for setting the same `von`/`bis` date range shown elsewhere — but it looked like a broken dropdown that "forgets" your choice.
- Replaced the "Schnellauswahl" buttons + Jahr select + Ausgabe select + von/bis inputs (4 separate, simultaneously-visible controls) with a single `mat-button-toggle-group` ("Jahr" / "Aktuelles Monat" / "Ausgabe" / "Benutzerdefiniert"). Only one control is visible at a time, so there's no stale-label problem left to paper over — each one now keeps showing what was actually selected.
- "Jahr" now also folds in the old "Aktuelles Jahr" quick button: it defaults to the current year (added to the option list even if it has no closed distributions yet) and can be switched to any other available year.

## Test plan
- [x] `ng test` (539/539 tests pass)
- [x] `ng build`
- [x] Manually exercised all 4 modes against local backend + testdata (Jahr defaults to current year and keeps selection when switched to a past year; Ausgabe keeps the picked distribution visible; Benutzerdefiniert preserves the previously resolved von/bis; Aktuelles Monat applies immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)