### PR TITLE
Set JWT cookie path via tafeladmin.server.relativeBaseUrl

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
@@ -5,6 +5,7 @@ import at.wrk.tafel.admin.backend.common.auth.components.TafelLoginFilter
 import at.wrk.tafel.admin.backend.common.auth.components.TafelPasswordGenerator
 import at.wrk.tafel.admin.backend.common.auth.components.TafelUserDetailsManager
 import at.wrk.tafel.admin.backend.common.auth.model.*
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*
 class UserController(
     private val userDetailsManager: TafelUserDetailsManager,
     private val tafelPasswordGenerator: TafelPasswordGenerator,
+    private val tafelAdminProperties: TafelAdminProperties,
 ) {
 
     companion object {
@@ -65,7 +67,7 @@ class UserController(
     fun logout(request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<Unit> {
         val user = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
 
-        val cookie = TafelLoginFilter.createTokenCookie(null, 0, request)
+        val cookie = TafelLoginFilter.createTokenCookie(null, 0, tafelAdminProperties.server.relativeBaseUrl, request)
         response.addCookie(cookie)
 
         logger.info("User ${user.username} logged out!")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
@@ -4,6 +4,7 @@ import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import at.wrk.tafel.admin.backend.common.auth.model.LoginResponse
 import at.wrk.tafel.admin.backend.common.auth.model.TafelUser
 import at.wrk.tafel.admin.backend.config.properties.ApplicationProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
@@ -25,6 +26,7 @@ class TafelLoginFilter(
     authenticationManager: AuthenticationManager,
     private val jwtTokenService: JwtTokenService,
     private val applicationProperties: ApplicationProperties,
+    private val tafelAdminProperties: TafelAdminProperties,
     private val jsonMapper: JsonMapper
 ) : UsernamePasswordAuthenticationFilter(authenticationManager) {
 
@@ -32,12 +34,12 @@ class TafelLoginFilter(
         private val basicAuthConverter = BasicAuthenticationConverter()
         const val jwtCookieName = "tafel-admin-jwt"
 
-        fun createTokenCookie(token: String?, maxAge: Int, request: HttpServletRequest): Cookie {
+        fun createTokenCookie(token: String?, maxAge: Int, path: String, request: HttpServletRequest): Cookie {
             val cookie = Cookie(jwtCookieName, token)
             cookie.isHttpOnly = true
             cookie.secure = request.isSecure
             cookie.maxAge = maxAge
-            cookie.path = "/"
+            cookie.path = path
             cookie.setAttribute("SameSite", "strict")
             return cookie
         }
@@ -77,7 +79,7 @@ class TafelLoginFilter(
 
             logger.info("Login successful via user '${user.username}' on '${request.requestURL}' (password-change required: ${user.passwordChangeRequired})")
 
-            val cookie = createTokenCookie(token, expirationTimeInSeconds, request)
+            val cookie = createTokenCookie(token, expirationTimeInSeconds, tafelAdminProperties.server.relativeBaseUrl, request)
             response.addCookie(cookie)
 
             val responseBody = LoginResponse(passwordChangeRequired = user.passwordChangeRequired)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
@@ -3,6 +3,7 @@ package at.wrk.tafel.admin.backend.config
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import at.wrk.tafel.admin.backend.common.auth.components.*
 import at.wrk.tafel.admin.backend.config.properties.ApplicationProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
 import org.passay.DefaultPasswordValidator
@@ -41,6 +42,7 @@ class WebSecurityConfig(
     private val userRepository: UserRepository,
     private val employeeRepository: EmployeeRepository,
     private val applicationProperties: ApplicationProperties,
+    private val tafelAdminProperties: TafelAdminProperties,
     private val jsonMapper: JsonMapper,
     private val loginAttemptService: LoginAttemptService,
 ) {
@@ -100,6 +102,7 @@ class WebSecurityConfig(
                     authenticationManager = authenticationManager(),
                     jwtTokenService = jwtTokenService,
                     applicationProperties = applicationProperties,
+                    tafelAdminProperties = tafelAdminProperties,
                     jsonMapper = jsonMapper
                 )
             )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/properties/TafelAdminProperties.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/properties/TafelAdminProperties.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ExcludeFromTestCoverage
 data class TafelAdminProperties(
     val mail: TafelAdminMailProperties? = null,
+    val server: TafelAdminServerProperties = TafelAdminServerProperties(),
 )
 
 @ExcludeFromTestCoverage
@@ -14,4 +15,9 @@ data class TafelAdminMailProperties(
     val from: String,
     val subjectPrefix: String? = null,
     val defaultRecipientsBcc: List<String>? = emptyList(),
+)
+
+@ExcludeFromTestCoverage
+data class TafelAdminServerProperties(
+    val relativeBaseUrl: String = "/",
 )

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
@@ -3,6 +3,8 @@ package at.wrk.tafel.admin.backend.security
 import at.wrk.tafel.admin.backend.common.auth.UserController
 import at.wrk.tafel.admin.backend.common.auth.components.*
 import at.wrk.tafel.admin.backend.common.auth.model.*
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminServerProperties
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -31,6 +33,9 @@ class UserControllerTest {
 
     @RelaxedMockK
     private lateinit var tafelPasswordGenerator: TafelPasswordGenerator
+
+    @RelaxedMockK
+    private lateinit var tafelAdminProperties: TafelAdminProperties
 
     @RelaxedMockK
     private lateinit var request: HttpServletRequest
@@ -102,6 +107,9 @@ class UserControllerTest {
 
     @Test
     fun `logout`() {
+        val relativeBaseUrl = "/test-base/"
+        every { tafelAdminProperties.server } returns TafelAdminServerProperties(relativeBaseUrl = relativeBaseUrl)
+
         val authentication = TafelJwtAuthentication(
             tokenValue = "TOKEN",
             username = testUser.username,
@@ -118,6 +126,7 @@ class UserControllerTest {
                 assertThat(it.name).isEqualTo(TafelLoginFilter.jwtCookieName)
                 assertThat(it.value).isNull()
                 assertThat(it.maxAge).isZero
+                assertThat(it.path).isEqualTo(relativeBaseUrl)
                 assertThat(it.attributes["SameSite"]).isEqualTo("strict")
             })
         }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelLoginFilterTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelLoginFilterTest.kt
@@ -4,6 +4,8 @@ import at.wrk.tafel.admin.backend.common.auth.components.JwtTokenService
 import at.wrk.tafel.admin.backend.common.auth.components.TafelLoginFilter
 import at.wrk.tafel.admin.backend.common.auth.model.LoginResponse
 import at.wrk.tafel.admin.backend.config.properties.ApplicationProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminServerProperties
 import at.wrk.tafel.admin.backend.security.testUser
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -49,6 +51,9 @@ class TafelLoginFilterTest {
     private lateinit var applicationProperties: ApplicationProperties
 
     @RelaxedMockK
+    private lateinit var tafelAdminProperties: TafelAdminProperties
+
+    @RelaxedMockK
     private lateinit var jsonMapper: JsonMapper
 
     @InjectMockKs
@@ -78,10 +83,12 @@ class TafelLoginFilterTest {
     fun `successfulAuthentication when login is successful`() {
         val token = "TOKEN"
         val expirationTime = 10000
+        val relativeBaseUrl = "/test-base/"
 
         every { authResult.principal } returns testUser
         every { jwtTokenService.generateToken(any(), any(), any()) } returns token
         every { applicationProperties.security.jwtToken.expirationTimeInSeconds } returns expirationTime
+        every { tafelAdminProperties.server } returns TafelAdminServerProperties(relativeBaseUrl = relativeBaseUrl)
 
         tafelLoginFilter.successfulAuthentication(request, response, filterChain, authResult)
 
@@ -98,7 +105,7 @@ class TafelLoginFilterTest {
                 assertThat(it.name).isEqualTo(TafelLoginFilter.jwtCookieName)
                 assertThat(it.value).isEqualTo(token)
                 assertThat(it.maxAge).isEqualTo(expirationTime)
-                assertThat(it.path).isEqualTo("/")
+                assertThat(it.path).isEqualTo(relativeBaseUrl)
                 assertThat(it.attributes["SameSite"]).isEqualTo("strict")
             })
         }
@@ -108,10 +115,12 @@ class TafelLoginFilterTest {
     fun `successfulAuthentication when passwordChange is required`() {
         val token = "TOKEN"
         val expirationTime = 5000
+        val relativeBaseUrl = "/test-base/"
 
         every { authResult.principal } returns testUser.copy(passwordChangeRequired = true)
         every { jwtTokenService.generateToken(any(), any(), any()) } returns token
         every { applicationProperties.security.jwtToken.expirationTimePwdChangeInSeconds } returns expirationTime
+        every { tafelAdminProperties.server } returns TafelAdminServerProperties(relativeBaseUrl = relativeBaseUrl)
 
         tafelLoginFilter.successfulAuthentication(request, response, filterChain, authResult)
 
@@ -127,7 +136,7 @@ class TafelLoginFilterTest {
                 assertThat(it.name).isEqualTo(TafelLoginFilter.jwtCookieName)
                 assertThat(it.value).isEqualTo(token)
                 assertThat(it.maxAge).isEqualTo(expirationTime)
-                assertThat(it.path).isEqualTo("/")
+                assertThat(it.path).isEqualTo(relativeBaseUrl)
                 assertThat(it.attributes["SameSite"]).isEqualTo("strict")
             })
         }


### PR DESCRIPTION
## Summary
- The session cookie path is already parameterized per-deployment via `tafeladmin.server.relativeBaseUrl` (`application.yml:20-21`, `74`), but the JWT auth cookie hardcoded `cookie.path = "/"` in `TafelLoginFilter.createTokenCookie()`.
- Added `server.relativeBaseUrl` to `TafelAdminProperties`, changed `createTokenCookie()` to accept a `path` parameter, and updated both call sites (`TafelLoginFilter.successfulAuthentication`, `UserController.logout`) to pass `tafelAdminProperties.server.relativeBaseUrl`.
- No new profile files needed — separation between test/prod is already achieved per-deployment via env var overrides, matching the existing session cookie pattern.

Fixes #2782

## Test plan
- [x] `./gradlew :backend:compileKotlin :backend:compileTestKotlin` passes
- [x] `./gradlew :backend:test` passes (full suite)
- [x] Updated `TafelLoginFilterTest` and `UserControllerTest` to assert the cookie path is sourced from `tafeladmin.server.relativeBaseUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)