### PR TITLE
Add sortOrder + drag-and-drop reordering to Shelters

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionStatisticShelterEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionStatisticShelterEntity.kt
@@ -40,4 +40,7 @@ class DistributionStatisticShelterEntity : BaseChangeTrackingEntity() {
 
     @Column(name = "persons_count")
     var personsCount: Int? = null
+
+    @Column(name = "sort_order")
+    var sortOrder: Int? = null
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/ShelterEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/ShelterEntity.kt
@@ -45,4 +45,7 @@ class ShelterEntity : BaseChangeTrackingEntity() {
 
     @Column(name = "enabled")
     var enabled: Boolean? = null
+
+    @Column(name = "sort_order")
+    var sortOrder: Int? = null
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
@@ -55,7 +55,9 @@ class DashboardService(
     private fun getStatisticsData(currentDistribution: DistributionEntity?): DashboardStatisticsData = DashboardStatisticsData(
         employeeCount = currentDistribution?.statistic?.employeeCount.takeIf { it != 0 },
         // Intentionally names, not shelter ids: statistics keep a historic copy independent of later shelter renames/deletions
-        selectedShelterNames = currentDistribution?.statistic?.shelters?.mapNotNull { it.name } ?: emptyList(),
+        selectedShelterNames = currentDistribution?.statistic?.shelters
+            ?.sortedWith(compareBy({ it.sortOrder ?: 0 }, { it.name }))
+            ?.mapNotNull { it.name } ?: emptyList(),
     )
 
     private fun getLogisticsData(currentDistribution: DistributionEntity): DashboardLogisticsData = DashboardLogisticsData(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
@@ -353,6 +353,7 @@ class DistributionService(
                     addressCity = it.addressCity
                     addressDoor = it.addressDoor
                     personsCount = it.personsCount
+                    sortOrder = it.sortOrder
                 }
             }.toMutableList()
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
@@ -3,6 +3,7 @@ package at.wrk.tafel.admin.backend.modules.logistics
 import at.wrk.tafel.admin.backend.modules.logistics.internal.ShelterService
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterListResponse
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterReorderRequest
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 
@@ -33,4 +34,12 @@ class SheltersController(
         @PathVariable shelterId: Long,
         @RequestBody updatedShelter: Shelter,
     ): Shelter = shelterService.updateShelter(shelterId, updatedShelter)
+
+    @PostMapping("/reorder")
+    fun reorderShelters(
+        @RequestBody request: ShelterReorderRequest,
+    ): ShelterListResponse {
+        shelterService.reorderShelters(request.shelterIds)
+        return ShelterListResponse(shelters = shelterService.getAllShelters())
+    }
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
@@ -18,12 +18,12 @@ class ShelterService(
     @Transactional
     fun getActiveShelters(): List<Shelter> = shelterRepository.findByEnabledIsTrue()
         .map { mapShelter(it) }
-        .sortedBy { it.name }
+        .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
     @Transactional
     fun getAllShelters(): List<Shelter> = shelterRepository.findAll()
         .map { mapShelter(it) }
-        .sortedBy { it.name }
+        .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
     fun createShelter(shelter: Shelter): Shelter {
         val shelterEntity = ShelterEntity().apply {
@@ -37,6 +37,7 @@ class ShelterService(
             note = shelter.note
             personsCount = shelter.personsCount
             enabled = shelter.enabled
+            sortOrder = nextSortOrder()
         }
 
         // attach contacts
@@ -65,6 +66,7 @@ class ShelterService(
         note = shelterEntity.note,
         personsCount = shelterEntity.personsCount!!,
         enabled = shelterEntity.enabled!!,
+        sortOrder = shelterEntity.sortOrder ?: 0,
         contacts = shelterEntity.contacts.map {
             ShelterContact(
                 firstname = it.firstname,
@@ -88,6 +90,7 @@ class ShelterService(
         shelterEntity.note = updatedShelter.note
         shelterEntity.personsCount = updatedShelter.personsCount
         shelterEntity.enabled = updatedShelter.enabled
+        shelterEntity.sortOrder = updatedShelter.sortOrder
 
         // replace contacts
         shelterEntity.contacts = updatedShelter.contacts.map { contact ->
@@ -102,4 +105,17 @@ class ShelterService(
         val savedEntity = shelterRepository.save(shelterEntity)
         return mapShelter(savedEntity)
     }
+
+    @Transactional
+    fun reorderShelters(shelterIds: List<Long>) {
+        shelterIds.forEachIndexed { index, shelterId ->
+            val entity = shelterRepository.findByIdOrNull(shelterId)
+                ?: throw TafelValidationException("Shelter with id $shelterId not found")
+
+            entity.sortOrder = index + 1
+            shelterRepository.save(entity)
+        }
+    }
+
+    private fun nextSortOrder(): Int = (shelterRepository.findAll().maxOfOrNull { it.sortOrder ?: 0 } ?: 0) + 1
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModel.kt
@@ -20,7 +20,13 @@ data class Shelter(
     val note: String?,
     val personsCount: Int,
     val enabled: Boolean,
+    val sortOrder: Int,
     val contacts: List<ShelterContact>,
+)
+
+@ExcludeFromTestCoverage
+data class ShelterReorderRequest(
+    val shelterIds: List<Long>,
 )
 
 @ExcludeFromTestCoverage

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
@@ -53,7 +53,7 @@ class DailyReportService(
             personsInSheltersTotalCount = statistic.shelters.sumOf { it.personsCount ?: 0 },
             shelters = statistic.shelters
                 .filter { it.personsCount!! > 0 }
-                .sortedBy { it.name }
+                .sortedWith(compareBy({ it.sortOrder ?: 0 }, { it.name }))
                 .map {
                     DailyReportShelterPdfModel(
                         name = it.name!!,

--- a/backend/src/main/resources/db-migration/R__00073_shelters_sortorder.sql
+++ b/backend/src/main/resources/db-migration/R__00073_shelters_sortorder.sql
@@ -1,0 +1,13 @@
+alter table if exists shelters
+    add if not exists sort_order integer default 0 not null;
+
+-- Backfills sort_order from the shelters' current de-facto order (alphabetical by name,
+-- what getActiveShelters()/getAllShelters() sort by today) so existing display order is
+-- preserved until someone drags a row. Idempotent: re-running is a no-op once consecutive.
+update shelters s
+set sort_order = renumbered.new_sort_order
+from (
+    select id, row_number() over (order by name) as new_sort_order
+    from shelters
+) renumbered
+where s.id = renumbered.id;

--- a/backend/src/main/resources/db-migration/R__00074_distribution_statistics_shelters_sortorder.sql
+++ b/backend/src/main/resources/db-migration/R__00074_distribution_statistics_shelters_sortorder.sql
@@ -1,0 +1,8 @@
+-- No backfill: distributions_statistics_shelters is a historic, denormalized snapshot (kept
+-- independent of later shelter renames/deletions - see DashboardService.getStatisticsData) with
+-- no FK back to shelters, so there is no reliable way to recover the order a past snapshot was
+-- taken in. Existing rows just default to 0 (no worse than today's arbitrary order); from now on
+-- DistributionService.updateDistributionStatisticData freezes the live shelter sort_order onto
+-- each new snapshot row at save time.
+alter table if exists distributions_statistics_shelters
+    add if not exists sort_order integer default 0 not null;

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
@@ -107,6 +107,32 @@ internal class DashboardServiceTest {
     }
 
     @Test
+    fun `get statistics sorts shelters by their frozen sortOrder, not name`() {
+        val testDistributionEntity = DistributionEntity().apply {
+            id = 123
+            endedAt = null
+            statistic = DistributionStatisticEntity().apply {
+                employeeCount = 100
+                shelters = mutableListOf(
+                    DistributionStatisticShelterEntity().apply {
+                        name = "Shelter Z"
+                        sortOrder = 1
+                    },
+                    DistributionStatisticShelterEntity().apply {
+                        name = "Shelter A"
+                        sortOrder = 2
+                    },
+                )
+            }
+        }
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity
+
+        val data = service.getData()
+
+        assertThat(data.statistics!!.selectedShelterNames).containsExactly("Shelter Z", "Shelter A")
+    }
+
+    @Test
     fun `get notes`() {
         val testNotes = "dummy-notes"
         val testDistributionEntity = DistributionEntity().apply {

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
@@ -882,9 +882,11 @@ internal class DistributionServiceTest {
         assertThat(firstShelter.addressDoor).isEqualTo(testShelter1.addressDoor)
         assertThat(firstShelter.addressCity).isEqualTo(testShelter1.addressCity)
         assertThat(firstShelter.personsCount).isEqualTo(testShelter1.personsCount)
+        assertThat(firstShelter.sortOrder).isEqualTo(testShelter1.sortOrder)
 
         val secondShelter = updatedDistributionEntity.statistic!!.shelters[1]
         assertThat(secondShelter).isNotNull
+        assertThat(secondShelter.sortOrder).isEqualTo(testShelter2.sortOrder)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/LogisticsTestdata.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/LogisticsTestdata.kt
@@ -207,6 +207,7 @@ val testShelter1 = ShelterEntity().apply {
     note = "Note 1"
     personsCount = 1
     enabled = true
+    sortOrder = 1
 }
 
 val testDistributionStatisticShelterEntity1 = DistributionStatisticShelterEntity().apply {
@@ -233,6 +234,7 @@ val testShelter2 = ShelterEntity().apply {
     note = "Note 2"
     personsCount = 2
     enabled = true
+    sortOrder = 2
 }
 
 val testShelter3 = ShelterEntity().apply {
@@ -247,6 +249,7 @@ val testShelter3 = ShelterEntity().apply {
     note = "Note 3"
     personsCount = 3
     enabled = false
+    sortOrder = 3
 }
 
 val testDistributionStatisticShelterEntity2 = DistributionStatisticShelterEntity().apply {

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/LogisticsTestdata.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/LogisticsTestdata.kt
@@ -220,6 +220,7 @@ val testDistributionStatisticShelterEntity1 = DistributionStatisticShelterEntity
     addressDoor = testShelter1.addressDoor
     addressCity = testShelter1.addressCity
     personsCount = testShelter1.personsCount
+    sortOrder = testShelter1.sortOrder
 }
 
 val testShelter2 = ShelterEntity().apply {
@@ -262,4 +263,5 @@ val testDistributionStatisticShelterEntity2 = DistributionStatisticShelterEntity
     addressDoor = testShelter2.addressDoor
     addressCity = testShelter2.addressCity
     personsCount = testShelter2.personsCount
+    sortOrder = testShelter2.sortOrder
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersControllerTest.kt
@@ -2,6 +2,8 @@ package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.ShelterService
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterListResponse
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterReorderRequest
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -34,9 +36,10 @@ class SheltersControllerTest {
             note = "Note 1",
             personsCount = 1,
             enabled = true,
+            sortOrder = 1,
             contacts = emptyList(),
         )
-        val shelter2 = shelter1.copy(id = 2, name = "Shelter 2")
+        val shelter2 = shelter1.copy(id = 2, name = "Shelter 2", sortOrder = 2)
 
         every { service.getActiveShelters() } returns listOf(shelter1, shelter2)
 
@@ -60,9 +63,10 @@ class SheltersControllerTest {
             note = "Note 1",
             personsCount = 1,
             enabled = true,
+            sortOrder = 1,
             contacts = emptyList(),
         )
-        val shelter2 = shelter1.copy(id = 2, name = "Shelter 2")
+        val shelter2 = shelter1.copy(id = 2, name = "Shelter 2", sortOrder = 2)
 
         every { service.getAllShelters() } returns listOf(shelter1, shelter2)
 
@@ -86,6 +90,7 @@ class SheltersControllerTest {
             note = "Note 1",
             personsCount = 1,
             enabled = true,
+            sortOrder = 1,
             contacts = emptyList(),
         )
         val updatedShelter = Shelter(
@@ -100,6 +105,7 @@ class SheltersControllerTest {
             note = "Note 2",
             personsCount = 2,
             enabled = false,
+            sortOrder = 1,
             contacts = emptyList(),
         )
         every { service.updateShelter(any(), any()) } returns updatedShelter
@@ -126,10 +132,11 @@ class SheltersControllerTest {
             note = "New note",
             personsCount = 5,
             enabled = true,
+            sortOrder = 0,
             contacts = emptyList(),
         )
 
-        val createdShelter = newShelter.copy(id = 42L)
+        val createdShelter = newShelter.copy(id = 42L, sortOrder = 1)
 
         every { service.createShelter(any()) } returns createdShelter
 
@@ -139,5 +146,36 @@ class SheltersControllerTest {
         verify {
             service.createShelter(newShelter)
         }
+    }
+
+    @Test
+    fun `reorder shelters`() {
+        val shelter1 = Shelter(
+            id = 1,
+            name = "Shelter 1",
+            addressStreet = "Street",
+            addressHouseNumber = "1",
+            addressStairway = "A",
+            addressPostalCode = 12345,
+            addressDoor = "1",
+            addressCity = "City 1",
+            note = "Note 1",
+            personsCount = 1,
+            enabled = true,
+            sortOrder = 2,
+            contacts = emptyList(),
+        )
+        val shelter2 = shelter1.copy(id = 2, name = "Shelter 2", sortOrder = 1)
+        val request = ShelterReorderRequest(shelterIds = listOf(2L, 1L))
+
+        every { service.reorderShelters(request.shelterIds) } returns Unit
+        every { service.getAllShelters() } returns listOf(shelter2, shelter1)
+
+        val response = controller.reorderShelters(request)
+
+        assertThat(response).isEqualTo(
+            ShelterListResponse(shelters = listOf(shelter2, shelter1)),
+        )
+        verify { service.reorderShelters(request.shelterIds) }
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
@@ -49,6 +49,7 @@ class ShelterServiceTest {
                 note = testShelter1.note,
                 personsCount = testShelter1.personsCount!!,
                 enabled = testShelter1.enabled!!,
+                sortOrder = testShelter1.sortOrder!!,
                 contacts = emptyList(),
             ),
         )
@@ -74,6 +75,7 @@ class ShelterServiceTest {
                 note = testShelter1.note,
                 personsCount = testShelter1.personsCount!!,
                 enabled = testShelter1.enabled!!,
+                sortOrder = testShelter1.sortOrder!!,
                 contacts = emptyList(),
             ),
         )
@@ -93,6 +95,7 @@ class ShelterServiceTest {
             note = "Updated note",
             personsCount = 5,
             enabled = false,
+            sortOrder = 5,
             contacts = emptyList(),
         )
 
@@ -105,7 +108,7 @@ class ShelterServiceTest {
     }
 
     @Test
-    fun `create shelter`() {
+    fun `create shelter assigns next sort order after the current max, ignoring the input value`() {
         val createInput = Shelter(
             id = 0L,
             name = "New Shelter",
@@ -118,9 +121,11 @@ class ShelterServiceTest {
             note = "New note",
             personsCount = 5,
             enabled = true,
+            sortOrder = 999,
             contacts = emptyList(),
         )
 
+        every { shelterRepository.findAll() } returns listOf(testShelter1, testShelter2, testShelter3)
         every { shelterRepository.save(any()) } answers {
             val arg = firstArg() as ShelterEntity
             arg.id = 42
@@ -142,11 +147,42 @@ class ShelterServiceTest {
                 note = createInput.note,
                 personsCount = createInput.personsCount,
                 enabled = createInput.enabled,
+                sortOrder = 4,
                 contacts = createInput.contacts,
             ),
         )
 
         verify { shelterRepository.save(any()) }
+    }
+
+    @Test
+    fun `create shelter assigns sort order 1 when no shelters exist yet`() {
+        val createInput = Shelter(
+            id = 0L,
+            name = "New Shelter",
+            addressStreet = "New Street",
+            addressHouseNumber = "10",
+            addressStairway = null,
+            addressPostalCode = 11111,
+            addressDoor = null,
+            addressCity = "New City",
+            note = "New note",
+            personsCount = 5,
+            enabled = true,
+            sortOrder = 999,
+            contacts = emptyList(),
+        )
+
+        every { shelterRepository.findAll() } returns emptyList()
+        every { shelterRepository.save(any()) } answers {
+            val arg = firstArg() as ShelterEntity
+            arg.id = 42
+            arg
+        }
+
+        val result = service.createShelter(createInput)
+
+        assertThat(result.sortOrder).isEqualTo(1)
     }
 
     @Test
@@ -163,6 +199,7 @@ class ShelterServiceTest {
             note = "New note",
             personsCount = 5,
             enabled = true,
+            sortOrder = 0,
             contacts = listOf(
                 ShelterContact(firstname = "Max", lastname = "Mustermann", phone = "0123456789"),
             ),
@@ -200,6 +237,7 @@ class ShelterServiceTest {
             note = "Updated note",
             personsCount = 5,
             enabled = false,
+            sortOrder = 5,
             contacts = listOf(
                 ShelterContact(firstname = "Erika", lastname = "Musterfrau", phone = "0987654321"),
             ),
@@ -226,6 +264,43 @@ class ShelterServiceTest {
             .hasMessage("Shelter with id 99 not found")
     }
 
+    @Test
+    fun `reorder shelters assigns sequential sort order matching the given order`() {
+        val entity1 = ShelterEntity().apply {
+            id = 1
+            sortOrder = 200
+        }
+        val entity2 = ShelterEntity().apply {
+            id = 2
+            sortOrder = 100
+        }
+        val entity3 = ShelterEntity().apply {
+            id = 3
+            sortOrder = 300
+        }
+
+        every { shelterRepository.findByIdOrNull(3L) } returns entity3
+        every { shelterRepository.findByIdOrNull(1L) } returns entity1
+        every { shelterRepository.findByIdOrNull(2L) } returns entity2
+        every { shelterRepository.save(any()) } answers { firstArg() as ShelterEntity }
+
+        service.reorderShelters(listOf(3L, 1L, 2L))
+
+        assertThat(entity3.sortOrder).isEqualTo(1)
+        assertThat(entity1.sortOrder).isEqualTo(2)
+        assertThat(entity2.sortOrder).isEqualTo(3)
+        verify(exactly = 3) { shelterRepository.save(any()) }
+    }
+
+    @Test
+    fun `reorder shelters throws exception when a shelter is not found`() {
+        every { shelterRepository.findByIdOrNull(99L) } returns null
+
+        assertThatThrownBy { service.reorderShelters(listOf(99L)) }
+            .isInstanceOf(TafelValidationException::class.java)
+            .hasMessage("Shelter with id 99 not found")
+    }
+
     private fun testShelter3ShelterModel() = Shelter(
         id = testShelter3.id!!,
         name = testShelter3.name!!,
@@ -238,6 +313,7 @@ class ShelterServiceTest {
         note = testShelter3.note,
         personsCount = testShelter3.personsCount!!,
         enabled = testShelter3.enabled!!,
+        sortOrder = testShelter3.sortOrder!!,
         contacts = emptyList(),
     )
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportServiceTest.kt
@@ -2,6 +2,7 @@ package at.wrk.tafel.admin.backend.modules.reporting
 
 import at.wrk.tafel.admin.backend.common.pdf.PDFService
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
+import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticShelterEntity
 import at.wrk.tafel.admin.backend.modules.logistics.testDistributionStatisticShelterEntity1
 import at.wrk.tafel.admin.backend.modules.logistics.testDistributionStatisticShelterEntity2
 import at.wrk.tafel.admin.backend.modules.reporting.internal.DailyReportPdfModel
@@ -110,5 +111,32 @@ internal class DailyReportServiceTest {
                 personCount = 2,
             ),
         )
+    }
+
+    @Test
+    fun `shelters are sorted by their frozen sortOrder, not name`() {
+        val statistic = DistributionStatisticEntity().apply {
+            shelters = listOf(
+                DistributionStatisticShelterEntity().apply {
+                    name = "Shelter Z"
+                    personsCount = 1
+                    sortOrder = 1
+                },
+                DistributionStatisticShelterEntity().apply {
+                    name = "Shelter A"
+                    personsCount = 2
+                    sortOrder = 2
+                },
+            ).toMutableList()
+        }
+
+        every { pdfService.generatePdf(any(), any()) } returns ByteArray(0)
+
+        service.generateDailyReportPdf(statistic)
+
+        val pdfModelSlot = slot<DailyReportPdfModel>()
+        verify { pdfService.generatePdf(capture(pdfModelSlot), any()) }
+
+        assertThat(pdfModelSlot.captured.shelters.map { it.name }).containsExactly("Shelter Z", "Shelter A")
     }
 }

--- a/frontend/src/main/webapp/src/app/api/shelter-api.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/api/shelter-api.service.spec.ts
@@ -33,7 +33,8 @@ describe('ShelterApiService', () => {
           addressCity: 'Test City',
           note: 'Test Note',
           personsCount: 100,
-          enabled: true
+          enabled: true,
+          sortOrder: 1
         },
         {
           id: 2,
@@ -46,7 +47,8 @@ describe('ShelterApiService', () => {
           addressCity: 'Test City',
           note: 'Test Note 2',
           personsCount: 200,
-          enabled: true
+          enabled: true,
+          sortOrder: 2
         }
       ]
     };
@@ -74,7 +76,8 @@ describe('ShelterApiService', () => {
           addressCity: 'Test City',
           note: 'Test Note',
           personsCount: 100,
-          enabled: true
+          enabled: true,
+          sortOrder: 1
         },
         {
           id: 2,
@@ -87,7 +90,8 @@ describe('ShelterApiService', () => {
           addressCity: 'Test City',
           note: 'Test Note 2',
           personsCount: 200,
-          enabled: true
+          enabled: true,
+          sortOrder: 2
         }
       ]
     };
@@ -121,6 +125,50 @@ describe('ShelterApiService', () => {
 
     const req = httpMock.expectOne({method: 'POST', url: '/shelters/1'});
     req.flush(updatedShelter);
+    httpMock.verify();
+  });
+
+  it('reorder shelters', () => {
+    const testResponse: ShelterListResponse = {
+      shelters: [
+        {
+          id: 2,
+          name: 'Test Shelter 2',
+          addressStreet: 'Test Street',
+          addressHouseNumber: '1',
+          addressStairway: 'A',
+          addressDoor: 'B',
+          addressPostalCode: 12345,
+          addressCity: 'Test City',
+          note: 'Test Note 2',
+          personsCount: 200,
+          enabled: true,
+          sortOrder: 1
+        },
+        {
+          id: 1,
+          name: 'Test Shelter 1',
+          addressStreet: 'Test Street',
+          addressHouseNumber: '1',
+          addressStairway: 'A',
+          addressDoor: 'B',
+          addressPostalCode: 12345,
+          addressCity: 'Test City',
+          note: 'Test Note',
+          personsCount: 100,
+          enabled: true,
+          sortOrder: 2
+        }
+      ]
+    };
+
+    apiService.reorderShelters([2, 1]).subscribe((data: ShelterListResponse) => {
+      expect(data).toEqual(testResponse);
+    });
+
+    const req = httpMock.expectOne({method: 'POST', url: '/shelters/reorder'});
+    expect(req.request.body).toEqual({shelterIds: [2, 1]});
+    req.flush(testResponse);
     httpMock.verify();
   });
 

--- a/frontend/src/main/webapp/src/app/api/shelter-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/shelter-api.service.ts
@@ -22,6 +22,10 @@ export class ShelterApiService {
     return this.http.post<ShelterItem>('/shelters', shelter);
   }
 
+  reorderShelters(shelterIds: number[]): Observable<ShelterListResponse> {
+    return this.http.post<ShelterListResponse>('/shelters/reorder', {shelterIds});
+  }
+
 }
 
 export interface ShelterListResponse {
@@ -40,6 +44,7 @@ export interface ShelterItem {
   note: string;
   personsCount: number;
   enabled: boolean;
+  sortOrder: number;
   contacts?: ShelterContact[];
 }
 

--- a/frontend/src/main/webapp/src/app/common/pipes/format-shelter-address.pipe.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/pipes/format-shelter-address.pipe.spec.ts
@@ -24,7 +24,8 @@ describe('FormatShelterAddressPipe', () => {
       addressDoor: '21',
       addressPostalCode: 1020,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);
@@ -42,7 +43,8 @@ describe('FormatShelterAddressPipe', () => {
       addressHouseNumber: '10',
       addressPostalCode: 1030,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);
@@ -61,7 +63,8 @@ describe('FormatShelterAddressPipe', () => {
       addressHouseNumber: '88',
       addressPostalCode: 1070,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);
@@ -79,7 +82,8 @@ describe('FormatShelterAddressPipe', () => {
       addressHouseNumber: '1',
       addressPostalCode: 1010,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);
@@ -111,7 +115,8 @@ describe('FormatShelterAddressPipe', () => {
       addressDoor: '',
       addressPostalCode: 1050,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);
@@ -131,7 +136,8 @@ describe('FormatShelterAddressPipe', () => {
       addressDoor: '   ',
       addressPostalCode: 1090,
       addressCity: 'Wien',
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     };
 
     const result = pipe.transform(shelter);

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statics-input.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statics-input.component.spec.ts
@@ -26,7 +26,8 @@ describe('DistributionStatisticsInputComponent', () => {
       addressCity: 'Test City',
       note: 'Test Note',
       personsCount: 100,
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     },
     {
       id: 2,
@@ -39,7 +40,8 @@ describe('DistributionStatisticsInputComponent', () => {
       addressCity: 'Test City',
       note: 'Test Note 2',
       personsCount: 200,
-      enabled: true
+      enabled: true,
+      sortOrder: 2
     }
   ];
   const testDistribution: DistributionItem = {
@@ -105,7 +107,8 @@ describe('DistributionStatisticsInputComponent', () => {
         addressCity: 'Wien',
         note: 'Testnote 1',
         personsCount: 100,
-        enabled: true
+        enabled: true,
+        sortOrder: 1
       },
       {
         id: 2,
@@ -116,7 +119,8 @@ describe('DistributionStatisticsInputComponent', () => {
         addressCity: 'Wien',
         note: 'Testnote 2',
         personsCount: 50,
-        enabled: true
+        enabled: true,
+        sortOrder: 2
       }
     ]);
 

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.spec.ts
@@ -35,7 +35,8 @@ describe('SelectSheltersComponent', () => {
       addressCity: 'Test City',
       note: 'Test Note',
       personsCount: 100,
-      enabled: true
+      enabled: true,
+      sortOrder: 1
     },
     {
       id: 2,
@@ -48,7 +49,8 @@ describe('SelectSheltersComponent', () => {
       addressCity: 'Test City',
       note: 'Test Note 2',
       personsCount: 200,
-      enabled: true
+      enabled: true,
+      sortOrder: 2
     }
   ];
 

--- a/frontend/src/main/webapp/src/app/modules/dashboard/resolver/dashboard-shelters-resolver-component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/resolver/dashboard-shelters-resolver-component.spec.ts
@@ -43,7 +43,8 @@ describe('DashboardSheltersDataResolver', () => {
           addressCity: 'Test City',
           note: 'Test Note',
           personsCount: 100,
-          enabled: true
+          enabled: true,
+          sortOrder: 1
         },
         {
           id: 2,
@@ -56,7 +57,8 @@ describe('DashboardSheltersDataResolver', () => {
           addressCity: 'Test City',
           note: 'Test Note 2',
           personsCount: 200,
-          enabled: true
+          enabled: true,
+          sortOrder: 2
         }
       ]
     };

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-details-dialog.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-details-dialog.component.spec.ts
@@ -19,6 +19,7 @@ describe('ShelterDetailsDialogComponent', () => {
     note: 'Note',
     personsCount: 2,
     enabled: true,
+    sortOrder: 1,
     contacts: [
       { firstname: 'John', lastname: 'Doe', phone: '012345' }
     ]

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-edit-dialog.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-edit-dialog.component.spec.ts
@@ -18,6 +18,7 @@ describe('ShelterEditDialogComponent', () => {
     note: 'Note',
     personsCount: 2,
     enabled: true,
+    sortOrder: 1,
     contacts: [{ firstname: 'John', lastname: 'Doe', phone: '123' }]
   };
 

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-edit-dialog.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/dialogs/shelter-edit-dialog.component.ts
@@ -46,6 +46,9 @@ export class ShelterEditDialogComponent {
     note: [this.data.shelter?.note ?? ''],
     personsCount: [this.data.shelter?.personsCount ?? '', [Validators.required]],
     enabled: [this.data.shelter?.enabled ?? true],
+    // Not user-editable here - preserved as-is on edit, auto-assigned by the backend on
+    // create; reordering afterwards happens via drag-and-drop.
+    sortOrder: [this.data.shelter?.sortOrder ?? 0],
     contacts: this.fb.array((this.data.shelter?.contacts ?? []).map(c => this.createContactGroup(c)))
   });
 

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.html
@@ -10,7 +10,16 @@
     </mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <table mat-table [dataSource]="shelters()?.shelters ?? []" testid="shelters-table">
+    <table mat-table [dataSource]="shelters()?.shelters ?? []" testid="shelters-table"
+           cdkDropList [cdkDropListData]="shelters()?.shelters ?? []" (cdkDropListDropped)="drop($event)">
+      <ng-container matColumnDef="drag">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let shelter; let i = index">
+          <fa-icon [icon]="faGripVertical" cdkDragHandle class="cursor-move"
+                   [attr.testid]="'dragShelterHandle-' + i"></fa-icon>
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="active">
         <th mat-header-cell *matHeaderCellDef>Aktiv</th>
         <td mat-cell *matCellDef="let shelter; let i = index">
@@ -59,6 +68,7 @@
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; let i = index; columns: displayedColumns;"
+          cdkDrag [cdkDragData]="row"
           [attr.testid]="'shelters-row-' + i"></tr>
     </table>
   </mat-card-content>

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.spec.ts
@@ -1,35 +1,64 @@
 import {TestBed} from '@angular/core/testing';
 import {provideHttpClient, withXhr} from '@angular/common/http';
 import {provideHttpClientTesting} from '@angular/common/http/testing';
+import {CdkDragDrop} from '@angular/cdk/drag-drop';
 import {SettingsSheltersComponent} from './settings-shelters.component';
-import {ShelterApiService, ShelterListResponse} from '../../../../api/shelter-api.service';
+import {ShelterApiService, ShelterItem, ShelterListResponse} from '../../../../api/shelter-api.service';
 import {MatDialog} from '@angular/material/dialog';
-import {of} from 'rxjs';
+import {of, throwError} from 'rxjs';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 
 describe('SettingsSheltersComponent', () => {
+  const testShelter1: ShelterItem = {
+    id: 1,
+    name: 'Shelter 1',
+    addressStreet: 'Street',
+    addressHouseNumber: '1',
+    addressPostalCode: 1234,
+    addressCity: 'City 1',
+    note: 'Note 1',
+    personsCount: 1,
+    enabled: true,
+    sortOrder: 1
+  };
+  const testShelter2: ShelterItem = {
+    id: 2,
+    name: 'Shelter 2',
+    addressStreet: 'Street',
+    addressHouseNumber: '2',
+    addressPostalCode: 4321,
+    addressCity: 'City 2',
+    note: 'Note 2',
+    personsCount: 2,
+    enabled: true,
+    sortOrder: 2
+  };
+
+  let shelterApiMock: Partial<ShelterApiService>;
+  let toastrMock: Partial<TafelToastrService>;
 
   beforeEach(() => {
-    const shelterApiMock: Partial<ShelterApiService> = {
-      getAllShelters: () => of<ShelterListResponse>({ shelters: [] })
+    shelterApiMock = {
+      getAllShelters: vi.fn(() => of<ShelterListResponse>({shelters: [testShelter1, testShelter2]})),
+      reorderShelters: vi.fn(() => of<ShelterListResponse>({shelters: [testShelter2, testShelter1]}))
     };
 
-    const toastrMock: Partial<TafelToastrService> = {
+    toastrMock = {
       success: vi.fn(),
       error: vi.fn()
     };
 
     const matDialogMock: Partial<MatDialog> = {
-      open: vi.fn(() => ({ afterClosed: () => of(undefined) })) as any
+      open: vi.fn(() => ({afterClosed: () => of(undefined)})) as any
     };
 
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(withXhr()),
         provideHttpClientTesting(),
-        { provide: ShelterApiService, useValue: shelterApiMock },
-        { provide: TafelToastrService, useValue: toastrMock },
-        { provide: MatDialog, useValue: matDialogMock }
+        {provide: ShelterApiService, useValue: shelterApiMock},
+        {provide: TafelToastrService, useValue: toastrMock},
+        {provide: MatDialog, useValue: matDialogMock}
       ]
     }).compileComponents();
   });
@@ -46,7 +75,33 @@ describe('SettingsSheltersComponent', () => {
     fixture.detectChanges();
     const component = fixture.componentInstance;
     expect(component['shelters']()).toBeDefined();
-    expect(component['shelters']()?.shelters.length).toBe(0);
+    expect(component['shelters']()?.shelters.length).toBe(2);
+  });
+
+  it('drop() reorders optimistically and persists the new order', () => {
+    const fixture = TestBed.createComponent(SettingsSheltersComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    const event = {previousIndex: 0, currentIndex: 1} as CdkDragDrop<ShelterItem[]>;
+    component['drop'](event);
+
+    expect(component['shelters']()?.shelters.map(s => s.id)).toEqual([testShelter2.id, testShelter1.id]);
+    expect(shelterApiMock.reorderShelters).toHaveBeenCalledWith([testShelter2.id, testShelter1.id]);
+  });
+
+  it('drop() reverts and shows an error toast when persisting fails', () => {
+    shelterApiMock.reorderShelters = vi.fn(() => throwError(() => new Error('failed')));
+
+    const fixture = TestBed.createComponent(SettingsSheltersComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    const event = {previousIndex: 0, currentIndex: 1} as CdkDragDrop<ShelterItem[]>;
+    component['drop'](event);
+
+    expect(toastrMock.error).toHaveBeenCalled();
+    expect(shelterApiMock.getAllShelters).toHaveBeenCalledTimes(2);
   });
 
 });

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.ts
@@ -16,10 +16,11 @@ import {
   MatRowDef,
   MatTable
 } from '@angular/material/table';
+import {CdkDrag, CdkDragDrop, CdkDragHandle, CdkDropList, moveItemInArray} from '@angular/cdk/drag-drop';
 import {ShelterApiService, ShelterItem, ShelterListResponse} from '../../../../api/shelter-api.service';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {MatButton} from '@angular/material/button';
-import {faEye, faEyeSlash, faMagnifyingGlass, faPencil, faPlus} from '@fortawesome/free-solid-svg-icons';
+import {faEye, faEyeSlash, faGripVertical, faMagnifyingGlass, faPencil, faPlus} from '@fortawesome/free-solid-svg-icons';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 
 @Component({
@@ -42,7 +43,10 @@ import {TafelToastrService} from '../../../../common/components/tafel-toastr/taf
     MatTable,
     MatHeaderCellDef,
     FaIconComponent,
-    MatButton
+    MatButton,
+    CdkDropList,
+    CdkDrag,
+    CdkDragHandle
   ]
 })
 export class SettingsSheltersComponent {
@@ -52,7 +56,7 @@ export class SettingsSheltersComponent {
 
   private _shelters = signal<ShelterListResponse | null>(null);
   protected shelters = this._shelters;
-  displayedColumns = ['active', 'name', 'address', 'persons', 'actions'];
+  displayedColumns = ['drag', 'active', 'name', 'address', 'persons', 'actions'];
 
   constructor() {
     this.loadShelters();
@@ -128,9 +132,24 @@ export class SettingsSheltersComponent {
     });
   }
 
+  protected drop(event: CdkDragDrop<ShelterItem[]>) {
+    const reordered = [...(this.shelters()?.shelters ?? [])];
+    moveItemInArray(reordered, event.previousIndex, event.currentIndex);
+    this._shelters.set({shelters: reordered}); // optimistic, updates in the background
+
+    this.shelterApiService.reorderShelters(reordered.map(shelter => shelter.id)).subscribe({
+      next: data => this._shelters.set(data),
+      error: () => {
+        this.toastr.error('Fehler beim Ändern der Reihenfolge', 'Fehler');
+        this.loadShelters();
+      }
+    });
+  }
+
   protected readonly faMagnifyingGlass = faMagnifyingGlass;
   protected readonly faPencil = faPencil;
   protected readonly faEye = faEye;
   protected readonly faEyeSlash = faEyeSlash;
   protected readonly faPlus = faPlus;
+  protected readonly faGripVertical = faGripVertical;
 }


### PR DESCRIPTION
## Summary
Follow-up to #2807 (food categories admin), applying the same reordering mechanism to the Shelters ("Notschlafstellen") admin page:
- New `sort_order` column on `shelters` (migration `R__00073`), backfilled from the current alphabetical order so existing display order is unaffected until someone drags a row.
- `GET /api/shelters/active` and `GET /api/shelters` now sort by `sortOrder` (name as tiebreaker) instead of just name.
- New `POST /api/shelters/reorder` endpoint (bulk reorder, same shape as the food-categories one), and `createShelter` now auto-assigns the next sort order instead of trusting client input.
- Frontend: CDK drag-and-drop wired into the admin table via a dedicated grip handle, persisting the new order in the background with optimistic UI update and revert-on-error. The existing add/edit dialog is otherwise unchanged - `sortOrder` is a hidden field there, never shown or dragged from within it.

## Test plan
- [x] `./gradlew :backend:test` and `./gradlew :backend:ktlintCheck` - pass
- [x] `npm run test-ci` (frontend) - all 574 tests pass
- [ ] Manual: open `Einstellungen → Notschlafstellen`, confirm shelters list in their current (alphabetical, now consecutively-numbered) order, drag a row to a new position and confirm it persists after reload, create a new shelter and confirm it appears last

🤖 Generated with [Claude Code](https://claude.com/claude-code)