### PR TITLE
Convert remaining zoneless-risky component state to signals

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.html
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.html
@@ -9,16 +9,16 @@
         <mat-label>Scanner auswählen</mat-label>
         <mat-select testid="scannerIdInput" [(ngModel)]="selectedScannerId">
           <mat-option [value]="undefined">Nicht aktiv</mat-option>
-          @for (scannerId of scannerIds; track trackByScannerId(scannerId)) {
+          @for (scannerId of scannerIds(); track trackByScannerId(scannerId)) {
             <mat-option [value]="scannerId">Nr. {{ scannerId }}</mat-option>
           }
         </mat-select>
       </mat-form-field>
       <h4 class="m-0 md:col-span-1">
         <div class="badge"
-             [ngClass]="{'badge-success': scannerReadyState, 'badge-danger': !scannerReadyState}"
+             [ngClass]="{'badge-success': scannerReadyState(), 'badge-danger': !scannerReadyState()}"
              testid="state-camera">
-          {{ scannerReadyState ? 'AKTIV' : 'INAKTIV' }}
+          {{ scannerReadyState() ? 'AKTIV' : 'INAKTIV' }}
         </div>
       </h4>
     </div>
@@ -30,11 +30,11 @@
       <mat-form-field class="md:col-span-2">
         <mat-label>Kundennummer</mat-label>
         <input #customerIdInput matInput testid="customerIdInput" type="number" name="customerIdInput"
-               [(ngModel)]="customerId" tafelAutofocus
+               [ngModel]="customerId()" (ngModelChange)="customerId.set($event)" tafelAutofocus
                (keydown.enter)="searchForCustomerId()"
                (wheel)="$event.preventDefault()">
       </mat-form-field>
-      <button matButton="filled" [disabled]="!customerId" (click)="searchForCustomerId()" testid="showCustomerButton" class="md:col-span-1">
+      <button matButton="filled" [disabled]="!customerId()" (click)="searchForCustomerId()" testid="showCustomerButton" class="md:col-span-1">
         Anzeigen
       </button>
     </div>
@@ -136,18 +136,18 @@
                 <div class="font-semibold">Aktuellste Notiz</div>
               </mat-card-header>
               <mat-card-content>
-                @if (customerNotes?.length === 0) {
+                @if (customerNotes()?.length === 0) {
                   <div class="font-semibold">
                     <h6 testid="nonotes-label">Keine Notiz vorhanden</h6>
                   </div>
                 }
-                @if (customerNotes && customerNotes?.length !== 0) {
+                @if (customerNotes() && customerNotes()?.length !== 0) {
                   <div>
                     <div class="mb-2 font-semibold" testid="note-title">
-                      {{ customerNotes[0].timestamp | date : 'dd.MM.yyyy HH:mm' }}&nbsp;{{ customerNotes[0].author }}
+                      {{ customerNotes()![0].timestamp | date : 'dd.MM.yyyy HH:mm' }}&nbsp;{{ customerNotes()![0].author }}
                     </div>
                     <div testid="note-text">
-                      {{ customerNotes[0].note }}
+                      {{ customerNotes()![0].note }}
                     </div>
                   </div>
                 }
@@ -168,14 +168,14 @@
               <mat-form-field class="w-48">
                 <mat-label>Ticket-Nummer</mat-label>
                 <input #ticketNumberInput matInput testid="ticketNumberInput" type="number"
-                       name="ticketNumberInput" [(ngModel)]="ticketNumber"
+                       name="ticketNumberInput" [ngModel]="ticketNumber()" (ngModelChange)="ticketNumber.set($event)"
                        required (keydown.enter)="assignCustomer()"
-                       [ngClass]="{'mat-form-field-invalid': !ticketNumber, 'mat-form-field-valid': ticketNumber}">
-                @if (!ticketNumber) {
+                       [ngClass]="{'mat-form-field-invalid': !ticketNumber(), 'mat-form-field-valid': ticketNumber()}">
+                @if (!ticketNumber()) {
                   <mat-error>Bitte geben Sie eine Ticket-Nummer ein</mat-error>
                 }
               </mat-form-field>
-              @if (ticketNumberEdit === true) {
+              @if (ticketNumberEdit() === true) {
                 <button matButton="filled" class="button-danger" testid="deleteTicketButton" (click)="deleteTicket()">
                   <fa-icon [icon]="faTrashCan"></fa-icon>
                 </button>
@@ -186,7 +186,7 @@
       </mat-card-content>
       <mat-card-actions align="end">
         <div class="flex gap-4">
-          <button matButton="filled" class="button-success" [disabled]="customerState() === 0 || !ticketNumber"
+          <button matButton="filled" class="button-success" [disabled]="customerState() === 0 || !ticketNumber()"
                   testid="assignCustomerButton" (click)="assignCustomer()">Annehmen
           </button>
           <button #cancelButton matButton="filled" testid="cancelButton" (click)="cancel()">Abbrechen</button>

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
@@ -150,7 +150,7 @@ describe('CheckinComponent', () => {
     it('component can be created', () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         expect(component).toBeTruthy();
     });
@@ -167,11 +167,11 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         await fixture.whenStable();
 
-        expect(component.scannerIds).toEqual(scannersResponse.scannerIds);
+        expect(component.scannerIds()).toEqual(scannersResponse.scannerIds);
     });
 
     it('ngOnInit without ongoing distribution navigates to dashboard', () => {
@@ -180,7 +180,7 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
         fixture.detectChanges();
 
         expect(router.navigate).toHaveBeenCalledWith(['uebersicht']);
@@ -193,7 +193,7 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
         component.scannerSubscription = testSubscription;
 
         // Trigger destroyRef cleanup by destroying the fixture
@@ -212,18 +212,18 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
-        expect(component.currentScannerId).toBeUndefined();
-        expect(component.customerId).toBeUndefined();
-        expect(component.scannerReadyState).toBeFalsy();
+        expect(component.currentScannerId()).toBeUndefined();
+        expect(component.customerId()).toBeUndefined();
+        expect(component.scannerReadyState()).toBeFalsy();
 
         const newScannerId = 123;
         component.selectedScannerId = newScannerId;
 
-        expect(component.currentScannerId).toBe(newScannerId);
-        expect(component.customerId).toBe(customerId);
-        expect(component.scannerReadyState).toBeTruthy();
+        expect(component.currentScannerId()).toBe(newScannerId);
+        expect(component.customerId()).toBe(customerId);
+        expect(component.scannerReadyState()).toBeTruthy();
         expect(sseService.listen).toHaveBeenCalledWith(`/sse/scanners/${newScannerId}/results`);
         expect(customerApiService.getCustomer).toHaveBeenCalled();
     });
@@ -235,17 +235,17 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
-        component.currentScannerId = 123;
-        component.customerId = 1111;
-        component.scannerReadyState = true;
+        component.customerNotes.set([]);
+        component.currentScannerId.set(123);
+        component.customerId.set(1111);
+        component.scannerReadyState.set(true);
         component.scannerSubscription = testSubscription;
 
         component.selectedScannerId = undefined;
 
-        expect(component.currentScannerId).toBeUndefined();
-        expect(component.customerId).not.toBeUndefined();
-        expect(component.scannerReadyState).toBeFalsy();
+        expect(component.currentScannerId()).toBeUndefined();
+        expect(component.customerId()).not.toBeUndefined();
+        expect(component.scannerReadyState()).toBeFalsy();
         expect(testSubscription.unsubscribe).toHaveBeenCalled();
         expect(sseService.listen).not.toHaveBeenCalled();
         expect(customerApiService.getCustomer).not.toHaveBeenCalled();
@@ -259,17 +259,17 @@ describe('CheckinComponent', () => {
 
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
-        component.currentScannerId = 123;
-        component.customerId = 1111;
-        component.scannerReadyState = true;
+        component.customerNotes.set([]);
+        component.currentScannerId.set(123);
+        component.customerId.set(1111);
+        component.scannerReadyState.set(true);
         component.scannerSubscription = testSubscription;
 
         const newScannerId = 456;
         component.selectedScannerId = newScannerId;
 
-        expect(component.currentScannerId).toBe(newScannerId);
-        expect(component.scannerReadyState).toBeTruthy();
+        expect(component.currentScannerId()).toBe(newScannerId);
+        expect(component.scannerReadyState()).toBeTruthy();
         expect(testSubscription.unsubscribe).toHaveBeenCalled();
         expect(sseService.listen).toHaveBeenCalledWith(`/sse/scanners/${newScannerId}/results`);
     });
@@ -277,8 +277,8 @@ describe('CheckinComponent', () => {
     it('searchForCustomerId found valid customer', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
-        component.ticketNumber = 123;
+        component.customerNotes.set([]);
+        component.ticketNumber.set(123);
 
         const mockCustomer = {
             id: 133,
@@ -310,7 +310,7 @@ describe('CheckinComponent', () => {
             pageSize: 5
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
         distributionTicketApiService.getCurrentTicketForCustomer.mockReturnValue(of({
             ticketNumber: null
         }));
@@ -325,15 +325,15 @@ describe('CheckinComponent', () => {
         expect(component.customerState()).toBe(CustomerState.VALID);
         expect(component.customerStateText()).toBe('GÜLTIG');
 
-        expect(component.ticketNumber).toBeUndefined();
-        expect(component.ticketNumberEdit).toBe(false);
+        expect(component.ticketNumber()).toBeUndefined();
+        expect(component.ticketNumberEdit()).toBe(false);
     });
 
     it('searchForCustomerId found valid customer with assigned ticket', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
-        component.ticketNumber = 123;
+        component.customerNotes.set([]);
+        component.ticketNumber.set(123);
 
         const mockCustomer = {
             id: 133,
@@ -365,7 +365,7 @@ describe('CheckinComponent', () => {
             pageSize: 5
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
 
         const testTicketNumber = 123;
         distributionTicketApiService.getCurrentTicketForCustomer.mockReturnValue(of({
@@ -382,14 +382,14 @@ describe('CheckinComponent', () => {
         expect(component.customerState()).toBe(CustomerState.VALID);
         expect(component.customerStateText()).toBe('GÜLTIG');
 
-        expect(component.ticketNumber).toBe(testTicketNumber);
-        expect(component.ticketNumberEdit).toBe(true);
+        expect(component.ticketNumber()).toBe(testTicketNumber);
+        expect(component.ticketNumberEdit()).toBe(true);
     });
 
     it('searchForCustomerId found valid customer but expires soon', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -420,7 +420,7 @@ describe('CheckinComponent', () => {
             pageSize: 5
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
         distributionTicketApiService.getCurrentTicketForCustomer.mockReturnValue(of({
             ticketNumber: null
         }));
@@ -439,7 +439,7 @@ describe('CheckinComponent', () => {
     it('searchForCustomerId found invalid customer', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -470,7 +470,7 @@ describe('CheckinComponent', () => {
             pageSize: 5
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
         distributionTicketApiService.getCurrentTicketForCustomer.mockReturnValue(of({
             ticketNumber: null
         }));
@@ -489,7 +489,7 @@ describe('CheckinComponent', () => {
     it('searchForCustomerId found locked customer', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -521,7 +521,7 @@ describe('CheckinComponent', () => {
             pageSize: 5
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
         distributionTicketApiService.getCurrentTicketForCustomer.mockReturnValue(of({
             ticketNumber: null
         }));
@@ -540,7 +540,7 @@ describe('CheckinComponent', () => {
     it('searchForCustomerId customer not found shows toast', () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         customerApiService.getCustomer.mockReturnValue(throwError(() => ({ status: 404 })));
         const notesResponse: CustomerNotesResponse = {
@@ -552,13 +552,13 @@ describe('CheckinComponent', () => {
         };
         customerNoteApiService.getNotesForCustomer.mockReturnValue(of(notesResponse));
         const testCustomerId = 1234;
-        component.customerId = testCustomerId;
+        component.customerId.set(testCustomerId);
 
         component.searchForCustomerId();
 
         expect(component.customer()).toBeUndefined();
         expect(component.customerState()).toBeUndefined();
-        expect(component.customerNotes).toEqual([]);
+        expect(component.customerNotes()).toEqual([]);
         expect(customerApiService.getCustomer).toHaveBeenCalledWith(testCustomerId);
         expect(toastr.info).toHaveBeenCalledWith(`Kunde ${testCustomerId} nicht gefunden!`);
     });
@@ -566,7 +566,7 @@ describe('CheckinComponent', () => {
     it('searchForCustomerId found notes', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -614,18 +614,18 @@ describe('CheckinComponent', () => {
             ticketNumber: null
         }));
 
-        component.customerId = mockCustomer.id;
+        component.customerId.set(mockCustomer.id);
         component.searchForCustomerId();
         await fixture.whenStable();
         fixture.detectChanges();
 
-        expect(component.customerNotes).toEqual(mockNotesResponse.items);
+        expect(component.customerNotes()).toEqual(mockNotesResponse.items);
     });
 
     it('reset customer', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
         fixture.detectChanges();  // Populate ViewChildren from template
 
         const mockCustomer = {
@@ -655,17 +655,17 @@ describe('CheckinComponent', () => {
         await fixture.whenStable();
         fixture.detectChanges();
 
-        expect(component.customerId).toBeUndefined();
+        expect(component.customerId()).toBeUndefined();
         expect(component.customerState()).toBeUndefined();
         expect(component.customerStateText()).toBeNull();
-        expect(component.customerNotes).toBeDefined();
-        expect(component.customerNotes.length).toBe(0);
+        expect(component.customerNotes()).toBeDefined();
+        expect(component.customerNotes()!.length).toBe(0);
     });
 
     it('assign customer', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
         fixture.detectChanges();  // Populate ViewChildren from template
 
         const mockCustomer = {
@@ -692,7 +692,7 @@ describe('CheckinComponent', () => {
         component.processCustomer(mockCustomer);
 
         const ticketNumber = 55;
-        component.ticketNumber = ticketNumber;
+        component.ticketNumber.set(ticketNumber);
 
         distributionApiService.assignCustomer.mockReturnValue(of(undefined));
 
@@ -702,18 +702,18 @@ describe('CheckinComponent', () => {
 
         expect(distributionApiService.assignCustomer).toHaveBeenCalledWith(mockCustomer.id, ticketNumber);
 
-        expect(component.customerId).toBeUndefined();
+        expect(component.customerId()).toBeUndefined();
         expect(component.customerState()).toBeUndefined();
         expect(component.customerStateText()).toBeNull();
-        expect(component.customerNotes).toBeDefined();
-        expect(component.customerNotes.length).toBe(0);
-        expect(component.ticketNumber).toBeUndefined();
+        expect(component.customerNotes()).toBeDefined();
+        expect(component.customerNotes()!.length).toBe(0);
+        expect(component.ticketNumber()).toBeUndefined();
     });
 
     it('assign customer ignored without proper value', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -738,7 +738,7 @@ describe('CheckinComponent', () => {
         };
         component.processCustomer(mockCustomer);
 
-        component.ticketNumber = undefined;
+        component.ticketNumber.set(undefined);
 
         component.assignCustomer();
         await fixture.whenStable();
@@ -750,7 +750,7 @@ describe('CheckinComponent', () => {
     it('delete ticket successful', async () => {
         const fixture = TestBed.createComponent(CheckinComponent);
         const component = fixture.componentInstance;
-        component.customerNotes = [];
+        component.customerNotes.set([]);
 
         const mockCustomer = {
             id: 133,
@@ -783,8 +783,8 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(distributionTicketApiService.deleteCurrentTicketOfCustomer).toHaveBeenCalledWith(mockCustomer.id);
-        expect(component.ticketNumber).toBeUndefined();
-        expect(component.ticketNumberEdit).toBeUndefined();
+        expect(component.ticketNumber()).toBeUndefined();
+        expect(component.ticketNumberEdit()).toBeUndefined();
         expect(toastr.success).toHaveBeenCalledWith('Ticket-Nummer gelöscht!');
     });
 

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, computed, DestroyRef, effect, ElementRef, inject, signal, viewChild} from '@angular/core';
+import {Component, computed, DestroyRef, effect, ElementRef, inject, signal, viewChild} from '@angular/core';
 import {CustomerApiService, CustomerData} from '../../../../api/customer-api.service';
 import {Subscription} from 'rxjs';
 import dayjs from 'dayjs';
@@ -59,23 +59,22 @@ export class CheckinComponent {
   private readonly router = inject(Router);
   private readonly toastr = inject(TafelToastrService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly cdr = inject(ChangeDetectorRef);
   private readonly VALID_UNTIL_WARNLIMIT_WEEKS = 8;
 
   customerIdInputRef = viewChild<ElementRef>('customerIdInput');
   ticketNumberInputRef = viewChild<ElementRef>('ticketNumberInput');
   cancelButtonRef = viewChild<ElementRef>('cancelButton');
 
-  scannerIds: number[] = [];
-  currentScannerId: number | undefined;
-  scannerReadyState: boolean | undefined;
+  scannerIds = signal<number[]>([]);
+  currentScannerId = signal<number | undefined>(undefined);
+  scannerReadyState = signal<boolean | undefined>(undefined);
   scannerSubscription: Subscription | undefined;
-  customerId: number | undefined;
+  customerId = signal<number | undefined>(undefined);
   customer = signal<CustomerData | undefined>(undefined);
   customerState = signal<CustomerState | undefined>(undefined);
-  customerNotes: CustomerNoteItem[] | undefined;
-  ticketNumber: number | undefined;
-  ticketNumberEdit: boolean | undefined = false;
+  customerNotes = signal<CustomerNoteItem[] | undefined>(undefined);
+  ticketNumber = signal<number | undefined>(undefined);
+  ticketNumberEdit = signal<boolean | undefined>(false);
 
   customerStateColor = computed<string | null>(() => {
     switch (this.customerState()) {
@@ -145,30 +144,29 @@ export class CheckinComponent {
   }
 
   get selectedScannerId(): number | undefined {
-    return this.currentScannerId;
+    return this.currentScannerId();
   }
 
   set selectedScannerId(scannerId: number | undefined) {
-    this.currentScannerId = scannerId;
+    this.currentScannerId.set(scannerId);
     if (this.scannerSubscription) {
       this.scannerSubscription.unsubscribe();
     }
-    this.scannerReadyState = false;
+    this.scannerReadyState.set(false);
 
     if (scannerId) {
-      this.scannerSubscription = this.sseService.listen<ScanResult>(`/sse/scanners/${this.currentScannerId}/results`)
+      this.scannerSubscription = this.sseService.listen<ScanResult>(`/sse/scanners/${scannerId}/results`)
         .subscribe((result: ScanResult) => {
-          this.customerId = result.value;
+          this.customerId.set(result.value);
           this.searchForCustomerId();
-          this.cdr.markForCheck();
         });
 
-      this.scannerReadyState = true;
+      this.scannerReadyState.set(true);
     }
   }
 
   get scannerReadyStateColor(): string {
-    return this.scannerReadyState ? 'success' : 'danger';
+    return this.scannerReadyState() ? 'success' : 'danger';
   }
 
   readonly currentDistribution = this.globalStateService.getCurrentDistribution();
@@ -185,8 +183,7 @@ export class CheckinComponent {
     // Load scanners on init
     effect(() => {
       this.scannerApiService.getScanners().subscribe((response: ScannerList) => {
-        this.scannerIds = response.scannerIds;
-        this.cdr.markForCheck();
+        this.scannerIds.set(response.scannerIds);
       });
     });
 
@@ -203,39 +200,36 @@ export class CheckinComponent {
       next: (customerData: CustomerData) => {
         this.processCustomer(customerData);
 
-        this.customerNoteApiService.getNotesForCustomer(this.customerId!).subscribe(notesResponse => {
-          this.customerNotes = notesResponse.items;
-          this.cdr.markForCheck();
+        this.customerNoteApiService.getNotesForCustomer(this.customerId()!).subscribe(notesResponse => {
+          this.customerNotes.set(notesResponse.items);
         });
 
         this.distributionTicketApiService.getCurrentTicketForCustomer(customerData.id!)
           .subscribe((ticketNumberResponse: TicketNumberResponse) => {
             if (ticketNumberResponse.ticketNumber) {
-              this.ticketNumber = ticketNumberResponse.ticketNumber;
+              this.ticketNumber.set(ticketNumberResponse.ticketNumber);
             }
-            this.ticketNumberEdit = this.ticketNumber != null;
-            this.cdr.markForCheck();
+            this.ticketNumberEdit.set(this.ticketNumber() != null);
           });
       },
       error: (error: any) => {
         if (error.status === 404) {
           this.processCustomer(undefined);
-          this.customerNotes = [];
-          this.toastr.info(`Kunde ${this.customerId} nicht gefunden!`);
-          this.cdr.markForCheck();
+          this.customerNotes.set([]);
+          this.toastr.info(`Kunde ${this.customerId()} nicht gefunden!`);
         }
       },
     };
 
-    if (this.customerId) {
-      this.customerApiService.getCustomer(this.customerId).subscribe(observer);
+    if (this.customerId()) {
+      this.customerApiService.getCustomer(this.customerId()!).subscribe(observer);
     } else {
       this.toastr.warning('Keine Kundennummer angegeben!');
     }
   }
 
   processCustomer(customer: CustomerData | undefined) {
-    this.ticketNumber = undefined;
+    this.ticketNumber.set(undefined);
     this.customer.set(customer);
 
     if (customer) {
@@ -265,16 +259,15 @@ export class CheckinComponent {
 
   cancel() {
     this.processCustomer(undefined);
-    this.customerNotes = [];
-    this.customerId = undefined;
-    this.ticketNumber = undefined;
-    this.ticketNumberEdit = undefined;
+    this.customerNotes.set([]);
+    this.customerId.set(undefined);
+    this.ticketNumber.set(undefined);
+    this.ticketNumberEdit.set(undefined);
     this.customerIdInputRef()?.nativeElement?.focus?.();
-    this.cdr.markForCheck();
   }
 
   assignCustomer() {
-    const ticketNumber = this.ticketNumber;
+    const ticketNumber = this.ticketNumber();
     if (ticketNumber !== undefined && ticketNumber > 0) {
 
       const observer = {
@@ -288,11 +281,10 @@ export class CheckinComponent {
   deleteTicket() {
     const observer = {
       next: () => {
-        this.ticketNumber = undefined;
-        this.ticketNumberEdit = undefined;
+        this.ticketNumber.set(undefined);
+        this.ticketNumberEdit.set(undefined);
         this.toastr.success('Ticket-Nummer gelöscht!');
         this.ticketNumberInputRef()?.nativeElement?.focus?.();
-        this.cdr.markForCheck();
       }
     };
     this.distributionTicketApiService.deleteCurrentTicketOfCustomer(this.customer()!.id!).subscribe(observer);

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
@@ -62,7 +62,7 @@
   </div>
   <div class="grid grid-cols-1 md:grid-cols-12 gap-6 mt-4">
     <div class="md:col-span-5">
-      @if (!selectedDriver) {
+      @if (!selectedDriver()) {
         <label class="form-label">Fahrer *</label>
         <div class="flex items-center gap-2">
           <input testid="driverSearchInput" type="text" formControlName="driverSearchInput" class="form-control"
@@ -90,7 +90,7 @@
       } @else {
         <label class="form-label">Fahrer *</label>
         <div class="flex items-center justify-between gap-2">
-          <div testid="selectedDriverDescription">{{ selectedDriver.personnelNumber }} {{ selectedDriver.firstname }} {{ selectedDriver.lastname }}</div>
+          <div testid="selectedDriverDescription">{{ selectedDriver()!.personnelNumber }} {{ selectedDriver()!.firstname }} {{ selectedDriver()!.lastname }}</div>
           <button type="button" matButton="filled" testid="selectedDriverRemoveButton" class="button-danger"
                   (click)="resetDriver()">
             <fa-icon [icon]="faRemove"></fa-icon>
@@ -99,7 +99,7 @@
       }
     </div>
     <div class="md:col-span-5 mt-4 md:mt-0">
-      @if (!selectedCoDriver) {
+      @if (!selectedCoDriver()) {
         <label class="form-label">Beifahrer *</label>
         <div class="flex items-center gap-2">
           <input testid="coDriverSearchInput" type="text" formControlName="coDriverSearchInput" class="form-control"
@@ -127,7 +127,7 @@
       } @else {
         <label class="form-label">Beifahrer *</label>
         <div class="flex items-center justify-between gap-2">
-          <div testid="selectedCoDriverDescription">{{ selectedCoDriver.personnelNumber }} {{ selectedCoDriver.firstname }} {{ selectedCoDriver.lastname }}</div>
+          <div testid="selectedCoDriverDescription">{{ selectedCoDriver()!.personnelNumber }} {{ selectedCoDriver()!.firstname }} {{ selectedCoDriver()!.lastname }}</div>
           <button type="button" matButton="filled" testid="selectedCoDriverRemoveButton" class="button-danger"
                   (click)="resetCoDriver()">
             <fa-icon [icon]="faRemove"></fa-icon>

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.spec.ts
@@ -292,13 +292,13 @@ describe('FoodCollectionRecordingBasedataComponent', () => {
     component.setSelectedDriver(mockEmployees[0]);
 
     expect(component.driverSearchInput.value).toEqual('D1');
-    expect(component.selectedDriver).toEqual(mockEmployees[0]);
+    expect(component.selectedDriver()).toEqual(mockEmployees[0]);
 
     // Reset driver
     component.resetDriver();
 
     expect(component.driverSearchInput.value).toBeNull();
-    expect(component.selectedDriver).toBeNull();
+    expect(component.selectedDriver()).toBeNull();
   });
 
   it('should reset co-driver when resetCoDriver is called', () => {
@@ -318,13 +318,13 @@ describe('FoodCollectionRecordingBasedataComponent', () => {
     component.setSelectedCoDriver(mockEmployees[1]);
 
     expect(component.coDriverSearchInput.value).toEqual('D2');
-    expect(component.selectedCoDriver).toEqual(mockEmployees[1]);
+    expect(component.selectedCoDriver()).toEqual(mockEmployees[1]);
 
     // Reset co-driver
     component.resetCoDriver();
 
     expect(component.coDriverSearchInput.value).toBeNull();
-    expect(component.selectedCoDriver).toBeNull();
+    expect(component.selectedCoDriver()).toBeNull();
   });
 
   it('should save route data when km difference is <= 350', () => {

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Component, effect, inject, input, model, viewChild} from '@angular/core';
+import {Component, effect, inject, input, model, signal, viewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDialog} from '@angular/material/dialog';
@@ -40,10 +40,9 @@ export class FoodCollectionRecordingBasedataComponent {
   private readonly fb = inject(FormBuilder);
   private readonly toastr = inject(TafelToastrService);
   private readonly dialog = inject(MatDialog);
-  private readonly cdr = inject(ChangeDetectorRef);
 
-  selectedDriver: EmployeeData | null = null;
-  selectedCoDriver: EmployeeData | null = null;
+  selectedDriver = signal<EmployeeData | null>(null);
+  selectedCoDriver = signal<EmployeeData | null>(null);
 
   form = this.fb.group({
       car: this.fb.control<CarData | null>(null, [Validators.required]),
@@ -51,14 +50,14 @@ export class FoodCollectionRecordingBasedataComponent {
         [
           Validators.required,
           Validators.maxLength(50),
-          CustomValidator.hasValue(() => this.selectedDriver, 'Bitte die Mitarbeiter-Suche starten')
+          CustomValidator.hasValue(() => this.selectedDriver(), 'Bitte die Mitarbeiter-Suche starten')
         ]
       ),
       coDriverSearchInput: this.fb.control<string | null>(null,
         [
           Validators.required,
           Validators.maxLength(50),
-          CustomValidator.hasValue(() => this.selectedCoDriver, 'Bitte die Mitarbeiter-Suche starten')
+          CustomValidator.hasValue(() => this.selectedCoDriver(), 'Bitte die Mitarbeiter-Suche starten')
         ]
       ),
       kmStart: this.fb.control<number | null>(null, [Validators.required, Validators.min(1)]),
@@ -77,9 +76,9 @@ export class FoodCollectionRecordingBasedataComponent {
     this.kmStart.reset();
     this.kmEnd.reset();
     this.driverSearchInput.reset();
-    this.selectedDriver = null;
+    this.selectedDriver.set(null);
     this.coDriverSearchInput.reset();
-    this.selectedCoDriver = null;
+    this.selectedCoDriver.set(null);
 
     if (foodCollectionData) {
       this.car.setValue(this.carList().cars.find(car => car.id === foodCollectionData.carId) ?? null);
@@ -108,8 +107,6 @@ export class FoodCollectionRecordingBasedataComponent {
       this.kmStart.setValue(foodCollectionData.kmStart);
       this.kmEnd.setValue(foodCollectionData.kmEnd);
     }
-
-    this.cdr.markForCheck();
   });
 
   private createKmValidation() {
@@ -144,17 +141,17 @@ export class FoodCollectionRecordingBasedataComponent {
   }
 
   setSelectedDriver(employee: EmployeeData) {
-    this.selectedDriver = employee;
+    this.selectedDriver.set(employee);
     this.driverSearchInput.updateValueAndValidity();
   }
 
   setSelectedCoDriver(employee: EmployeeData) {
-    this.selectedCoDriver = employee;
+    this.selectedCoDriver.set(employee);
     this.coDriverSearchInput.updateValueAndValidity();
   }
 
   isSaveDisabled(): boolean {
-    return this.form.invalid || !this.selectedDriver || !this.selectedCoDriver;
+    return this.form.invalid || !this.selectedDriver() || !this.selectedCoDriver();
   }
 
   save(overrideKmDiff: boolean = false) {
@@ -175,8 +172,8 @@ export class FoodCollectionRecordingBasedataComponent {
 
     const routeData: FoodCollectionSaveRouteDataRequest = {
       carId: this.car.value!.id,
-      driverId: this.selectedDriver!.id,
-      coDriverId: this.selectedCoDriver!.id,
+      driverId: this.selectedDriver()!.id,
+      coDriverId: this.selectedCoDriver()!.id,
       kmStart: kmStart,
       kmEnd: kmEnd
     };
@@ -189,12 +186,12 @@ export class FoodCollectionRecordingBasedataComponent {
 
   resetDriver() {
     this.driverSearchInput.setValue(null);
-    this.selectedDriver = null;
+    this.selectedDriver.set(null);
   }
 
   resetCoDriver() {
     this.coDriverSearchInput.setValue(null);
-    this.selectedCoDriver = null;
+    this.selectedCoDriver.set(null);
   }
 
   get car() {


### PR DESCRIPTION
## Summary

Closes #2788, scoped down after an audit (see [comment](https://github.com/wrk-tafel/admin/issues/2788#issuecomment-5095543807)) — the app is already mostly signal-based and zoneless; the remaining risk was two components holding UI state in plain fields and relying on manual `ChangeDetectorRef.markForCheck()` calls after async mutations to render at all.

- `CheckinComponent`: converted `scannerIds`, `currentScannerId`, `scannerReadyState`, `customerId`, `customerNotes`, `ticketNumber`, `ticketNumberEdit` to signals; updated template (including two-way `ngModel` bindings) and removed manual `markForCheck()` calls / the injected `ChangeDetectorRef`.
- `FoodCollectionRecordingBasedataComponent`: converted `selectedDriver`/`selectedCoDriver` to signals; same cleanup.

Full audit + plan: https://claude.ai/code/artifact/b5e00fa9-259e-4eea-9309-38287a751e91

## Test plan
- [x] `ng test` — full suite (539 tests) passes
- [x] `ng lint` — passes