### PR TITLE
Remove dead userValidForSave field from UserEditComponent

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
@@ -19,7 +19,6 @@ export class UserEditComponent {
 
   // Writable signal linked to input - resets when userData changes, locally writable from form updates
   userUpdated = linkedSignal<UserData | undefined>(() => this.userData());
-  userValidForSave = false;
   userFormComponent = viewChild<UserFormComponent>(UserFormComponent);
   private readonly userApiService = inject(UserApiService);
   private readonly router = inject(Router);
@@ -40,7 +39,6 @@ export class UserEditComponent {
 
   userDataUpdated(event: UserData) {
     this.userUpdated.set(event);
-    this.userValidForSave = false;
   }
 
   save() {


### PR DESCRIPTION
## Summary

Phase 3 (housekeeping) of #2788 (see [audit/plan](https://claude.ai/code/artifact/b5e00fa9-259e-4eea-9309-38287a751e91)) — `userValidForSave` was set to `false` in `userDataUpdated()` but never read anywhere in the component or template. The save button's actual enabled state is driven by `isSaveEnabled()` (`formComponent.isValid()`), so this was dead state left over from an earlier implementation, not something worth converting to a signal.

## Test plan
- [x] `ng test` — full suite (539 tests) passes
- [x] `ng lint` — passes