### PR TITLE
Convert AuthenticationService userInfo to a signal

### DIFF
--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.spec.ts
@@ -41,8 +41,8 @@ describe('AuthenticationService', () => {
 
         service.login('USER', 'PWD').then(response => {
             expect(response).toEqual({ successful: true, passwordChangeRequired: false, locked: false });
-            expect(service.userInfo!.username).toBe(userInfoResponseBody.username);
-            expect(service.userInfo!.permissions).toEqual(userInfoResponseBody.permissions);
+            expect(service.userInfo()!.username).toBe(userInfoResponseBody.username);
+            expect(service.userInfo()!.permissions).toEqual(userInfoResponseBody.permissions);
         });
 
         const mockLoginReq = httpMock.expectOne('/login');
@@ -69,8 +69,8 @@ describe('AuthenticationService', () => {
 
         service.login('USER', 'PWD').then(response => {
             expect(response).toEqual({ successful: true, passwordChangeRequired: true, locked: false });
-            expect(service.userInfo!.username).toBe(userInfoResponseBody.username);
-            expect(service.userInfo!.permissions).toEqual(userInfoResponseBody.permissions);
+            expect(service.userInfo()!.username).toBe(userInfoResponseBody.username);
+            expect(service.userInfo()!.permissions).toEqual(userInfoResponseBody.permissions);
         });
 
         const loginMockReq = httpMock.expectOne('/login');
@@ -90,12 +90,12 @@ describe('AuthenticationService', () => {
     });
 
     it('login failed', async () => {
-        service.userInfo = { username: 'test123', permissions: [] };
+        service.userInfo.set({ username: 'test123', permissions: [] });
 
         service.login('USER', 'PWD').then(response => {
             expect(response).toEqual({ successful: false, passwordChangeRequired: false, locked: false });
             // check if it's reset
-            expect(service.userInfo).toBeNull();
+            expect(service.userInfo()).toBeNull();
         });
 
         const loginMockReq = httpMock.expectOne('/login');
@@ -111,12 +111,12 @@ describe('AuthenticationService', () => {
     });
 
     it('login failed - account locked', async () => {
-        service.userInfo = { username: 'test123', permissions: [] };
+        service.userInfo.set({ username: 'test123', permissions: [] });
 
         service.login('USER', 'PWD').then(response => {
             expect(response).toEqual({ successful: false, passwordChangeRequired: false, locked: true });
             // check if it's reset
-            expect(service.userInfo).toBeNull();
+            expect(service.userInfo()).toBeNull();
         });
 
         const loginMockReq = httpMock.expectOne('/login');
@@ -144,7 +144,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasPermission - permission exists', () => {
-        service.userInfo = { username: 'test123', permissions: ['PERM1'] };
+        service.userInfo.set({ username: 'test123', permissions: ['PERM1'] });
 
         const hasPermission = service.hasPermission('PERM1');
 
@@ -152,7 +152,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasPermission - permission doesnt exist', () => {
-        service.userInfo = { username: 'test123', permissions: ['PERM2'] };
+        service.userInfo.set({ username: 'test123', permissions: ['PERM2'] });
 
         const hasPermission = service.hasPermission('PERM1');
 
@@ -160,7 +160,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasPermission - no permissions given', () => {
-        service.userInfo = { username: 'test123', permissions: [] };
+        service.userInfo.set({ username: 'test123', permissions: [] });
 
         const hasPermission = service.hasPermission('PERM1');
 
@@ -168,7 +168,7 @@ describe('AuthenticationService', () => {
     });
 
     it('getUsername - authenticated', () => {
-        service.userInfo = { username: 'test-user', permissions: [] };
+        service.userInfo.set({ username: 'test-user', permissions: [] });
 
         const username = service.getUsername();
 
@@ -182,7 +182,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermission - no permissions', () => {
-        service.userInfo = { username: 'test-user', permissions: [] };
+        service.userInfo.set({ username: 'test-user', permissions: [] });
 
         const hasAnyPermission = service.hasAnyPermission();
 
@@ -190,7 +190,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermission - given permissions', () => {
-        service.userInfo = { username: 'test-user', permissions: ['PERM1'] };
+        service.userInfo.set({ username: 'test-user', permissions: ['PERM1'] });
 
         const hasAnyPermission = service.hasAnyPermission();
 
@@ -198,11 +198,11 @@ describe('AuthenticationService', () => {
     });
 
     it('logout', () => {
-        service.userInfo = { username: 'test-user', permissions: ['PERM1'] };
+        service.userInfo.set({ username: 'test-user', permissions: ['PERM1'] });
 
         /* eslint-disable @typescript-eslint/no-unused-vars */
         service.logout().subscribe(response => {
-            expect(service.userInfo).toBeNull();
+            expect(service.userInfo()).toBeNull();
         });
 
         const mockReq = httpMock.expectOne('/users/logout');
@@ -214,7 +214,7 @@ describe('AuthenticationService', () => {
     });
 
     it('isAuthenticated true', () => {
-        service.userInfo = { username: 'test-user', permissions: ['PERM1'] };
+        service.userInfo.set({ username: 'test-user', permissions: ['PERM1'] });
 
         const isAuthenticated = service.isAuthenticated();
 
@@ -222,7 +222,7 @@ describe('AuthenticationService', () => {
     });
 
     it('isAuthenticated false', () => {
-        service.userInfo = null;
+        service.userInfo.set(null);
 
         const isAuthenticated = service.isAuthenticated();
 
@@ -230,7 +230,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermissionOf - single permission exists', () => {
-        service.userInfo = { username: 'test123', permissions: ['PERM1', 'PERM2'] };
+        service.userInfo.set({ username: 'test123', permissions: ['PERM1', 'PERM2'] });
 
         const hasPermission = service.hasAnyPermissionOf(['PERM1']);
 
@@ -238,7 +238,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermissionOf - multiple permissions exist and one does not exist', () => {
-        service.userInfo = { username: 'test123', permissions: ['PERM1', 'PERM2'] };
+        service.userInfo.set({ username: 'test123', permissions: ['PERM1', 'PERM2'] });
 
         const hasPermission = service.hasAnyPermissionOf(['PERM1', 'PERM2', 'PERM3']);
 
@@ -246,7 +246,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermissionOf - permission doesnt exist', () => {
-        service.userInfo = { username: 'test123', permissions: ['PERM2'] };
+        service.userInfo.set({ username: 'test123', permissions: ['PERM2'] });
 
         const hasPermission = service.hasAnyPermissionOf(['PERM1']);
 
@@ -254,7 +254,7 @@ describe('AuthenticationService', () => {
     });
 
     it('hasAnyPermissionOf - no permissions given', () => {
-        service.userInfo = { username: 'test123', permissions: [] };
+        service.userInfo.set({ username: 'test123', permissions: [] });
 
         const hasPermission = service.hasAnyPermissionOf(['PERM1']);
 

--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
@@ -1,12 +1,12 @@
 import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
-import {inject, Service} from '@angular/core';
+import {inject, Service, signal} from '@angular/core';
 import {Router} from '@angular/router';
 import {firstValueFrom, Observable, of} from 'rxjs';
 import {catchError, map, tap} from 'rxjs/operators';
 
 @Service()
 export class AuthenticationService {
-  userInfo: UserInfo | null = null;
+  userInfo = signal<UserInfo | null>(null);
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
 
@@ -18,13 +18,13 @@ export class AuthenticationService {
         }),
 
         catchError((error: HttpErrorResponse) => {
-          this.userInfo = null;
+          this.userInfo.set(null);
           return of({successful: false, passwordChangeRequired: false, locked: error.status === 423});
         })));
   }
 
   public isAuthenticated(): boolean {
-    return this.userInfo !== null;
+    return this.userInfo() !== null;
   }
 
   public redirectToLogin(msgKey?: string) {
@@ -32,7 +32,7 @@ export class AuthenticationService {
   }
 
   public hasAnyPermission(): boolean {
-    return (this.userInfo?.permissions.length ?? 0) > 0;
+    return (this.userInfo()?.permissions.length ?? 0) > 0;
   }
 
   public hasPermission(permission: string): boolean {
@@ -40,23 +40,23 @@ export class AuthenticationService {
   }
 
   public hasAnyPermissionOf(permissions: string[]): boolean {
-    const foundPermissions = this.userInfo?.permissions.filter(permission => permissions.indexOf(permission) > -1) ?? [];
+    const foundPermissions = this.userInfo()?.permissions.filter(permission => permissions.indexOf(permission) > -1) ?? [];
     return foundPermissions.length > 0;
   }
 
   public getUsername(): string | undefined {
-    return this.userInfo?.username;
+    return this.userInfo()?.username;
   }
 
   public logout(): Observable<void> {
-    this.userInfo = null;
+    this.userInfo.set(null);
     return this.http.post<void>('/users/logout', null);
   }
 
   public loadUserInfo(): Promise<UserInfo | null> {
     return firstValueFrom(this.http.get<UserInfo>('/users/info')
       .pipe(tap(userInfo => {
-          this.userInfo = userInfo;
+          this.userInfo.set(userInfo);
           return of(userInfo);
         }),
 


### PR DESCRIPTION
## Summary

Phase 2 of #2788 (see [audit/plan](https://claude.ai/code/artifact/b5e00fa9-259e-4eea-9309-38287a751e91)) — converts `AuthenticationService.userInfo` from a plain field to a `signal()`, matching the pattern already established by `GlobalStateService`.

- `userInfo` consumers (`isAuthenticated()`, `hasPermission()`, `hasAnyPermissionOf()`, `getUsername()`, etc.) are all internal to the service and were updated to read via `userInfo()`.
- Side effect: `TafelIfPermissionDirective`'s `effect()` calls `hasPermission()` internally, so it now reactively tracks `userInfo` and permission-gated UI elements update immediately on login/logout, rather than only reflecting auth state from before the element was first rendered.

## Test plan
- [x] `ng test` — full suite (539 tests) passes
- [x] `ng lint` — passes