### PR TITLE
Add ArchUnit rules securing REST controller conventions

### DIFF
--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
@@ -1,6 +1,33 @@
 package at.wrk.tafel.admin.backend.architecture
 
+import at.wrk.tafel.admin.backend.architecture.conditions.HaveApiRequestMappingPathCondition
+import at.wrk.tafel.admin.backend.modules.base.country.CountryController
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeController
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods
+import org.springframework.web.bind.annotation.RestController
 
 @AnalyzeClasses(packages = ["at.wrk.tafel.admin.backend"])
-internal class ProjectSpecificRulesTest
+internal class ProjectSpecificRulesTest {
+
+    @ArchTest
+    val `rest controllers should be mapped under api so the security filter chain covers them` = classes()
+        .that().areAnnotatedWith(RestController::class.java)
+        .should(HaveApiRequestMappingPathCondition)
+
+    @ArchTest
+    val `rest controllers should not expose database entities directly` = noMethods()
+        .that().arePublic()
+        .and().areDeclaredInClassesThat().areAnnotatedWith(RestController::class.java)
+        .and().areDeclaredInClassesThat().areNotAssignableTo(CountryController::class.java)
+        .and().areDeclaredInClassesThat().areNotAssignableTo(EmployeeController::class.java)
+        .should().haveRawReturnType(resideInAPackage("..database.model.."))
+        .because(
+            "controllers should map entities to DTOs instead of returning them directly from an endpoint - " +
+                "CountryController and EmployeeController are exempted for now as they still access repositories directly"
+        )
+
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/conditions/HaveApiRequestMappingPathCondition.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/conditions/HaveApiRequestMappingPathCondition.kt
@@ -1,0 +1,34 @@
+package at.wrk.tafel.admin.backend.architecture.conditions
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import org.springframework.web.bind.annotation.RequestMapping
+
+/**
+ * The security filter chain (see WebSecurityConfig) only requires authentication for paths
+ * under `/api` - everything else is implicitly permitted. Controllers must therefore be
+ * mapped under `/api` or they'd be served without any authentication check.
+ */
+object HaveApiRequestMappingPathCondition : ArchCondition<JavaClass>("have a @RequestMapping path starting with /api") {
+
+    override fun check(item: JavaClass, events: ConditionEvents) {
+        val requestMapping = item.tryGetAnnotationOfType(RequestMapping::class.java)
+        if (!requestMapping.isPresent) {
+            events.add(SimpleConditionEvent.violated(item, "${item.name} has no class-level @RequestMapping"))
+            return
+        }
+
+        val paths = requestMapping.get().value.ifEmpty { requestMapping.get().path }
+        if (paths.isEmpty() || paths.any { !it.startsWith("/api") }) {
+            events.add(
+                SimpleConditionEvent.violated(
+                    item,
+                    "${item.name} has @RequestMapping path(s) ${paths.toList()} not starting with /api"
+                )
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- Evaluated Konsist vs. ArchUnit for the Kotlin backend (#2799) and, while digging through the controllers to look for additional opportunities, found two invariants that were followed by convention but never enforced by a test.
- **Controllers must be mapped under `/api`**: `WebSecurityConfig` only requires authentication for `/api/**` requests; anything mapped outside that falls through to `permitAll()`. A new `HaveApiRequestMappingPathCondition` ArchUnit condition fails the build if a `@RestController`'s `@RequestMapping` path doesn't start with `/api`.
- **Controllers must not return JPA entities directly**: a new rule fails the build if a public controller method's return type resides in `..database.model..`, preventing entity leakage into API responses (lazy-loaded fields, internal columns, etc). Scoped to public methods only, so the existing private `mapEntity(): Dto` helper pattern used across controllers is unaffected.
- `CountryController` and `EmployeeController` are exempted from the entity rule for now — they read from repositories directly instead of going through a service layer, which is a separate, pre-existing decision left out of scope here.

Decision on Konsist vs. ArchUnit: staying on ArchUnit. Module-boundary enforcement is already owned by Spring Modulith (`ModularityTest`), and the concerns found here are either ArchUnit's core strength (layering/dependency checks) or well within its custom-condition API — switching would mean re-implementing ArchUnit's built-in `GeneralCodingRules` (already used in `GeneralCodingRulesTest`) by hand for no functional gain, plus onboarding a new dependency through this repo's pinned dependency-lock/verification pipeline.

## Test plan
- [x] `./gradlew :backend:test --tests "at.wrk.tafel.admin.backend.architecture.*"` passes locally, confirming both new rules hold against the current codebase.