### PR TITLE
Increase documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,9 @@ The frontend is an Angular 22 single-page application using Angular Material and
 - **dashboard**: Overview with distribution state, registered customers, food amounts, statistics input
 - **customer**: Search, create, edit, detail views with duplicate detection. Deliberately *not* renamed to match the backend's `household`/`person` model — routes, components, and `CustomerData`/`CustomerAddPersonData` DTOs are unchanged; only `customer-api.service.ts` translates to/from the backend's household+persons wire shape (main person flattened onto the customer object, other persons as `additionalPersons`)
 - **checkin**: Scanner registration, QR code reading, ticket screen for customer calls
-- **logistics**: Food collection recording (desktop/responsive layouts), route management
+- **logistics**: Food collection recording only (desktop/responsive layouts), one screen (`warenerfassung`). Route/shelter/shop/car/food-category admin CRUD screens actually live under the **settings** module below, not here.
 - **user**: User search, create, edit with password change functionality
-- **settings**: System settings and mail recipient configuration
+- **settings**: System settings and mail recipient configuration, plus admin CRUD screens for shelters (`notschlafstellen`) and food categories (`lebensmittelkategorien`), both with drag-and-drop sortOrder reordering (Angular CDK)
 - **statistics**: Chart.js-powered distribution/demographic statistics panels
 
 **Architecture Patterns:**
@@ -171,7 +171,7 @@ modules/<feature>/
 - Angular CDK 22 (component dev kit)
 - Tailwind CSS 4 (utility-first CSS framework)
 - RxJS for reactive programming
-- html5-qrcode for scanner functionality
+- @zxing/browser / @zxing/library for scanner QR decoding
 - ngx-cookie-service for session management
 - Chart.js for statistics visualization
 - FontAwesome Angular (icon library)
@@ -291,7 +291,7 @@ Authentication: Basic HTTP auth with JWT token stored in cookie.
 
 ## Special Considerations
 
-- **Distribution State**: Many features require an active distribution (started but not ended). The backend enforces this via `@ActiveDistributionRequired` annotation, and the frontend uses `tafelIfDistributionActive` directive.
+- **Distribution State**: Many features require an active distribution (started but not ended). The backend enforces this via the `@TafelActiveDistributionRequired` marker annotation, checked by a global `HandlerInterceptor` (`TafelActiveDistributionRequiredInterceptor`, not an AOP aspect) registered for all controllers; the frontend uses the `tafelIfDistributionActive` directive.
 - **Customer Duplicates**: The system detects potential duplicates based on lastname, firstname, and birthdate. Review duplicate candidates before creating customers.
 - **Income Validation**: Customer income is validated against configurable limits. The validation logic is in `IncomeValidatorService`.
 - **PDF Generation**: Uses XSL-FO templates in `backend/src/main/resources/pdf-templates/`. PDFs are generated via Apache FOP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,6 @@ The application uses PostgreSQL with Flyway for schema management. Migration fil
 - Use `resource()` for data fetching with automatic loading/error states
 - Read signals in templates with `()` - e.g., `@if (loading())`
 - Application runs in **zoneless mode** - no `ngZone.run()` needed
-- Angular signal patterns documentation referenced in `ANGULAR_SIGNAL_PATTERNS.md` does not currently exist in the repo
 
 ## API Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+This project is a solo/hobby-maintained food bank admin system, but the same conventions apply
+whether you're a future-you or an external contributor. This guide distills the setup, workflow,
+and conventions already documented in [README.md](README.md) and [AGENTS.md](AGENTS.md) into a
+single checklist.
+
+## Setup
+
+See [README.md](README.md#prerequisites) and [README.md](README.md#getting-started) for
+prerequisites (Java 26, Node.js, Docker) and the local dev loop (start infra with
+`docker compose up -d`, backend with `./gradlew :backend:bootRun --args='--spring.profiles.active=local'`,
+frontend with `npm run dev`).
+
+## Before opening a PR
+
+Run the checks locally that CI will otherwise catch:
+
+```bash
+# Backend: compile, lint, test
+./gradlew :backend:compileKotlin
+./gradlew :backend:test
+
+# Frontend: lint, unit tests
+cd frontend/src/main/webapp
+npm run lint
+npm run test-ci
+```
+
+Both backend and frontend changes should include tests. Backend unit tests are `*Test.kt`,
+integration tests (Testcontainers-backed) are `*IT.kt`; frontend unit tests are `*.spec.ts`
+(Vitest) and E2E flows live in `cypress/e2e/` (Cypress, requires the backend running with the
+`e2e` profile — see [README.md](README.md#e2e-tests)).
+
+## Enforced conventions
+
+A few conventions are enforced by automated checks, not just style guides — violating them fails
+the build, not just a review comment:
+
+- **ktlint** (backend): run via the Gradle build; fix violations with `./gradlew :backend:ktlintFormat`.
+- **ArchUnit rules** (backend, `backend/src/test/kotlin/.../architecture/`): enforce naming
+  conventions (`*Controller`, `*Service`, `*Repository`, `*Entity`) and REST controller conventions
+  (e.g. `@RequestMapping` path rules). These run as part of `:backend:test`.
+- **eslint-plugin-boundaries** (frontend, `eslint.config.js`): enforces module boundaries between
+  `app/modules/*` — don't reach into another feature module's internals; go through its public
+  API/service instead.
+- **Spring Modulith module boundaries** (backend, `package-info.java` per module): each module
+  declares `allowedDependencies`; adding a new cross-module import that isn't declared there will
+  fail module verification. See the per-module `README.md` files under
+  `backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/*/` for what each module exposes.
+
+## Code conventions
+
+See [AGENTS.md](AGENTS.md#code-conventions) for the full list (naming suffixes, package layout,
+Angular signal-based patterns, template flow-control syntax). The short version:
+
+- Backend: constructor injection, `@Transactional` on mutating service methods, converters in
+  `internal/converter/` for entity-to-DTO mapping.
+- Frontend: standalone components only (no NgModules), `input()`/`output()`/`signal()`/`computed()`
+  instead of the decorator-based equivalents, `@for`/`@if` instead of `*ngFor`/`*ngIf`.
+
+## Commit / PR style
+
+- Commit subjects and PR titles are short, imperative, present tense (e.g. "Add sortOrder support
+  to Shelters", "Fix ktlint violation in FoodCategoryServiceTest").
+- Keep PRs focused on one change; incidental fixes found along the way are welcome as separate
+  small commits but call them out in the PR description.
+- Database schema changes go in a new Flyway migration under
+  `backend/src/main/resources/db-migration/` (see [AGENTS.md](AGENTS.md#creating-a-new-database-migration)).
+
+## Dependency updates
+
+Dependabot manages routine dependency bumps. If you update `gradle/libs.versions.toml` by hand,
+regenerate the verification metadata (see
+[README.md](README.md#dependency-verification)):
+
+```bash
+./gradlew --write-verification-metadata sha256 --refresh-dependencies
+```
+
+## CI
+
+Every PR runs build, test, lint, a Docker image build, and E2E tests (see
+[README.md](README.md#cicd) for the full pipeline table). SonarCloud reports code quality and
+coverage on the PR.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/AdvisoryLockKey.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/AdvisoryLockKey.kt
@@ -10,4 +10,8 @@ enum class AdvisoryLockKey(val lockId: Long) {
     // serializes read-modify-write updates to a food collection's items to avoid
     // duplicate-key races when multiple patches for the same route/shop overlap
     PATCH_FOOD_COLLECTION_ITEM(4000L),
+
+    // serializes scanner registration's gap-filling scanner-id lookup to avoid
+    // two concurrent registrations computing and inserting the same id
+    SCANNER_REGISTRATION(5000L),
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
@@ -10,6 +10,8 @@ Enum defining all available lock keys in the system. Each key has a unique numer
 Available lock keys:
 - `CREATE_DISTRIBUTION` (1000L) - For creating new distribution events
 - `CLOSE_DISTRIBUTION` (2000L) - For closing distribution events
+- `LOGIN_ATTEMPT_TRACKING` (3000L) - Serializes concurrent login-failure updates across instances
+- `PATCH_FOOD_COLLECTION_ITEM` (4000L) - Serializes read-modify-write updates to a food collection's items to avoid duplicate-key races when multiple patches for the same route/shop overlap
 
 ### AdvisoryLockRepository
 Spring Data JPA repository providing native query methods for PostgreSQL advisory lock functions.
@@ -19,17 +21,20 @@ Service providing high-level methods to acquire and release advisory locks using
 
 ## Usage
 
-### Basic Lock Usage
+### Basic Lock Usage (`withLock`)
+
+Blocks until the lock is acquired, always releases it afterwards (even on exception), and
+returns the block's result:
 
 ```kotlin
 @Service
 class MyService(
     private val advisoryLockService: AdvisoryLockService
 ) {
-    
+
     @Transactional
-    fun criticalOperation() {
-        advisoryLockService.withLock(AdvisoryLockKey.DISTRIBUTION_MANAGEMENT) {
+    fun criticalOperation(): SomeResult {
+        return advisoryLockService.withLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
             // Critical section - only one transaction can execute this at a time
             doSomethingCritical()
         }
@@ -37,42 +42,50 @@ class MyService(
 }
 ```
 
-### Try-Lock Pattern
+### Try-Lock Pattern (`tryWithLock`)
+
+Never blocks: returns `false` immediately if the lock is already held elsewhere, `true` if it
+acquired the lock, ran the block, and released it. Real usage from `DistributionService`:
 
 ```kotlin
 @Transactional
-fun tryOperation(): Boolean {
-    return advisoryLockService.tryWithLock(AdvisoryLockKey.CUSTOMER_TICKET_ASSIGNMENT) {
-        // Execute if lock is available
-        doOperation()
+fun createNewDistribution(): DistributionEntity {
+    var result: DistributionEntity? = null
+
+    val acquired = advisoryLockService.tryWithLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
+        val currentDistribution = distributionRepository.getCurrentDistribution()
+        if (currentDistribution != null) {
+            throw TafelValidationException("Ausgabe bereits gestartet!")
+        }
+        result = /* ... create and save the distribution ... */
     }
+
+    if (!acquired) {
+        throw TafelValidationException("Ausgabe wird bereits erstellt!")
+    }
+    return result!!
 }
 ```
+
+Note `tryWithLock`'s block returns `Unit`, not a value - assign to an outer `var` (as above) to
+get a result out of it, unlike `withLock` which returns the block's value directly.
 
 ### Manual Lock Management
 
 ```kotlin
 @Transactional
 fun manualLockOperation() {
-    advisoryLockService.acquireLock(AdvisoryLockKey.FOOD_COLLECTION_UPDATE)
+    advisoryLockService.acquireLock(AdvisoryLockKey.PATCH_FOOD_COLLECTION_ITEM)
     try {
         doOperation()
     } finally {
-        advisoryLockService.releaseLock(AdvisoryLockKey.FOOD_COLLECTION_UPDATE)
+        advisoryLockService.releaseLock(AdvisoryLockKey.PATCH_FOOD_COLLECTION_ITEM)
     }
 }
 ```
 
-### Check Lock Status
-
-```kotlin
-@Transactional
-fun checkLock() {
-    if (advisoryLockService.isLockHeld(AdvisoryLockKey.DISTRIBUTION_MANAGEMENT)) {
-        // Lock is currently held by this transaction
-    }
-}
-```
+There is also a non-blocking variant of manual acquisition, `tryAcquireLock(lockKey): Boolean`,
+which `tryWithLock` is built on top of.
 
 ## Lock Types
 
@@ -93,10 +106,11 @@ To add a new lock key:
 
 ```kotlin
 enum class AdvisoryLockKey(val lockId: Long) {
-    DISTRIBUTION_MANAGEMENT(1L),
-    CUSTOMER_TICKET_ASSIGNMENT(2L),
-    FOOD_COLLECTION_UPDATE(3L),
-    MY_NEW_LOCK(4L);  // Add new lock key here
+    CREATE_DISTRIBUTION(1000L),
+    CLOSE_DISTRIBUTION(2000L),
+    LOGIN_ATTEMPT_TRACKING(3000L),
+    PATCH_FOOD_COLLECTION_ITEM(4000L),
+    MY_NEW_LOCK(5000L), // Add new lock key here - existing keys are spaced 1000 apart by convention
 }
 ```
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
@@ -12,6 +12,7 @@ Available lock keys:
 - `CLOSE_DISTRIBUTION` (2000L) - For closing distribution events
 - `LOGIN_ATTEMPT_TRACKING` (3000L) - Serializes concurrent login-failure updates across instances
 - `PATCH_FOOD_COLLECTION_ITEM` (4000L) - Serializes read-modify-write updates to a food collection's items to avoid duplicate-key races when multiple patches for the same route/shop overlap
+- `SCANNER_REGISTRATION` (5000L) - Serializes scanner registration's gap-filling scanner-id lookup to avoid two concurrent registrations computing and inserting the same id
 
 ### AdvisoryLockRepository
 Spring Data JPA repository providing native query methods for PostgreSQL advisory lock functions.
@@ -110,7 +111,8 @@ enum class AdvisoryLockKey(val lockId: Long) {
     CLOSE_DISTRIBUTION(2000L),
     LOGIN_ATTEMPT_TRACKING(3000L),
     PATCH_FOOD_COLLECTION_ITEM(4000L),
-    MY_NEW_LOCK(5000L), // Add new lock key here - existing keys are spaced 1000 apart by convention
+    SCANNER_REGISTRATION(5000L),
+    MY_NEW_LOCK(6000L), // Add new lock key here - existing keys are spaced 1000 apart by convention
 }
 ```
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
@@ -16,6 +16,15 @@ import java.sql.Connection
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
+/**
+ * Holds a single dedicated JDBC connection issuing Postgres `LISTEN sse_outbox`, and fans out
+ * incoming `NOTIFY` payloads (JSON-encoded [SseOutboxNotificationEvent]) to callbacks registered
+ * by [SseOutboxService], keyed by `notificationName`.
+ *
+ * The listener loop runs on its own coroutine and blocks in `PGConnection.getNotifications` with
+ * an effectively infinite timeout ([NOTIFICATIONS_POLL_TIMEOUT]) rather than polling - it only
+ * wakes up when Postgres delivers a notification on the connection.
+ */
 @Service
 class SseOutboxListenerService(
     private val jdbcTemplate: JdbcTemplate,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxService.kt
@@ -15,6 +15,16 @@ import java.io.IOException
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
+/**
+ * Publishing side of the SSE outbox pattern: persists an event as a row in `sse_outbox` and lets
+ * emitters subscribe to named notifications for real-time push to the frontend.
+ *
+ * Writing the row (not calling `pg_notify` directly) is what makes this an outbox: the insert
+ * commits atomically with the business transaction that produced the event, and a Postgres
+ * trigger (see migration `R__00057_added_notification_procedure.sql`) fires `pg_notify('sse_outbox', ...)`
+ * only after that commit. [SseOutboxListenerService] is the other half - it holds the single
+ * `LISTEN` connection and fans notifications back out to the callbacks registered here.
+ */
 @Service
 class SseOutboxService(
     private val jsonMapper: JsonMapper,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/checkin/ScannerRegistrationRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/checkin/ScannerRegistrationRepository.kt
@@ -7,12 +7,6 @@ import java.time.LocalDateTime
 
 interface ScannerRegistrationRepository : JpaRepository<ScannerRegistrationEntity, Long> {
 
-    @Query(value = "SELECT pg_advisory_lock(1000)", nativeQuery = true)
-    fun acquireLock()
-
-    @Query(value = "SELECT pg_advisory_unlock(1000)", nativeQuery = true)
-    fun releaseLock()
-
     @Query(
         value = """
                 SELECT COALESCE(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/RouteShopRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/RouteShopRepository.kt
@@ -1,5 +1,0 @@
-package at.wrk.tafel.admin.backend.database.model.logistics
-
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface RouteShopRepository : JpaRepository<RouteStopEntity, Long>

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
@@ -1,0 +1,77 @@
+# Base Module
+
+`base` is a grab-bag of small, shared concerns: countries, employees, and generic exception
+handling. Unlike every other feature module, **there is no `modules/base/package-info.java`** — the
+`base` package itself is not a Spring Modulith `@ApplicationModule`. Instead, each subpackage
+(`country`, `employee`, `exception`) has its own `package-info.java` annotated with
+`@org.springframework.modulith.NamedInterface("...")`, making each one an independently
+addressable, explicitly exported slice that other modules can declare a dependency on individually
+(e.g. `allowedDependencies = {"base::exception", "base::employee"}` in `logistics`'s
+`package-info.java`). Do not add a blanket `base` module dependency anywhere — always depend on the
+specific named interface (`base::country`, `base::employee`, or `base::exception`) you actually need.
+
+Entities backing this module are **not** colocated with it: they live under `database/model/base`
+(`EmployeeEntity`, `EmployeeRepository`) and `database/model/staticdata` (`CountryEntity`,
+`CountryRepository`), consistent with the repo-wide convention that entities/repositories live in
+`database/model/`, not `modules/`.
+
+## Components
+
+### `country` — `@NamedInterface("country")`
+- [`CountryController`](country/CountryController.kt): `GET /api/countries`, requires only
+  `isAuthenticated()` (no specific permission) — returns the full country list, unpaginated.
+- [`CountryModel.kt`](country/CountryModel.kt): exposes `Country(id, code, name)` and
+  `CountryListResponse`.
+- Backed by `CountryRepository`/`CountryEntity` in `database/model/staticdata` (table
+  `static_countries`).
+- **Only consumer:** the `household` module. `HouseholdConverter` resolves a `Person`'s
+  `CountryEntity` by id (`countryRepository.findById(person.country.id)`), and
+  `HouseholdConverter.mapCountryToResponse` maps it back to the `base.country.Country` DTO for the
+  `Person.country` field in `HouseholdResponseModel.kt`. `household`'s `package-info.java` lists
+  `base::country` in `allowedDependencies` accordingly. No other module references
+  `modules.base.country`.
+
+### `employee` — `@NamedInterface("employee")`
+- [`EmployeeController`](employee/EmployeeController.kt): `GET /api/employees` (paginated search by
+  name/personnel number) and `POST /api/employees` (create), both gated behind `LOGISTICS`
+  authority (not a typo — employee management is treated as a logistics concern, since employees are
+  mainly used to track who staffed a distribution/collection).
+- [`EmployeeModel.kt`](employee/EmployeeModel.kt): `Employee(id, personnelNumber, firstname,
+  lastname)`, `EmployeeListResponse`, `EmployeeCreateRequest`.
+- Backed by `EmployeeRepository`/`EmployeeEntity` in `database/model/base` (table `employees`).
+- **Only consumer:** the `logistics` module (`FoodCollectionService`, `FoodCollectionsModel`), which
+  declares `base::employee` in its `allowedDependencies`. Note that `household` does **not** depend
+  on `base::employee` even though `HouseholdEntity.issuer` and `HouseholdNoteEntity.employee` are
+  both `EmployeeEntity` references — `household` reaches `EmployeeEntity` directly through
+  `UserEntity.employee` (a `database.model` type, not a `modules.base.employee` type), so it never
+  needs this named interface.
+
+### `exception` — `@NamedInterface("exception")`
+- [`TafelExceptions.kt`](exception/TafelExceptions.kt): two exception types,
+  `TafelException` and `TafelValidationException` (both `RuntimeException` with an optional
+  `HttpStatus`; when `status` is null the handler below defaults to 400 Bad Request). They are
+  functionally near-identical today — the distinction is intent/logging severity, not behavior.
+- [`GenericExceptionHandler`](exception/GenericExceptionHandler.kt): a `@ControllerAdvice` with
+  three handlers:
+  - `TafelException` → logged at `warn`.
+  - `TafelValidationException` → logged at `debug` (expected/user-facing validation failures
+    shouldn't spam the warn log).
+  - anything else (`Exception`) → logged at `error`, always answered as 500.
+  All three build a localized `TafelErrorResponse` (`http-error.<status>.title` message key looked
+  up via `MessageSource`) and special-case SSE requests: if the incoming request's `Accept` header
+  contains `text/event-stream`, the error is written as an `event: error` SSE frame instead of a
+  normal JSON error body, so error responses don't break an open EventSource connection.
+- **Widely used:** `household`, `logistics`, `distribution`, and `settings` all declare
+  `base::exception` in their `allowedDependencies` and throw `TafelValidationException` for
+  business-rule violations (e.g. "Kunde Nr. X bereits vorhanden!" in `HouseholdController`). This is
+  the module to reach for whenever a service needs to reject a request with a clear HTTP status and
+  a user-facing message.
+
+## Adding to this module
+
+Because there's no top-level `base` `@ApplicationModule`, adding a new shared subpackage means:
+1. Create the subpackage under `modules/base/<name>/`.
+2. Add a `package-info.java` with `@org.springframework.modulith.NamedInterface("<name>")`.
+3. Put entities/repositories under `database/model/<...>`, not under `modules/base/<name>/`.
+4. Any module that wants to use it must add `"base::<name>"` to its own `allowedDependencies` in its
+   `package-info.java` — Spring Modulith's build-time verification will fail the build otherwise.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/package-info.java
@@ -1,2 +1,6 @@
+/**
+ * Country reference data (ISO country list) used for address fields across the application.
+ * Exposed to other modules via the {@code country} named interface.
+ */
 @org.springframework.modulith.NamedInterface("country")
 package at.wrk.tafel.admin.backend.modules.base.country;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/package-info.java
@@ -1,2 +1,6 @@
+/**
+ * Employee records referenced by change tracking (created/updated by) across other modules.
+ * Exposed to other modules via the {@code employee} named interface.
+ */
 @org.springframework.modulith.NamedInterface("employee")
 package at.wrk.tafel.admin.backend.modules.base.employee;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/package-info.java
@@ -1,2 +1,6 @@
+/**
+ * Shared exception types and centralized exception handling used across all modules.
+ * Exposed to other modules via the {@code exception} named interface.
+ */
 @org.springframework.modulith.NamedInterface("exception")
 package at.wrk.tafel.admin.backend.modules.base.exception;

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/README.md
@@ -1,0 +1,134 @@
+# Checkin Module
+
+This is the smallest feature module in the backend — two Kotlin files plus one entity/repository pair.
+It handles **scanner device registration** and **relaying raw scan results in real time**. It does *not*
+know what a scan means (customer lookup, ticket assignment, etc.) — that's entirely up to the frontend.
+
+## Components
+
+### ScannerController (`ScannerController.kt`)
+`@RestController` under `/api`, class-level `@PreAuthorize("hasAnyAuthority('SCANNER', 'CHECKIN')")`
+(applies to every endpoint below, none override it):
+- `GET /api/scanners` — list all currently-registered scanner ids.
+- `POST /api/scanners/register?scannerId=<optional>` — register a new scanner, or refresh/re-claim an
+  existing one; returns the assigned `scannerId`.
+- `POST /api/scanners/{scannerId}/results?scanResult=<long>` — accept a raw scan result value (e.g. a
+  decoded QR code payload) for a given scanner and publish it via the SSE outbox.
+- `GET /api/sse/scanners/{scannerId}/results` — SSE stream of `ScanResult` events for one specific
+  scanner (filtered by `scannerId` client-side of the outbox forwarding, via `acceptFilter`).
+
+### ScannerService (`internal/ScannerService.kt`)
+- `registerScanner(existingScannerId: Int? = null)` — see gotchas below for its exact (non-obvious)
+  behavior.
+- `getScannerIds()` — all registered scanner ids, sorted.
+- `cleanupScannerRegistrations()` — `@Scheduled(fixedDelay = 1, TimeUnit.HOURS)`, deletes registrations
+  whose `registrationTime` is older than `SCANNER_REGISTRATIONS_KEEP_DAYS` (2 days). This is what frees up
+  a scanner id for reuse — see below.
+
+### ScannerRegistrationEntity / ScannerRegistrationRepository (`database/model/checkin/`)
+Table `scanner_registrations` (`id`, `registration_time`, `scanner_id`). Per
+`R__00058_add_scanner_registration.sql`, `scanner_id` has a **DB-level `UNIQUE NOT NULL`** constraint —
+this is why the registration flow needs an advisory lock (see below).
+
+## What a "scanner" actually is here
+
+A scanner is just an integer id (`scannerId`) that a physical/browser-based scanning client registers
+for itself once, then uses to tag every subsequent scan result and to open its own SSE stream. There is
+no concept of "which customer" or "which distribution" anywhere in this module — `ScanResult.value` is
+an opaque `Long` the caller decides the meaning of. This is a direct consequence of the module boundary
+below.
+
+## `allowedDependencies = {}`
+
+```java
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.checkin;
+```
+
+`checkin` is not allowed to import any other feature module (`distribution`, `household`, `logistics`,
+etc.) — confirmed: neither `ScannerController` nor `ScannerService` reference anything under
+`modules.*` besides their own `internal` package. Its only outside dependencies are shared
+infrastructure that sits *outside* the `modules` tree and isn't subject to the Modulith check:
+`common.sse.SseUtil`, `database.common.sseoutbox.SseOutboxService`, and its own
+`database.model.checkin.*` entity/repository.
+
+**Architectural implication:** `checkin` cannot call into `distribution` to assign a ticket, nor into
+`household` to look up a customer from a scanned code. Turning a physical scan into "customer X gets
+ticket Y" is entirely a frontend responsibility — the frontend listens on
+`/api/sse/scanners/{scannerId}/results`, decodes/interprets `ScanResult.value` itself, and then calls the
+appropriate `household`/`distribution` endpoints separately. If a future feature needs the backend
+itself to react to a scan (e.g. server-side auto ticket assignment), it cannot be added directly inside
+`ScannerService` without either loosening `allowedDependencies`, or wiring it through the SSE outbox /
+an event, keeping `checkin` itself dependency-free.
+
+## Gotchas
+
+### `registerScanner()` uses its own raw advisory lock, not the shared one
+```kotlin
+@Query(value = "SELECT pg_advisory_lock(1000)", nativeQuery = true)
+fun acquireLock()
+
+@Query(value = "SELECT pg_advisory_unlock(1000)", nativeQuery = true)
+fun releaseLock()
+```
+This is a **session-level** lock (`pg_advisory_lock`/`pg_advisory_unlock`, manually released), called
+directly from `ScannerRegistrationRepository` — it does **not** go through
+`database.common.lock.AdvisoryLockService` / `AdvisoryLockKey` (see that module's own README). Two
+consequences worth knowing:
+- It bypasses the project's usual lock bookkeeping (`AdvisoryLockKey` enum), so there's nowhere else in
+  the codebase that documents "lock id `1000` is taken by scanner registration."
+- PostgreSQL advisory locks share **one keyspace regardless of session vs. transaction scope** — only
+  the release semantics differ. `AdvisoryLockKey.CREATE_DISTRIBUTION` (in the `distribution` module's
+  lock enum) also uses the numeric id `1000`, just via `pg_try_advisory_xact_lock`. Because both go
+  through the single-`bigint`-argument overload of the advisory lock functions, they occupy the *same*
+  lock id in Postgres. In practice the window is tiny (the session lock here is held only for the
+  duration of `registerScanner()`, a few statements), but it's a real, easy-to-miss cross-module
+  collision on a raw numeric id. If you add a new lock anywhere, prefer registering it in the shared
+  `AdvisoryLockKey` enum instead of a magic number, precisely to avoid this.
+
+### `getNextScannerId()` fills gaps, it doesn't just increment
+```sql
+SELECT COALESCE(
+  (SELECT t.scanner_id + 1 FROM (
+     SELECT scanner_id, LEAD(scanner_id) OVER (ORDER BY scanner_id) AS next_scanner_id
+     FROM scanner_registrations
+   ) t
+   WHERE next_scanner_id IS NULL OR next_scanner_id > t.scanner_id + 1
+   ORDER BY t.scanner_id LIMIT 1),
+  (SELECT COALESCE(MAX(scanner_id), 0) + 1 FROM scanner_registrations)
+) AS next_available_scanner_id;
+```
+Scanner ids are **reused**, not monotonically increasing: this finds the smallest gap in the existing
+`scanner_id` sequence, and only falls back to `MAX + 1` if there is no gap. Combined with the hourly
+`cleanupScannerRegistrations()` job (registrations older than 2 days are deleted), a scanner id that
+stopped being used two days ago will be handed out again to the next new registration. Don't assume
+scanner ids are stable/unique over the long term, or that a higher id was registered more recently.
+
+### `registerScanner(existingScannerId)` branch behavior is subtle
+```kotlin
+val nextScannerId = scannerRegisteredRepository.getNextScannerId()
+var scannerRegistration =
+    if (existingScannerId != null) {
+        scannerRegisteredRepository.findByScannerId(existingScannerId)
+    } else {
+        scannerRegisteredRepository.findByScannerId(nextScannerId)
+    }
+```
+- If the caller passes `existingScannerId` and that registration is still present (not yet cleaned up),
+  its `registrationTime` is refreshed (effectively a heartbeat/keep-alive) and the same id is returned.
+- If the caller passes `existingScannerId` but it has since been cleaned up (expired), a **brand new**
+  registration is created using `nextScannerId` instead — the caller silently gets a *different* scanner
+  id back, not an error. Frontend code re-registering an expired scanner must not assume it gets the same
+  id it asked for; it must always use the id in the response.
+- If `existingScannerId` is `null`, the `findByScannerId(nextScannerId)` lookup is effectively always a
+  miss (by construction, `getNextScannerId()` only ever returns an id currently *not* in use), so this
+  branch always inserts a new row. The lookup there is vestigial/defensive rather than load-bearing.
+
+### The advisory lock protects a real DB constraint
+The lock exists because `scanner_id` is `UNIQUE NOT NULL` at the DB level (see
+`R__00058_add_scanner_registration.sql`) and the "find next free gap" query above is a
+check-then-act: without serializing registrations, two concurrent `POST /api/scanners/register` calls
+could compute the same gap and both try to insert it, and the second one would fail the unique
+constraint instead of getting a different id.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/README.md
@@ -65,28 +65,20 @@ an event, keeping `checkin` itself dependency-free.
 
 ## Gotchas
 
-### `registerScanner()` uses its own raw advisory lock, not the shared one
+### `registerScanner()` goes through the shared `AdvisoryLockService`
 ```kotlin
-@Query(value = "SELECT pg_advisory_lock(1000)", nativeQuery = true)
-fun acquireLock()
-
-@Query(value = "SELECT pg_advisory_unlock(1000)", nativeQuery = true)
-fun releaseLock()
+fun registerScanner(existingScannerId: Int? = null): Int = advisoryLockService.withLock(AdvisoryLockKey.SCANNER_REGISTRATION) {
+    // ...
+}
 ```
-This is a **session-level** lock (`pg_advisory_lock`/`pg_advisory_unlock`, manually released), called
-directly from `ScannerRegistrationRepository` — it does **not** go through
-`database.common.lock.AdvisoryLockService` / `AdvisoryLockKey` (see that module's own README). Two
-consequences worth knowing:
-- It bypasses the project's usual lock bookkeeping (`AdvisoryLockKey` enum), so there's nowhere else in
-  the codebase that documents "lock id `1000` is taken by scanner registration."
-- PostgreSQL advisory locks share **one keyspace regardless of session vs. transaction scope** — only
-  the release semantics differ. `AdvisoryLockKey.CREATE_DISTRIBUTION` (in the `distribution` module's
-  lock enum) also uses the numeric id `1000`, just via `pg_try_advisory_xact_lock`. Because both go
-  through the single-`bigint`-argument overload of the advisory lock functions, they occupy the *same*
-  lock id in Postgres. In practice the window is tiny (the session lock here is held only for the
-  duration of `registerScanner()`, a few statements), but it's a real, easy-to-miss cross-module
-  collision on a raw numeric id. If you add a new lock anywhere, prefer registering it in the shared
-  `AdvisoryLockKey` enum instead of a magic number, precisely to avoid this.
+This used to be a raw `pg_advisory_lock(1000)`/`pg_advisory_unlock(1000)` pair called directly from
+`ScannerRegistrationRepository`, bypassing `database.common.lock.AdvisoryLockService`/`AdvisoryLockKey`
+entirely (see that module's own README). Because PostgreSQL advisory locks share **one keyspace
+regardless of session vs. transaction scope**, that raw numeric id `1000` collided with
+`AdvisoryLockKey.CREATE_DISTRIBUTION`, which also uses `1000` (via `pg_try_advisory_xact_lock`). It's
+now registered as its own key, `AdvisoryLockKey.SCANNER_REGISTRATION` (`5000L`), and acquired via
+`AdvisoryLockService.withLock` like everywhere else. If you add a new lock anywhere, always register it
+in the shared `AdvisoryLockKey` enum instead of a raw numeric id, precisely to avoid this class of bug.
 
 ### `getNextScannerId()` fills gaps, it doesn't just increment
 ```sql

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerService.kt
@@ -1,5 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.checkin.internal
 
+import at.wrk.tafel.admin.backend.database.common.lock.AdvisoryLockKey
+import at.wrk.tafel.admin.backend.database.common.lock.AdvisoryLockService
 import at.wrk.tafel.admin.backend.database.model.checkin.ScannerRegistrationEntity
 import at.wrk.tafel.admin.backend.database.model.checkin.ScannerRegistrationRepository
 import org.slf4j.Logger
@@ -13,6 +15,7 @@ import java.util.concurrent.TimeUnit
 @Service
 class ScannerService(
     private val scannerRegisteredRepository: ScannerRegistrationRepository,
+    private val advisoryLockService: AdvisoryLockService,
 ) {
 
     companion object {
@@ -22,9 +25,7 @@ class ScannerService(
     }
 
     @Transactional
-    fun registerScanner(existingScannerId: Int? = null): Int {
-        scannerRegisteredRepository.acquireLock()
-
+    fun registerScanner(existingScannerId: Int? = null): Int = advisoryLockService.withLock(AdvisoryLockKey.SCANNER_REGISTRATION) {
         val nextScannerId = scannerRegisteredRepository.getNextScannerId()
         var scannerRegistration =
             if (existingScannerId != null) {
@@ -48,8 +49,7 @@ class ScannerService(
             logger.info("Registered existing scanner with id: {}", existingScannerId)
         }
 
-        scannerRegisteredRepository.releaseLock()
-        return scannerRegistration.scannerId!!
+        scannerRegistration.scannerId!!
     }
 
     fun getScannerIds(): List<Int> = scannerRegisteredRepository.findAll().mapNotNull { it.scannerId }.sorted()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/package-info.java
@@ -1,3 +1,7 @@
+/**
+ * Scanner registration and customer check-in via QR code scanning.
+ * Has no allowed dependencies on other application modules.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/README.md
@@ -1,0 +1,117 @@
+# Dashboard Module
+
+This module serves the single overview screen shown to employees while a distribution is running: registered
+household count, ticket processing progress, logistics/food-collection progress, the selected shelters and
+employee count for the current statistic, and free-text distribution notes. There is exactly one endpoint,
+and it is a long-lived Server-Sent-Events (SSE) stream, not a request/response poll.
+
+## Components
+
+Only three source files (plus `package-info.java`):
+
+- **`DashboardController`** – `GET /api/sse/dashboard`. Opens an `SseEmitter`, immediately pushes one snapshot,
+  then subscribes to a single outbox notification (`dashboard_update`) and re-pushes a fresh snapshot every
+  time that notification fires. It never queries the database itself.
+- **`internal/DashboardService`** – Builds the `DashboardData` snapshot from scratch on every call
+  (`getData()`). Looks up the current open distribution
+  (`DistributionRepository.getCurrentDistribution()`), and if none is open, returns an all-null
+  `DashboardData` (the frontend renders this as "no active distribution"). If one is open, it assembles
+  ticket counts, registered-household count, statistics (employee count + shelter names), and logistics
+  (food collections vs. total routes, total food weight).
+- **`DashboardResponseModel`** (`DashboardData`, `DashboardTicketsData`, `DashboardStatisticsData`,
+  `DashboardLogisticsData`) – Plain DTOs serialized straight onto the SSE stream as JSON.
+
+## The `allowedDependencies = {}` puzzle
+
+`package-info.java` declares this module with **no allowed dependencies on any other application module**:
+
+```java
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.dashboard;
+```
+
+Yet the dashboard clearly needs data that "belongs" to `distribution` (registered households, tickets,
+statistics) and `logistics` (routes, food collections). It gets away with this because **it never imports
+anything from `modules.distribution` or `modules.logistics`**. Instead, `DashboardService` talks directly to
+JPA repositories/entities under `database.model.*`:
+
+```kotlin
+import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
+import at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseholdRepository
+import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
+import at.wrk.tafel.admin.backend.database.model.distribution.getCurrentDistribution
+import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
+```
+
+`database.model.*` is shared persistence infrastructure, not an `ApplicationModule` package under
+`modules.*` — Spring Modulith's dependency check only enforces boundaries between `modules.*` packages, so
+reading shared entities/repositories directly is not a violation. In effect: **dashboard has no allowed
+module dependencies because it depends on the database, not on the other modules' code.** This makes it a
+read-only aggregation module by construction — it cannot call into `distribution`/`logistics` service logic,
+only re-read the same rows those modules write.
+
+One consequence worth knowing: `getStatisticsData()` reads shelter *names* off of
+`DistributionStatisticEntity.shelters` rather than joining live `Shelter` rows, deliberately — see the
+comment in `DashboardService`:
+
+```kotlin
+// Intentionally names, not shelter ids: statistics keep a historic copy independent of later shelter renames/deletions
+```
+
+So even the "shelter" data displayed here is a frozen snapshot captured at statistic-save time by the
+`distribution` module, not a live reference — another reason dashboard doesn't need a dependency on
+`logistics`' `Shelter` entities to render it correctly.
+
+## How the SSE update actually gets triggered (the outbox flow)
+
+The dashboard's SSE endpoint pushes an initial snapshot on connect, then waits for a
+`dashboard_update` notification via `SseOutboxService.listenForNotificationEvents<Unit>(...)`. Note the
+`resultType = null` / generic type `Unit` — the notification payload is **ignored on purpose**; whenever
+`dashboard_update` fires, the callback just calls `dashboardService.getData()` again and pushes a brand new
+snapshot. This module never has to know *what* changed, only *that* something did.
+
+Unlike `distribution`'s or `checkin`'s SSE producers (`DistributionController`, `ScannerController`), which
+call `SseOutboxService.saveOutboxEntry(...)` from Kotlin code to enqueue an outbox row, **nothing in this
+module — or anywhere in application code — ever calls `saveOutboxEntry("dashboard_update", ...)`.** The
+`dashboard_update` rows are inserted purely at the database level:
+
+1. Flyway migration `R__00059_dashboard_add_notification_trigger.sql` defines
+   `insert_dashboard_update_to_sse_outbox()` and attaches it as an `AFTER INSERT OR UPDATE OR DELETE` trigger
+   on `distributions`, `distributions_households`, `distributions_statistics`,
+   `distributions_statistics_shelters`, `food_collections`, and `food_collections_items`. Any write to any of
+   those tables (by any module, through any code path — even a raw SQL migration) inserts a row into
+   `sse_outbox` with `notification_name = 'dashboard_update'` and `payload = NULL`.
+2. The insert is deliberately coalesced to at most one row per second:
+   `current_second := date_trunc('second', NOW())` combined with a
+   `UNIQUE (notification_name, event_time)` constraint and `ON CONFLICT ... DO NOTHING` — so a burst of
+   writes in the same table (e.g. saving several food collection items) produces at most one dashboard
+   refresh per second, not one per row.
+3. A second, generic trigger from `R__00057_added_notification_procedure.sql`
+   (`trigger_sse_outbox_notification` → `sse_outbox_notify_channel()`) fires on every `sse_outbox` insert
+   (regardless of `notification_name`) and calls `pg_notify('sse_outbox', ...)` with the notification name and
+   payload as JSON.
+4. `SseOutboxListenerService` (in `database.common.sseoutbox`, shared infra, not dashboard-specific) holds a
+   dedicated JDBC connection that runs `LISTEN sse_outbox;` and polls `PGConnection.getNotifications()` in a
+   background coroutine. When a notification arrives it looks up any callbacks registered for that
+   `notification_name` in an in-memory map and invokes them.
+5. `DashboardController`'s call to `listenForNotificationEvents(notificationName = "dashboard_update", ...)`
+   is what registered the callback in step 4. When it fires, the controller re-fetches and re-sends the
+   dashboard snapshot over its own `SseEmitter`.
+
+**Practical implication:** if you add a new table/column whose changes should be reflected on the dashboard,
+you need to add a trigger for it in a new Flyway migration (following the `R__00059` pattern) — adding a
+Kotlin-side event publish call in `distribution`/`logistics` will *not* make the dashboard refresh, because
+the dashboard module has no code path listening for anything except the DB-level `dashboard_update`
+notification.
+
+## Gotchas
+
+- `DashboardService.getData()` is called on every SSE push, not just once — it re-runs several JPA queries
+  and one `routeRepository.findAll()` per refresh. This is fine at Tafel's data volumes but is not a
+  cheap/cached read.
+- If there is no currently open distribution, `getData()` returns an all-null `DashboardData`; controllers
+  and the frontend must treat `null` as "nothing to show", not "zero".
+- `foodAmountTotal` sums `calculateWeight()` across every item of every food collection of the *current*
+  distribution only — it has no relation to the historic per-year totals computed in the `reporting` module.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/package-info.java
@@ -1,3 +1,9 @@
+/**
+ * Real-time overview page: distribution state, registered customers, and food amounts,
+ * delivered to the frontend via Server-Sent Events. Has no allowed dependencies on other
+ * application modules; cross-module data is consumed via Spring Modulith event publication
+ * rather than direct calls.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
@@ -1,0 +1,223 @@
+# Distribution Module
+
+This module manages **food distribution events** ("Ausgaben") — the day-to-day process of opening a
+distribution, calling customers up by ticket number, recording statistics, and closing the event out
+(which triggers PDF/CSV report generation and emails).
+
+## Core Concept: "the current distribution"
+
+There is no `active` boolean column. A distribution is "current"/"active" purely by data shape:
+
+```kotlin
+// database/model/distribution/DistributionRepository.kt
+fun DistributionRepository.getCurrentDistribution(): DistributionEntity? {
+    val latest = findFirstByOrderByIdDesc()
+    return if (latest?.endedAt == null) latest else null
+}
+```
+
+The row with the highest `id` is the current one; it's "active" only if its `ended_at` is still `null`.
+This means **only one distribution can ever be open at a time**, and distributions are implicitly
+ordered by id/creation, not by an explicit status column. `createNewDistribution()` refuses to create a
+new one while an unfinished one exists (`"Ausgabe bereits gestartet!"`).
+
+## Components
+
+### Entities (`database/model/distribution/`)
+- **DistributionEntity** (table `distributions`) — one row per distribution event: `startedAt`,
+  `endedAt`, free-text `notes`, the user who started/ended it, its 1:1 `statistic`, and its
+  `households`/`foodCollections` associations.
+- **DistributionHouseholdEntity** (table `distributions_households`) — a household's ticket within a
+  distribution: `ticketNumber`, `processed` (has this ticket already been called/served?),
+  `costContributionPaid`.
+- **DistributionStatisticEntity** / **DistributionStatisticShelterEntity** (tables
+  `distributions_statistics`, and a shelter snapshot list) — the statistics snapshot for a
+  *closed* distribution. `isEmpty()` is used to validate that a distribution isn't closed without
+  statistics ever having been entered.
+
+### DistributionService (`internal/DistributionService.kt`)
+The core service. Notable methods: `createNewDistribution()`, `assignHouseholdToDistribution()`,
+`getCurrentTicketNumber()` / `closeCurrentTicketAndGetNext()` / `reopenAndGetPreviousTicket()` /
+`deleteCurrentTicket()` (the ticket queue workflow), `validateClose()` / `closeDistribution()`,
+`generateHouseholdListPdf()`, `updateDistributionStatisticData()` / `updateDistributionNoteData()`,
+and `sendMails()` (manual re-send, see below).
+
+### Controllers
+- **DistributionController** — `/api/distributions*`: list, create, close, notes, statistics,
+  household-list PDF, manual mail re-send, and the `/api/sse/distributions` SSE stream that pushes
+  `DistributionItemUpdate` whenever the current distribution starts/ends.
+- **DistributionTicketController** (`internal/ticket/`) — `/api/distributions/tickets/households/{id}`:
+  get/delete the ticket assigned to a household.
+- **DistributionTicketScreenController** (`internal/ticket/`) — `/api/distributions/ticket-screen/*`
+  (`show-text`, `show-current`, `show-previous`, `show-next`) plus
+  `/api/sse/distributions/ticket-screen/current`: drives the fullscreen "now serving" ticket display.
+
+### Post-processor chain (`internal/postprocessors/`)
+- **DistributionPostProcessor** — a `fun interface` with a single `process(distribution, statistic)`
+  method.
+- **DistributionPostProcessorService** — runs `@Async` right after a distribution is closed. It
+  (re)computes and saves the statistics snapshot, then invokes every `DistributionPostProcessor` bean
+  Spring injects as `List<DistributionPostProcessor>`, catching and logging exceptions per-processor so
+  one failure doesn't block the others.
+- **DailyReportMailPostProcessor** — builds the daily-report PDF via `reporting.DailyReportService`
+  and emails it (skipped with a warning log if no households were served).
+- **StatisticMailPostProcessor** — builds CSV exports via `reporting.StatisticExportService` and
+  emails them.
+- **ReturnBoxesMailPostProcessor** — builds a per-route/per-shop "which empty boxes need to go back to
+  which shop" summary and emails it. Doesn't touch `reporting`.
+- **MissingCostContributionPostProcessor** — for every household whose `costContributionPaid == false`
+  on this distribution, adds the current cost-contribution amount to `household.pendingCostContribution`
+  so it can be collected next time. Doesn't touch `reporting` either.
+
+There are no `@Order` annotations on the post-processors — they run in whatever order Spring happens to
+inject the `List<DistributionPostProcessor>` bean. If processing order ever matters, that needs to be
+added explicitly.
+
+### DistributionStatisticService (`internal/statistic/`)
+Builds the `DistributionStatisticEntity` snapshot at close time: household/person/infant counts (new,
+prolonged, updated), average persons per household, and logistics numbers (shops visited, food weight
+collected, route km). Only called from `DistributionPostProcessorService`, never on-demand.
+
+## Why `distribution` depends on `reporting`
+
+`package-info.java` declares:
+```java
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"base::exception", "reporting"}
+)
+```
+Only two of the four post-processors actually reach into `reporting`:
+- `DailyReportMailPostProcessor` → `DailyReportService.generateDailyReportPdf(statistic)`
+- `StatisticMailPostProcessor` → `StatisticExportService.exportStatisticFiles(statistic)`
+
+Both are only called after a distribution closes. The household-list PDF (`generateHouseholdListPdf()`)
+uses the generic `common.pdf.PDFService` instead, not `reporting`.
+
+Note that `database.model.*` (entities/repositories for `household`, `logistics`, `auth`, etc.) is
+**not** subject to the Spring Modulith `allowedDependencies` check — only the `modules.*` package tree
+is. `DistributionService` and `MissingCostContributionPostProcessor` freely use `HouseholdRepository`,
+`ShelterRepository`, and `RouteRepository` from `database.model.*` even though `household` and
+`logistics` are not listed as allowed dependencies.
+
+## `@TafelActiveDistributionRequired` — how it actually works
+
+This is **not** the annotation name used in top-level docs (`@ActiveDistributionRequired`) — the real
+class is `at.wrk.tafel.admin.backend.common.api.TafelActiveDistributionRequired`, and it's **not** an
+AOP aspect. It's a plain marker annotation (`@Target(CLASS, FUNCTION)`), enforced by a Spring MVC
+`HandlerInterceptor`:
+
+```kotlin
+// common/api/TafelActiveDistributionRequiredInterceptor.kt
+override fun preHandle(request: ..., response: ..., handler: Any): Boolean {
+    if (handler is HandlerMethod) {
+        val methodAnnotation = handler.method.getAnnotation(TafelActiveDistributionRequired::class.java)
+        val classAnnotation = handler.beanType.getAnnotation(TafelActiveDistributionRequired::class.java)
+        if ((methodAnnotation != null || classAnnotation != null) && distributionRepository.getCurrentDistribution() == null) {
+            throw TafelValidationException("Ausgabe nicht gestartet!")
+        }
+    }
+    return true
+}
+```
+
+It's registered globally in `config/WebMvcConfig.kt` for *every* controller in the app (it's also used
+outside this module, e.g. `logistics/FoodCollectionsController`), not just `distribution`'s own
+controllers.
+
+**Gotcha:** this check only runs for requests dispatched through Spring MVC. Several `DistributionService`
+methods (`getCurrentTicketNumber`, `reopenAndGetPreviousTicket`, `closeCurrentTicketAndGetNext`,
+`assignHouseholdToDistribution`, `generateHouseholdListPdf`, `updateDistributionStatisticData`,
+`updateDistributionNoteData`) call `getCurrentDistribution()!!` with a force-unwrap, assuming a
+distribution is active. That assumption is only safe because every controller entry point into these
+methods is annotated with `@TafelActiveDistributionRequired`. If you add a new caller that bypasses the
+controller layer (another service, a `@Scheduled` job, a test calling the service directly without an
+active distribution), you'll get an `NPE`, not the friendly `TafelValidationException`.
+
+## Advisory locks: `CREATE_DISTRIBUTION` / `CLOSE_DISTRIBUTION`
+
+Confirmed from `database/common/lock/AdvisoryLockKey.kt`:
+```kotlin
+enum class AdvisoryLockKey(val lockId: Long) {
+    CREATE_DISTRIBUTION(1000L),
+    CLOSE_DISTRIBUTION(2000L),
+    LOGIN_ATTEMPT_TRACKING(3000L),
+    PATCH_FOOD_COLLECTION_ITEM(4000L),
+}
+```
+(the existing lock module's README shows stale example key names/ids that don't match this — always
+read the enum itself, not the README prose there.)
+
+Both `createNewDistribution()` and `closeDistribution()` use `advisoryLockService.tryWithLock(...)` —
+the **non-blocking** variant (`pg_try_advisory_xact_lock`). If the lock is already held, the operation
+doesn't wait; it fails immediately with a user-facing message ("Eine neue Ausgabe wird gerade
+gestartet...", "Die Ausgabe wird gerade geschlossen...") telling the user to reload. This is a
+deliberate UX choice: two admins double-clicking "start"/"close" at the same time should get a clear
+error, not a hung request.
+
+`closeDistribution()` also has a subtlety around transactions: inside the lock, it commits `endedAt` in
+its own `REQUIRES_NEW` transaction *before* kicking off the `@Async` post-processor chain. The code
+comments this explicitly:
+```kotlin
+// Use REQUIRES_NEW to ensure endedAt is committed before async post-processor runs
+```
+This matters because the post-processor runs on a different thread/connection — if `endedAt` were only
+visible in the (still-open, lock-holding) outer transaction, the async thread's own transaction might not
+see it yet.
+
+## Ticket numbering — correction vs. common assumption
+
+Contributors sometimes assume the backend computes/generates the next ticket number. **It doesn't.**
+`AssignHouseholdRequest(householdId, ticketNumber)` carries a ticket number chosen by the *caller*
+(the check-in/scanner flow); `DistributionService.assignHouseholdToDistribution()` only validates it:
+
+```kotlin
+val existingTicket = distribution.households.firstOrNull { it.ticketNumber == ticketNumber }
+// Can't assign to another household if already assigned but ok if it's the same household
+if (existingTicket != null && existingHousehold?.household?.id != householdId) {
+    throw TafelValidationException("Ticketnummer $ticketNumber bereits vergeben!")
+}
+```
+There is no server-side range check for the 1–999 range mentioned in top-level docs — that range is a
+paper-ticket-booklet/UI convention, not something enforced in this module. The backend's only
+invariant is *uniqueness of ticket number per distribution*, and it explicitly allows re-submitting the
+same `(householdId, ticketNumber)` pair (used to flip `costContributionPaid` without erroring).
+
+Once assigned, the "queue" is walked in `ticketNumber` order using the `processed` flag:
+- `getFirstUnprocessedDistributionHouseholdEntity()` → who's currently being called
+- `closeCurrentTicketAndGetNext()` marks the current one `processed = true` and returns the next
+- `reopenAndGetPreviousTicket()` finds the *last processed* ticket and flips it back to unprocessed (for
+  "oops, go back one")
+
+## Real-time updates: outbox pattern, not raw pub/sub
+
+Both the distribution-state stream and the ticket-screen stream go through
+`database.common.sseoutbox.SseOutboxService` rather than pushing directly to open `SseEmitter`s:
+
+1. A mutation (e.g. `closeAndNotify()` in `DistributionController`, or `saveToOutbox()` in
+   `DistributionTicketScreenController`) calls `sseOutboxService.saveOutboxEntry(notificationName, payload)`,
+   which persists a row to the `sse_outbox` table and fires `pg_notify` (via a DB trigger/outbox flush —
+   see the sseoutbox module) on the `sse_outbox` channel.
+2. `SseOutboxListenerService` holds one dedicated JDBC connection with `LISTEN sse_outbox;` and
+   dispatches incoming Postgres notifications to any registered callback for that `notificationName`.
+3. Each open `SseEmitter` (one per browser tab / ticket-screen display) registers a callback via
+   `sseOutboxService.forwardNotificationEventsToSse(...)`, optionally filtered (e.g. the scanner-results
+   stream in `checkin` filters by `scannerId`).
+
+This means the "current" distribution/ticket state is only ever pushed on write — a newly-connecting SSE
+client is fed an out-of-band "initial state" event first (`sseOutboxService.sendEvent(...)` called
+directly before `forwardNotificationEventsToSse`), because the outbox mechanism only forwards *future*
+notifications, not backlog.
+
+**Note on auth:** `DistributionTicketScreenController.listenForChanges()` (the SSE endpoint for the
+fullscreen ticket display) intentionally has no `@PreAuthorize`, per the class-level comment: the
+physical ticket-screen monitor authenticates as a low-privilege display account, so the read-only SSE
+stream is left open to any authenticated user while the state-changing endpoints
+(`show-next`/`show-previous`/`show-text`) require `CHECKIN`/`SCANNER`.
+
+## Manually re-sending mails
+
+`POST /api/distributions/{distributionId}/send-mails` (`DistributionService.sendMails()`) re-runs
+`DailyReportMailPostProcessor`, `ReturnBoxesMailPostProcessor`, and `StatisticMailPostProcessor` for an
+already-closed distribution — useful if a mail failed to deliver. It deliberately does **not** re-run
+`MissingCostContributionPostProcessor`, since re-running that would double-count pending cost
+contributions for households that already had them added when the distribution originally closed.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionPostProcessorService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionPostProcessorService.kt
@@ -8,6 +8,16 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 
+/**
+ * Runs the [DistributionPostProcessor] chain after a distribution closes.
+ *
+ * `process` is `@Async`, so it runs off the request thread in its own transaction, decoupled
+ * from whatever committed the distribution's closed state - the [DistributionEntity] is
+ * therefore re-fetched by id here rather than passed in directly, so its lazy associations are
+ * bound to this method's own persistence context instead of a stale/detached one. All registered
+ * [DistributionPostProcessor] beans then run in sequence, each wrapped in its own try/catch so
+ * one processor failing (e.g. a mail post-processor) does not stop the others from running.
+ */
 @Service
 class DistributionPostProcessorService(
     private val distributionStatisticService: DistributionStatisticService,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/DistributionPostProcessor.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/DistributionPostProcessor.kt
@@ -3,6 +3,14 @@ package at.wrk.tafel.admin.backend.modules.distribution.internal.postprocessors
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
 
+/**
+ * Contract for a side effect run after a distribution closes and its statistic is saved (see
+ * [at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionPostProcessorService]).
+ * Every Spring bean implementing this interface is picked up automatically (injected as a
+ * `List<DistributionPostProcessor>`) and run in an isolated try/catch - one processor throwing
+ * does not prevent the others from running. Implementations: [DailyReportMailPostProcessor],
+ * [StatisticMailPostProcessor], [MissingCostContributionPostProcessor], [ReturnBoxesMailPostProcessor].
+ */
 fun interface DistributionPostProcessor {
     fun process(distribution: DistributionEntity, statistic: DistributionStatisticEntity)
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/package-info.java
@@ -1,3 +1,8 @@
+/**
+ * Food distribution events: ticket management (numbers 1-999), statistics, and a
+ * post-processor chain for side effects on distribution close (emails, reports).
+ * Depends on {@code reporting} to trigger report/statistic generation when a distribution closes.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {"base::exception", "reporting"}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/README.md
@@ -1,0 +1,207 @@
+# Household Module
+
+This module manages the "case record" for a Tafel customer: a household and the persons living in
+it. It is the direct successor of the old `customer`/`customer_addpersons` model. The **business
+package is still called `household`**, and the **frontend feature module is still called
+`customer`** (only `customer-api.service.ts` on the frontend knows about the household/person
+split) — don't be surprised to see `household` and `customer` used interchangeably across the
+codebase depending on which layer you're in.
+
+`@ApplicationModule(allowedDependencies = {"base::country", "base::exception"})` (see
+[`package-info.java`](package-info.java)) - this module is only allowed to reach into the `country`
+and `exception` named interfaces of the `base` module. It does **not** depend on `base::employee`
+directly; instead it goes through `UserEntity.employee` (see below).
+
+## Domain model
+
+- A **household** (`households` table, [`HouseholdEntity`](../../database/model/household/HouseholdEntity.kt))
+  is the case record: business number (`household_id`), address, contact data, validity
+  (`valid_until`), lock state (`locked`/`lockedAt`/`lockedBy`/`lockReason`), cost-contribution state
+  (`pending_cost_contribution`) and the issuing employee (`issuer`).
+- A household has one or more **persons** (`persons` table,
+  [`PersonEntity`](../../database/model/person/PersonEntity.kt)), exactly one of which is flagged as
+  the **main person** via `is_main_person`. This is enforced in the database by a partial unique
+  index: `uq_persons_household_main on persons (household_id) where is_main_person = true`.
+- `households.main_person_id` points at that person's row, but every household member also has
+  `person.household_id` pointing back at the household. The API-facing `Household`/`Person` models
+  (in [`HouseholdResponseModel.kt`](HouseholdResponseModel.kt)) expose `persons: List<Person>` with
+  `mainPerson()`/`additionalPersons()` helper methods, mirroring
+  `HouseholdEntity.additionalPersons()` on the entity side.
+- Legacy: the old `customers` / `customers_addpersons` tables (see
+  `R__00067_household_person_refactor.sql`) were superseded by `households`/`persons`. They are kept
+  read-only for a production observation window before a separate cleanup migration
+  (`R__00068_household_person_cleanup.sql`) drops them. Do not read/write those tables or build new
+  features against them — they are not part of this module's persistence.
+
+## The `main_person_id` chicken-and-egg problem
+
+`households` and `persons` reference each other (`households.main_person_id -> persons.id` and
+`persons.household_id -> households.id`), so a brand-new household and its main person can never be
+inserted in the same statement — neither row can be written first if both foreign keys were
+`NOT NULL`. That's why `households.main_person_id` is **nullable at the DB level**, even though in a
+correct, fully-saved household it is never actually null.
+
+[`HouseholdService.saveWithMainPerson(entity)`](internal/HouseholdService.kt) is the method that
+deals with this. The rule it follows:
+
+```kotlin
+private fun saveWithMainPerson(entity: HouseholdEntity): HouseholdEntity {
+    val mainPerson = entity.persons.firstOrNull { it.isMainPerson }
+
+    // The main person row already exists - a single save is enough.
+    if (mainPerson?.id != null) {
+        entity.mainPerson = mainPerson
+        return householdRepository.saveAndFlush(entity)
+    }
+
+    // Brand new main person: write the household without the pointer first, then its persons,
+    // and only afterwards point the household at its main person.
+    entity.mainPerson = null
+    val savedEntity = householdRepository.saveAndFlush(entity)
+
+    savedEntity.mainPerson = savedEntity.persons.firstOrNull { it.isMainPerson }
+    return householdRepository.saveAndFlush(savedEntity)
+}
+```
+
+- **Existing household, existing main person** (typical update): one `saveAndFlush` is enough
+  because the main person's row (and its id) already exists, so JPA can cascade-save
+  household+persons+pointer together.
+- **Brand-new household** (create, or an update where the main person row itself is new): the
+  household is first saved with `mainPerson = null`, which cascade-saves its `persons` collection
+  (`@OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)` on `HouseholdEntity.persons`) and
+  gives every person row an id. Only then is `mainPerson` set to the now-persisted main person and
+  saved again with a second `saveAndFlush`.
+
+`createHousehold`/`updateHousehold` both funnel through `saveWithMainPerson` — never call
+`householdRepository.save()` directly on a new household if it might not yet have a persisted main
+person.
+
+The mirror image happens on delete:
+[`HouseholdService.deleteHouseholdByHouseholdId`](internal/HouseholdService.kt) sets
+`household.mainPerson = null` and flushes *before* calling `householdRepository.delete(household)` -
+otherwise deleting the persons (via `orphanRemoval`/cascade) would violate the
+`households -> persons` foreign key while `main_person_id` still points at a row being removed.
+
+[`HouseholdConverter.mapHouseholdToEntity`](internal/converter/HouseholdConverter.kt) has its own
+related gotcha: the main person's `PersonEntity` is always looked up and updated in place (via
+`storedMainPerson`), never deleted-and-recreated, so `main_person_id` never has to briefly point at
+a row that's about to be orphan-removed on the same flush.
+
+## Components
+
+### `HouseholdController` (`/api/households`)
+REST endpoint for household CRUD, validation, PDF generation, above-cost-limit listing, duplicate
+search and duplicate merging. All endpoints require `CUSTOMER` (or `CUSTOMER_DUPLICATES` /
+`CUSTOMERS_ABOVE_LIMIT` for the respective sub-features). Notable behavior:
+- `createHousehold`/`updateHousehold` take a `force: Boolean` query param and check
+  `isSupervisor` (role `SUPERVISOR`) from the JWT - see "Income validation" below for what that
+  gates.
+- `generatePdf` streams back a PDF (`HouseholdPdfType.MASTERDATA`, `IDCARD`, or `COMBINED`).
+
+### `HouseholdService` (`internal`)
+The core service: `createHousehold`, `updateHousehold`, `findByHouseholdId`, `getHouseholds`
+(paginated search with `HouseholdEntity.Specs` JPA specifications for name/postProcessing/
+cost-contribution/valid filters), `getHouseholdsAboveLimit`, `generatePdf`,
+`deleteHouseholdByHouseholdId`, `mergeHouseholds`. Owns the `saveWithMainPerson` save-order logic
+described above.
+
+`getHouseholdsAboveLimit` is worth knowing about if you touch it: the "above limit" filter can't be
+expressed in SQL because it depends on `IncomeValidatorService`, not stored columns, so it loads
+*every* valid household (via `HouseholdRepository.findAll(spec)`, which eagerly fetches `persons`
+via `@EntityGraph` to avoid N+1), evaluates income validation for each in memory, and then paginates
+the already-computed in-memory list.
+
+### `HouseholdConverter` (`internal/converter`)
+Bidirectional mapping between the API-facing `Household`/`Person` models and
+`HouseholdEntity`/`PersonEntity`. `mapHouseholdToEntity` also:
+- Resolves the next `household_id` from the `household_id_sequence` (via
+  `HouseholdRepository.getNextHouseholdSequenceValue()`) for new households.
+- Stamps `issuer` from the authenticated user's linked `EmployeeEntity` (`userEntity.employee`) -
+  this is how the module gets employee data without depending on `base::employee`.
+- Tracks `prolongedAt`: set to "now" whenever an update pushes `validUntil` further into the future
+  than it already was.
+- Force-clears `migrated = false` whenever a household is saved through the app (there's a
+  `// TODO revisit on 01.01.2026` comment - this flag exists only to track post-refactor
+  data-quality fixups and can likely be removed after that date).
+
+### `HouseholdDuplicationService` (`internal`)
+Finds potential duplicate households via a raw SQL query (`JdbcTemplate`, not JPA) comparing every
+household's main person against every other household's main person:
+- `soundex(lastname)` / `soundex(firstname)` must match (phonetic equality), **and**
+- `levenshtein(lower(firstname+lastname))` between the two full names must be `< 4`, **and**
+- `levenshtein(lower(street+housenumber+door))` between the two addresses must be `< 10`.
+
+Both conditions must hold - phonetically-similar names at very different addresses (or vice versa)
+are not flagged. Since firstname/lastname now live on `persons` rather than `households`, the query
+joins through `households.main_person_id` (see the `MAIN_PERSON_CTE` companion constant) rather than
+reading name columns directly off `households`. Pagination here is one duplicate *group* per page
+(`PageRequest.of(page, 1)`), not one household per page.
+
+`HouseholdController.mergeIntoHousehold` merges duplicates by simply deleting the source households
+(`householdService.mergeHouseholds` -> `deleteHouseholdByHouseholdId` per source id) - there is no
+data-merging of person records, notes, or distribution history; merging is a one-way deletion of the
+duplicate households, keeping only the target.
+
+### `IncomeValidatorService` / `IncomeValidatorServiceImpl` (`internal/income`)
+Validates a household's combined income against configurable limits stored in `StaticValueRepository`
+(`StaticValueType.ADDITIONAL_ADULT`, `ADDITIONAL_CHILD`, `TOLERANCE`, `FAMILY_BONUS`,
+`SIBLING_ADDITION`, `CHILD_TAX_ALLOWANCE`, and a per-person-count base limit). Key rules baked into
+the implementation:
+- A person `isChild()` if under 15; `isChildForFamilyBonus()` if 24 or under (a wider bracket).
+- Persons with `excludeFromIncomeCalculation` (mapped from `Person.excludeFromHousehold`) are
+  excluded from the income sum entirely, but can still receive family bonus.
+- The base limit is looked up per (adult count, child count) via
+  `StaticValueRepository.findLatestForPersonCount`, then a flat `TOLERANCE` amount is added on top
+  before comparing against the summed income - `IncomeValidatorResult.toleranceValue` reports how
+  much tolerance was applied, `amountExceededLimit` how far over the (tolerance-inclusive) limit the
+  household is.
+
+`HouseholdService.mapToValidationPersons` is the adapter that turns a `Household`'s persons into
+`IncomeValidatorPerson`s before calling this service - both `validate()` (called ad-hoc by the
+frontend before submit) and `createHousehold`/`updateHousehold` (called again server-side, since the
+client-computed result can't be trusted) go through it.
+
+**Supervisor/force gotcha:** if validation fails, `createHousehold`/`updateHousehold` behave
+differently depending on the caller's role:
+- Non-supervisor: the household is saved anyway, but forced `validUntil = yesterday` (i.e. saved as
+  already-invalid), and an `errorMsg` is returned to inform the user.
+- Supervisor without `force=true`: rejected outright with `TafelValidationException` (409 Conflict) -
+  supervisors get a chance to review and confirm before overriding.
+- Supervisor with `force=true`: saved as-is (validity untouched), no error.
+
+### `HouseholdPdfService` (`internal/masterdata`)
+Generates the household's PDFs (master data sheet, ID card, or a combined document) using
+`PDFService` (in `common/pdf`), which renders Apache FOP XSL-FO templates from
+`backend/src/main/resources/pdf-templates/customer-pdf/` (`masterdata-document.xsl`,
+`idcard-document.xsl`, `masterdata-idcard-document.xsl` - note: still under a `customer-pdf`
+directory, matching the "customer" legacy naming). `Model.kt` in the same package defines the
+XML-serializable `PdfData`/`PdfCustomerData`/`PdfAddressData`/`PdfAdditionalPersonData`/
+`PdfIdCardData` tree that gets marshalled to XML and fed to the XSL-FO transform. The ID card also
+embeds a QR code (containing the household's `household_id`) generated in-process via the `qrcode`
+library, with the Tafel logo overlaid.
+
+### `HouseholdNoteController` / `HouseholdNoteService` (`internal/note`)
+Free-text notes attached to a household (`household_notes` table,
+[`HouseholdNoteEntity`](../../database/model/household/HouseholdNoteEntity.kt)), each stamped with
+the authoring employee and a timestamp. Simple create/list (paginated, 5 per page, newest first);
+no update or delete endpoint exists.
+
+## Gotchas / best practices
+
+1. **Never bypass `saveWithMainPerson`.** Any new code path that persists a `HouseholdEntity`
+   directly (instead of going through `HouseholdService`) must reproduce the two-phase save when the
+   main person might be new, or you will hit a FK violation or leave `main_person_id` null.
+2. **Deleting a household must null out `mainPerson` first.** See
+   `deleteHouseholdByHouseholdId` - skipping this step breaks on the `households -> persons` FK.
+3. **Income validation happens twice on write** (once implicitly via the request the frontend
+   already validated, once again server-side in `createHousehold`/`updateHousehold`) - never trust
+   a client-supplied "valid" flag.
+4. **Duplicate detection reads `persons` via `households.main_person_id`, not `households` directly**
+   - if you add new duplicate-matching criteria, remember firstname/lastname/address for comparison
+   live partly on `persons` (name) and partly on `households` (address).
+5. **`customers`/`customers_addpersons` are legacy and read-only.** Don't add new reads or writes
+   against them; they exist only for a transitional observation window.
+6. This module can only see `base::country` and `base::exception` (per
+   `package-info.java`) - if you need employee data, go through `UserEntity.employee` /
+   `HouseholdEntity.issuer`, not a direct `base::employee` dependency.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationService.kt
@@ -14,6 +14,22 @@ import org.springframework.jdbc.core.SingleColumnRowMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
+/**
+ * Fuzzy-matches households against each other to surface likely duplicate registrations for
+ * manual review (see [AGENTS.md special considerations][at.wrk.tafel.admin.backend] - never
+ * auto-merges, only lists candidates).
+ *
+ * A pair is flagged as a possible duplicate when, on the main person's name and the household
+ * address, both:
+ * - `soundex(lastname)` and `soundex(firstname)` match (phonetic match, tolerant of spelling
+ *   variants), and
+ * - the Levenshtein distance of the concatenated name is below 4, and the Levenshtein distance
+ *   of the concatenated street/house-number/door is below 10.
+ *
+ * Implemented as raw SQL (via [JdbcTemplate]) rather than JPA/Specifications because `soundex`
+ * and `levenshtein` are Postgres functions with no JPQL equivalent; the query self-joins
+ * `households`/`persons` twice (`household` vs `compare`) to compare every pair.
+ */
 @Service
 class HouseholdDuplicationService(
     private val householdRepository: HouseholdRepository,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/income/IncomeValidatorServiceImpl.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/income/IncomeValidatorServiceImpl.kt
@@ -7,6 +7,22 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import kotlin.math.max
 
+/**
+ * Validates a household's combined monthly income against a configurable limit.
+ *
+ * All limits/bonuses are read from [StaticValueRepository] rather than hardcoded, so they can be
+ * adjusted per [StaticValueType] over time (each lookup is date-scoped via `currentDate`) without
+ * a code change. The overall algorithm:
+ * 1. Sum `monthlyIncome` for persons not flagged `excludeFromIncomeCalculation`.
+ * 2. Add a family bonus: per child flagged `receivesFamilyBonus`, an age-tiered [StaticValueType.FAMILY_BONUS]
+ *    amount plus a flat [StaticValueType.CHILD_TAX_ALLOWANCE], plus a [StaticValueType.SIBLING_ADDITION]
+ *    that scales with the number of qualifying children (capped at the highest configured tier for 7+).
+ * 3. Determine the base limit from [StaticValueRepository.findLatestForPersonCount] for the
+ *    adult/child counts, then add [StaticValueType.ADDITIONAL_ADULT] / [StaticValueType.ADDITIONAL_CHILD]
+ *    for persons beyond the base household size (2 adults, 2 or 3 children depending on adult count),
+ *    plus a [StaticValueType.TOLERANCE] buffer.
+ * 4. Valid when the income sum does not exceed the resulting limit.
+ */
 @Service
 class IncomeValidatorServiceImpl(
     private val staticValueRepository: StaticValueRepository,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/package-info.java
@@ -1,3 +1,9 @@
+/**
+ * Household/person management (the case record and its members) with income validation,
+ * duplicate detection, and PDF generation (ID cards, master data). Business package is
+ * named {@code household} but the frontend module and DTOs are still named {@code customer}
+ * on purpose - see the module README for the legacy naming and data-shape details.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {"base::country", "base::exception"}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
@@ -1,0 +1,141 @@
+# Logistics Module
+
+This module covers everything needed to plan and record a distribution's food-collection
+logistics: **routes** (with their shops), **food collections** (what was picked up, by whom, in
+which car), **food categories** (the weighing/return catalog), **shelters** (delivery
+destinations), **shops** (pickup points), and **cars** (the vehicle fleet).
+
+## Module boundary
+
+```java
+@org.springframework.modulith.ApplicationModule(
+    allowedDependencies = {"base::exception", "base::employee"}
+)
+```
+
+- `base::exception` — for `TafelValidationException`, thrown by every service here on
+  not-found/invalid-reference (see below).
+- `base::employee` — **not** for generic "created/updated by" change tracking (this module's
+  entities don't have that; `BaseChangeTrackingEntity` only carries `createdAt`/`updatedAt`
+  timestamps, no employee FK). It's needed because `FoodCollectionEntity` has two real,
+  first-class relations to an employee: `driver` and `coDriver` (`driver_employee_id` /
+  `co_driver_employee_id` columns), and `FoodCollectionService` maps those through
+  `EmployeeRepository` into the shared `Employee` model.
+
+**Only `modules/*` packages are subject to this boundary check.** Entities under
+`database/model/logistics/*` are *not* — they're shared infrastructure, and other modules reach
+into them directly without needing to be declared as an `allowedDependency` here:
+- `reporting.DailyReportService` and `distribution.DistributionService` both query
+  `ShelterRepository` directly (not through `ShelterService`).
+- `FoodCollectionService` itself pulls in `DistributionEntity`/`DistributionRepository` /
+  `getCurrentDistribution()` from `database.model.distribution` the same way, even though
+  `logistics` has no declared dependency on the `distribution` module.
+
+So don't assume the `allowedDependencies` list tells you everything this module talks to at the
+DB level — it only governs `modules`-to-`modules` traffic.
+
+## Components by sub-area
+
+### Routes & shops (`RouteController`, `internal/RouteService`, `internal/ShopService`)
+- `RouteEntity` (`routes`) has a `number` (`Double`, allows things like route "2.1") and a `name`,
+  plus `stops: List<RouteStopEntity>` (mapped by `route`, table `routes_stops`).
+- `RouteStopEntity` links a route to a `ShopEntity` at a given `time` (`LocalTime`), with a free
+  `description`.
+- There is **no standalone "list all shops" endpoint**. `ShopService.getShopsForRouteId(routeId)`
+  is the only way shops are surfaced to the frontend: it loads the route, sorts its `stops` by
+  `time`, and maps each stop's shop. Shops are always presented in route/stop-time order, never
+  independently.
+- `ShopEntity` (`shops`) embeds `ShopAddress` (`address_street`/`address_postal_code`/
+  `address_city`) and carries a `foodUnit: FoodUnit` (`BOX` or `KG`) — this drives weight
+  calculation in food collections (see below).
+- **Dead code warning:** `RouteShopRepository` is a `JpaRepository<RouteStopEntity, Long>` —
+  despite its name it repository-manages *stops*, not shops, and nothing in the codebase actually
+  uses it (`ShopService` goes through `RouteRepository` instead). Don't reach for it assuming it's
+  the shop repository.
+
+### Shelters (`SheltersController`, `internal/ShelterService`)
+- `ShelterEntity` (`shelters`) holds a full address (street/house number/stairway/door/postal
+  code/city), a `personsCount`, an `enabled` flag, and `sortOrder` (added recently alongside
+  drag-and-drop reordering in the UI). Contacts are a `@OneToMany` to `ShelterContactEntity`
+  (table `shelters_contacts`) with `cascade = [CascadeType.ALL], orphanRemoval = true`.
+- **Contacts are wholesale-replaced on every update**, not diffed: `updateShelter()` builds a
+  fresh `mutableList` of brand-new `ShelterContactEntity` instances and assigns it to
+  `shelterEntity.contacts`. This only works correctly because of `orphanRemoval = true` — it's
+  what causes Hibernate to delete the previously-attached contact rows that are no longer
+  referenced. If that cascade setting is ever removed, this update logic will silently leak
+  orphaned contact rows instead of failing loudly.
+- Sort order pattern (identical to food categories, see below): `createShelter()` calls
+  `nextSortOrder()` = `(max existing sortOrder ?: 0) + 1`; `reorderShelters(shelterIds)`
+  re-numbers strictly by the order the client sent, `index + 1`, with no gap-preservation.
+  `getActiveShelters()`/`getAllShelters()` both sort by `(sortOrder, name)`.
+- **No `LOGISTICS`/`SETTINGS` permission gate on this controller** — `SheltersController` is
+  annotated only `@PreAuthorize("isAuthenticated()")` at the class level, so *any* logged-in user
+  can create/update/reorder shelters, unlike food categories (see below) which require
+  `SETTINGS`. Confirm this is intentional before assuming permission parity across logistics
+  sub-areas.
+- Shelters are read cross-module (via `ShelterRepository` directly, bypassing `ShelterService`)
+  by `reporting.DailyReportService` and `distribution.DistributionService` — e.g. the "respect
+  shelter sortOrder in dashboard/daily report PDF" behavior lives in those consumers, not here.
+
+### Cars (`CarsController`, `internal/CarService`)
+- The simplest sub-area: `CarEntity` (`cars`) is just `licensePlate` + `name`. `CarService` only
+  exposes `getCars()` — there's currently no create/update/delete endpoint for cars in this
+  module; car master data is presumably maintained elsewhere (migration/manual DB) for now.
+
+### Food categories (`FoodCategoriesController`, `internal/FoodCategoryService`)
+- `FoodCategoryEntity` (`food_categories`) has `weightPerUnit` (`BigDecimal`), a `returnItem`
+  flag, `sortOrder`, and `enabled`.
+- `returnItem` marks deposit/return-box categories ("Kisten"). `getAllFoodCategories()` explicitly
+  filters these **out** (`it.returnItem != true`) with the comment that they're "out of scope for
+  this admin listing — they will get their own dedicated form later" — and `nextSortOrder()` also
+  only considers non-return items when computing the next slot, so return-item categories and
+  regular categories effectively occupy separate sort-order sequences.
+- `getActiveFoodCategories()` (used when actually recording a food collection) does **not**
+  filter `returnItem` — only `enabled`. Don't assume the two listing methods return comparable
+  sets.
+- **Permission split despite living in the `logistics` module:** `getActiveFoodCategories()`
+  requires `LOGISTICS`, but `getAllFoodCategories()` plus create/update/reorder all require
+  `SETTINGS`. Category master-data maintenance is gated as a settings concern even though the
+  code sits in `logistics`.
+
+### Food collections (`FoodCollectionsController`, `internal/FoodCollectionService`)
+This is the most involved sub-area — it records what a route's team actually picked up.
+- Every endpoint is annotated `@TafelActiveDistributionRequired` and resolves "the" food
+  collection via `distributionRepository.getCurrentDistribution()!!` — food collections only
+  exist in the context of the currently-open distribution. There is exactly one
+  `FoodCollectionEntity` per `(distribution, route)` pair, enforced by the DB unique constraint
+  `food_collections_uk (distribution_id, route_id)`. All the save paths
+  (`saveRouteData`/`saveItems`/`saveItemsPerShop`/`patchItem`) follow the same
+  find-existing-by-`(distribution, route)`-or-create-new pattern
+  (`getOrCreateFoodCollectionEntity` / inline equivalents), then `save()` (upsert).
+- `FoodCollectionItemEntity` (table `food_collections_items`) is an `@Embeddable`
+  `@ElementCollection`, **not** its own JPA entity — it has no independent identity/repository,
+  only exists as part of `FoodCollectionEntity.items`, and is always loaded/replaced together with
+  its parent. The DB unique constraint is `(food_category_id, shop_id, food_collection_id)`.
+- **Race condition guard:** `patchItem()` wraps its read-modify-write in
+  `advisoryLockService.withLock(AdvisoryLockKey.PATCH_FOOD_COLLECTION_ITEM)` (lock id `4000L` in
+  `AdvisoryLockKey`). The code comment explains why: concurrent auto-save requests for the same
+  category/shop would otherwise race on the read-modify-write and both try to insert the same
+  item, violating the `food_collections_items_pk` unique constraint. If you add another
+  read-modify-write path against `items`, consider whether it needs the same lock.
+  See `database/common/lock/README.md` for the advisory-lock mechanism itself.
+- `kmStart`/`kmEnd` are nullable at the DB level (migration `R__00061_food_collections_nullable`
+  dropped their original `NOT NULL`) — a food collection can exist before mileage is recorded.
+- `FoodCollectionItemEntity.calculateWeight()` is where the shop's `foodUnit` and the category's
+  `weightPerUnit` come together: if the shop's unit is `KG`, `amount` *is* the weight; otherwise
+  weight = `amount * category.weightPerUnit`. Get the shop's unit wrong and every subsequent
+  weight-based report/statistic derived from this collection is wrong too.
+
+## Persistence gotchas — summary
+
+- Unlike `household` (which needs a genuine two-step save because `households` and `persons`
+  mutually reference each other), nothing in `logistics` needs that pattern — none of these
+  entities have circular FK relationships.
+- Two independent "drag-and-drop sortOrder" implementations exist (shelters, food categories)
+  with essentially copy-pasted logic (`nextSortOrder()` = max+1 on create,
+  `reorder(ids)` = re-number by client-supplied order as `index + 1`). If you touch one, check
+  whether the same fix applies to the other.
+- Remember that `database/model/logistics/*` entities/repositories are freely reachable from any
+  other module (they're outside the Modulith-enforced `modules/*` tree) — grep for
+  `ShelterRepository`, `FoodCollectionRepository`, etc. before assuming a change here is
+  logistics-only.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
@@ -48,10 +48,10 @@ DB level — it only governs `modules`-to-`modules` traffic.
 - `ShopEntity` (`shops`) embeds `ShopAddress` (`address_street`/`address_postal_code`/
   `address_city`) and carries a `foodUnit: FoodUnit` (`BOX` or `KG`) — this drives weight
   calculation in food collections (see below).
-- **Dead code warning:** `RouteShopRepository` is a `JpaRepository<RouteStopEntity, Long>` —
-  despite its name it repository-manages *stops*, not shops, and nothing in the codebase actually
-  uses it (`ShopService` goes through `RouteRepository` instead). Don't reach for it assuming it's
-  the shop repository.
+- There is no standalone shop repository — `ShopService` goes through `RouteRepository` for
+  everything (see above). A `RouteShopRepository` used to exist here (`JpaRepository<RouteStopEntity, Long>`,
+  despite its name actually repository-managing *stops*, not shops) but was unused dead code and
+  has been removed; don't recreate a shop-specific repository without checking `ShopService` first.
 
 ### Shelters (`SheltersController`, `internal/ShelterService`)
 - `ShelterEntity` (`shelters`) holds a full address (street/house number/stairway/door/postal

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
@@ -9,33 +9,37 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/shelters")
-@PreAuthorize("isAuthenticated()")
 class SheltersController(
     private val shelterService: ShelterService,
 ) {
 
     @GetMapping("/active")
+    @PreAuthorize("isAuthenticated()")
     fun getActiveShelters(): ShelterListResponse = ShelterListResponse(
         shelters = shelterService.getActiveShelters(),
     )
 
     @GetMapping
+    @PreAuthorize("hasAuthority('SETTINGS')")
     fun getAllShelters(): ShelterListResponse = ShelterListResponse(
         shelters = shelterService.getAllShelters(),
     )
 
     @PostMapping
+    @PreAuthorize("hasAuthority('SETTINGS')")
     fun createShelter(
         @RequestBody shelter: Shelter,
     ): Shelter = shelterService.createShelter(shelter)
 
     @PostMapping("/{shelterId}")
+    @PreAuthorize("hasAuthority('SETTINGS')")
     fun updateShelter(
         @PathVariable shelterId: Long,
         @RequestBody updatedShelter: Shelter,
     ): Shelter = shelterService.updateShelter(shelterId, updatedShelter)
 
     @PostMapping("/reorder")
+    @PreAuthorize("hasAuthority('SETTINGS')")
     fun reorderShelters(
         @RequestBody request: ShelterReorderRequest,
     ): ShelterListResponse {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/package-info.java
@@ -1,3 +1,7 @@
+/**
+ * Routes, food collections, shelters, shops, cars, and food category management.
+ * Depends on {@code base::employee} for change-tracking references (created/updated by).
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {"base::exception", "base::employee"}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/README.md
@@ -1,0 +1,158 @@
+# Reporting Module
+
+This module turns raw distribution/statistic data into files people actually consume: the per-distribution
+daily report PDF that's emailed out, the set of CSV "TOeT" analysis exports emailed alongside it, and the
+ad-hoc CSV/chart statistics export used by the settings/statistics screen in the frontend.
+
+## Components
+
+### Public API (root package `modules.reporting`)
+- **`DailyReportService`** – Builds a `DailyReportPdfModel` from a `DistributionStatisticEntity` and renders
+  it to PDF via `PDFService.generatePdf(pdfModel, "/pdf-templates/daily-report/dailyreport-document.xsl")`.
+  Loads `assets/logo.png` for the header, formats the distribution's start/end time, and (notably) resolves
+  shelter data straight off the passed-in `DistributionStatisticEntity.shelters` — filtering to shelters with
+  `personsCount > 0` and sorting by `sortOrder` then `name` — not from a live `Shelter` lookup.
+- **`StatisticExportService`** – Runs every registered `StatisticExporter` bean (Spring collects the
+  `List<StatisticExporter>` automatically) against a `DistributionStatisticEntity`, turns each exporter's rows
+  into a CSV byte array via `CsvUtil`, and returns them as a list of `StatisticExportFile(name, content)`.
+- **`StatisticExportFile`** – Simple `(name, content: ByteArray)` DTO with a hand-written `equals`/`hashCode`
+  (needed because `ByteArray` doesn't get structural equality for free from a data class).
+- **`StatisticsController`** – `GET /api/statistics/*`, guarded by `@PreAuthorize("hasAuthority('STATISTICS')")`.
+  Serves `/settings` (years + list of closed distributions available to pick from), `/data` (chart data for a
+  date range), and `/generate-csv` (single combined CSV export for a date range). This is the API the
+  frontend's **statistics** feature module (Chart.js panels) talks to — unrelated to the daily-report/CSV
+  files emailed after closing a distribution.
+
+### `internal/` (not visible to other modules)
+- **`StatisticsService`** – Backs `StatisticsController`. Runs hand-written native SQL through
+  `EntityManager.createNativeQuery`, using two Postgres helper functions that are *not* defined in this
+  module (`get_timeline(fromDate, toDate)` and `format_by_resolution(date, res_code)` — search the Flyway
+  migrations if you need to change bucketing/resolution behavior). Produces beneficiary
+  household/person counts, shelter counts/averages, and shop/food totals, each as a labeled timeseries
+  (`StatisticsResult`), then also flattens the latest data point into `/generate-csv`'s single-row CSV export.
+  Note the explicit `Locale.ROOT` formatting call in `executeStatsQuery` — deliberately avoids the JVM default
+  `de-DE` locale (comma decimal separator) because the value round-trips through `String.toDouble()`, which
+  is locale-independent and would throw on a comma-formatted string.
+- **`DailyReportPdfModel`** / `DailyReportShelterPdfModel` – The XML-serializable model fed into FOP. Uses
+  `@JsonRootName("data")` because the XSL-FO template's root match is `/data`. Hand-written `equals`/`hashCode`
+  again because of the raw `logoBytes: ByteArray` field.
+- **`internal/statisticexporter/`** – One `StatisticExporter` implementation per CSV file emailed after a
+  distribution closes (see below).
+
+### `internal/statisticexporter/` — the "TOeT" CSV exporters
+Each implements the tiny `StatisticExporter` interface (`getName(): String`, `getRows(statistic): List<List<String>>`)
+and is picked up automatically as a `@Component` — add a new one and `StatisticExportService` will include it
+in the mailed export set without any other wiring change:
+
+- **`AgeDistributionExporter`** (`TOeT_Verteilung_Alter`) – Buckets every household member into fixed age
+  ranges (`AgeRange` enum, 0-20 … 91+) and reports household/person counts and percentages per bucket, for the
+  *current* distribution only.
+- **`CountryDistributionExporter`** (`TOeT_Verteilung_Nationalitaeten`) – Same idea, grouped by
+  `Person.country`, current distribution only.
+- **`HouseholdSizeDistributionExporter`** (`TOeT_Verteilung_Haushaltsgroesse`) – Distribution of household
+  sizes (1..10 persons), current distribution only.
+- **`DailyReportsExporter`** (`TOeT_Tagesreports`) – The odd one out: pulls **every distribution of the
+  current calendar year** via `distributionRepository.getDistributionsForYear(...)` and emits one row per
+  past distribution plus a row for the current one, i.e. a running year-to-date table, not just a snapshot of
+  today.
+- **`FoodCollectionsExporter`** (`TOeT_Spenden`) – Also year-to-date (same `getDistributionsForYear` pattern).
+  Builds one row per shop-per-food-collection-per-distribution, with one column per `FoodCategoryEntity`
+  (sorted return-items-last, then by name), so the column set changes if food categories are added/removed in
+  the `logistics` module.
+
+Because `AgeDistributionExporter`/`CountryDistributionExporter`/`HouseholdSizeDistributionExporter` only look
+at `currentStatistic.distribution.households`, they silently report empty/zero data if that relation isn't
+populated on the entity passed in — they do not requery the database for it.
+
+## The `allowedDependencies = {}` puzzle — reporting is a dependency *target*, not consumer
+
+Like `dashboard`, `reporting`'s `package-info.java` declares no allowed module dependencies:
+
+```java
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {}
+)
+package at.wrk.tafel.admin.backend.modules.reporting;
+```
+
+This is consistent, not contradictory, with `distribution` depending on `reporting` (per the top-level
+`AGENTS.md`): `allowedDependencies` on *this* module's annotation only constrains what `reporting` itself is
+allowed to import from other `modules.*` packages (it imports none — same trick as `dashboard`, it only reads
+`database.model.*` entities/repositories, e.g. `DistributionRepository`, `FoodCategoryRepository`, which are
+shared infrastructure, not application modules). It says nothing about who is allowed to depend on
+`reporting`.
+
+There are no explicit `@NamedInterface`/`@org.springframework.modulith.NamedInterface` annotations anywhere
+in this module. Spring Modulith's default rule applies instead: **a module's root package is its default
+public API; everything under `internal` is hidden from other modules.** Concretely, the classes sitting
+directly in `modules.reporting` (`DailyReportService`, `StatisticExportService`, `StatisticExportFile`,
+`StatisticsController` and the `StatisticsSettings`/`StatisticsData`/... DTOs) are importable by other
+modules; everything in `modules.reporting.internal.*` (the `StatisticsService`, the PDF model, the
+exporters) is not.
+
+`distribution`'s post-processor chain is exactly what depends on this public surface — confirmed by
+`import` lines in
+`modules/distribution/internal/postprocessors/DailyReportMailPostProcessor.kt` and
+`.../StatisticMailPostProcessor.kt`:
+
+```kotlin
+import at.wrk.tafel.admin.backend.modules.reporting.DailyReportService
+// ...
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticExportFile
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticExportService
+```
+
+`DailyReportMailPostProcessor.process(...)` calls `dailyReportService.generateDailyReportPdf(statistic)` and
+mails the bytes as a PDF attachment; `StatisticMailPostProcessor.process(...)` calls
+`statisticExportService.exportStatisticFiles(statistic)` and mails each `StatisticExportFile` as a CSV
+attachment. Both post-processors run as part of `distribution`'s close-distribution post-processor chain
+(`DistributionPostProcessorService`), i.e. reporting's public services are invoked synchronously right after
+a distribution is closed — there's no async/event-driven handoff here, unlike the dashboard's outbox-based
+decoupling.
+
+## PDF generation mechanics (XSL-FO + Apache FOP)
+
+`DailyReportService` is the only class in this module that generates a PDF, and it delegates the actual
+rendering to the shared `common.pdf.PDFService`:
+
+1. `PDFService.generatePdf(data, stylesheetPath)` serializes `data` (here, `DailyReportPdfModel`) to XML using
+   a Jackson `XmlMapper` — this is why the model is annotated `@JsonRootName("data")`, matching the XSL
+   template's expected root element.
+2. It runs that XML through an XSLT `Transformer` using the stylesheet at `stylesheetPath` — for daily
+   reports that's `backend/src/main/resources/pdf-templates/daily-report/dailyreport-document.xsl` (plus
+   whatever it `<xsl:include>`s from the sibling `pdf-templates/daily-report/includes/` folder; a custom
+   `ClasspathResourceURIResolver` lets those includes resolve as classpath resources).
+3. The XSLT output is XSL-FO, which `fopFactory.newFop(MimeConstants.MIME_PDF, ...)` (Apache FOP) renders
+   directly to PDF bytes. Fonts (Liberation Sans family) are extracted from the classpath to a temp directory
+   at factory-build time because FOP needs real filesystem paths, not classpath streams, for font
+   registration.
+
+If you need to change the daily report's layout, edit the XSL (and its includes) — the Kotlin side only needs
+to change if you're adding/removing *data* on `DailyReportPdfModel`/`DailyReportShelterPdfModel`, since the
+XML shape is derived straight from that data class's field names via Jackson.
+
+## CSV mechanics
+
+CSV generation goes through the shared `common.csv.CsvUtil.writeRowsToByteArray(rows: List<List<String>>)`,
+which uses Apache Commons CSV with `;` as the delimiter (not the default `,` — matches Austrian/German Excel
+locale expectations) and UTF-8 encoding. Every exporter in `statisticexporter/` and
+`StatisticsService.generateCsv()` build a plain `List<List<String>>` (including header rows mixed into the
+same list) and hand it to this one utility — there's no shared "CSV row builder" abstraction beyond that.
+
+## Gotchas
+
+- Three of the five `StatisticExporter`s (`AgeDistributionExporter`, `CountryDistributionExporter`,
+  `HouseholdSizeDistributionExporter`) are *point-in-time* (current distribution only); the other two
+  (`DailyReportsExporter`, `FoodCollectionsExporter`) are *year-to-date* and re-query the DB for every prior
+  distribution in the current calendar year via `DistributionRepository.getDistributionsForYear(...)`. Don't
+  assume all five exports cover the same time range.
+- `/api/statistics/*` (frontend "statistics" charts/CSV) and the CSV files emailed by
+  `StatisticMailPostProcessor` are two entirely separate code paths (`StatisticsService` vs. the
+  `statisticexporter/*` classes) that happen to both live in `reporting` — they use different SQL, different
+  row shapes, and different filenames. Don't conflate "the CSV export" as if there's only one.
+- Shelter data in the daily report PDF is a historical snapshot on `DistributionStatisticEntity`, not a live
+  join to `logistics`' `Shelter` entity — same reasoning as in the `dashboard` module's README: renaming or
+  deleting a shelter later must not change past PDFs/exports.
+- `FoodCollectionsExporter`'s CSV column set is derived from *current* `FoodCategoryEntity` rows at export
+  time, sorted return-items-last then by name — adding/renaming a food category in `logistics` changes the
+  column layout of future exports (but not past ones, since those were already generated and mailed).

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/package-info.java
@@ -1,3 +1,8 @@
+/**
+ * Statistics exports (CSV), daily reports (PDF), and age/country/household distributions.
+ * Declares no allowed dependencies itself, but is a dependency target for other modules
+ * (e.g. {@code distribution}) that trigger report/statistic generation.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {}
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
@@ -1,0 +1,103 @@
+# Settings Module
+
+A small admin surface (4 files) over two unrelated configuration concerns: **mail recipients**
+(who gets which automated email) and **static values** (time-boxed numeric parameters like income
+limits). Both are exposed under `/api/settings` behind `@PreAuthorize("hasAuthority('SETTINGS')")`.
+
+## Module boundary
+
+```java
+@org.springframework.modulith.ApplicationModule(
+    allowedDependencies = {"base::exception"}
+)
+```
+
+Confirmed — the only declared cross-module dependency is `base::exception`
+(`TafelValidationException`, thrown by `updateStaticValue()` when the id doesn't exist).
+
+**Why nothing else needs to be declared:** the entities this module manages —
+`MailRecipientEntity`/`MailRecipientRepository`/`MailType`/`RecipientType` (in
+`database.model.base`) and `StaticValueEntity`/`StaticValueRepository`/`StaticValueType` (in
+`database.model.staticdata`) — live outside the `modules/*` package tree that Spring Modulith
+enforces boundaries on. So `SettingsService` reaches directly into shared `database/model`
+repositories without that counting as a `modules`-to-`modules` dependency at all. This also means
+**`settings` doesn't own these tables exclusively** — see "who actually reads this data" below.
+
+## Components
+
+- **`SettingsController`** — two independent endpoint groups:
+  - `GET`/`POST /api/settings/mail-recipients`
+  - `GET /api/settings/static-values`, `POST /api/settings/static-values/{staticValueId}`
+- **`internal/SettingsService`** — all the logic for both concerns (no further internal
+  decomposition despite the two concerns being unrelated).
+- **`model/SettingsResponseModel.kt`** — `MailRecipients` / `MailRecipientsPerMailType` /
+  `MailRecipientAdresses` (note the model's own `MailRecipientType` enum duplicates
+  `database.model.base.RecipientType` value-for-value: `TO`/`CC`/`BCC` — the service converts
+  between them by name via `.uppercase()`/`.valueOf(...)`, not by direct reuse).
+- **`model/StaticValueSettingsModel.kt`** — `StaticValueListResponse` / `StaticValueItem`.
+
+## Mail recipients
+
+Modeled as flat rows in `mail_recipients`: `(mailType, recipientType, address)`, no grouping table.
+`MailType` (`database.model.base`) is `DAILY_REPORT`, `STATISTICS`, `RETURN_BOXES`;
+`RecipientType` is `TO`/`CC`/`BCC`.
+
+- `getMailRecipients()` groups the flat rows back into nested `MailType -> RecipientType ->
+  [addresses]` for the UI.
+- `updateMailRecipients()` is a **full delete-then-insert**, not a diff:
+  `mailRecipientRepository.deleteAll()` followed by `saveAll(recipients)` built fresh from the
+  request. Blank/whitespace-only addresses are filtered out before insert. There is no history —
+  saving is destructive and unconditional; if two admins edit concurrently, the last save wins and
+  silently discards the other's changes.
+- **The settings module never sends mail itself.** The actual consumer is
+  `common.mail.MailSenderService`, which calls `mailRecipientRepository.findAllByMailType(mailType)`
+  directly (bypassing `SettingsService`/this module entirely) to build the to/cc/bcc lists when
+  distribution post-processors (e.g. daily report, statistics mails) send email. This module is
+  purely the CRUD admin UI backing that table.
+
+## Static values
+
+`StaticValueEntity` (`static_values`) rows are **time-boxed** parameters: `type` (`StaticValueType`:
+`INCOME_LIMIT`, `ADDITIONAL_ADULT`, `ADDITIONAL_CHILD`, `TOLERANCE`, `FAMILY_BONUS`,
+`CHILD_TAX_ALLOWANCE`, `SIBLING_ADDITION`, `COST_CONTRIBUTION`), a `BigDecimal amount`, and a
+`[validFrom, validTo]` validity window, optionally further keyed by `countAdults`/`countChildren`/
+`age` for lookup-table-style values (e.g. income limit by household composition).
+
+- **`getStaticValues()` only ever returns the row currently valid "today"** per
+  `(type, countAdults, countChildren, age)` — historized past/future rows (see below) are hidden
+  from the admin listing on purpose, since admins only need to see/edit what applies right now.
+- **`updateStaticValue()` only lets the `amount` change.** `type`/`countAdults`/`countChildren`/
+  `age` are the lookup keys other code matches on (see `StaticValueRepository`'s
+  `findLatestForPersonCount`/`findSingleValueOfType`/`findValuesOfType`) and are deliberately not
+  editable through this endpoint — changing them here would silently break that matching
+  elsewhere.
+- Updates are **historized, not overwritten in place** — with one exception:
+  - If the currently-valid row's `validFrom == today` (i.e. it was already edited once today),
+    that same row is updated in place, to avoid stacking multiple same-day history rows.
+  - Otherwise, the old row is closed (`validTo = yesterday`) and a new row is inserted running from
+    `today` to a sentinel far-future end date, `FICTIVE_END_DATE = 2999-12-31` (this exact
+    placeholder convention — "no known end date" — is also used in migrations/testdata, so match
+    it rather than inventing e.g. `null` or `LocalDate.MAX`).
+- **Caching:** `StaticValueRepository`'s three query methods are each `@Cacheable` under a
+  *different* cache name (`staticValueLatestForPersonCount`, `staticValueSingle`,
+  `staticValueList`) — the comment in the repository explains this is because the default Spring
+  cache key generator only considers arguments, not the method, and
+  `findSingleValueOfType`/`findValuesOfType` share the same argument shape and would otherwise
+  collide. Values are cached for the process lifetime because household validation would
+  otherwise re-query the same rows once per household. `SettingsService.updateStaticValue()` is
+  annotated `@CacheEvict(cacheNames = [...three names...], allEntries = true)` to keep this safe
+  despite values now being editable at runtime — **if you add a new cached query method to
+  `StaticValueRepository`, add its cache name to this eviction list too, or edits made through this
+  module's UI will appear to silently not take effect.**
+- **Again, the settings module is admin-only — it doesn't gatekeep reads.** Actual business logic
+  reads `StaticValueRepository` directly, bypassing `settings` entirely:
+  `household.internal.income.IncomeValidatorServiceImpl` (income-limit/family-bonus/tolerance
+  calculations) and `distribution.internal.postprocessors.MissingCostContributionPostProcessor`
+  both inject `StaticValueRepository` themselves rather than going through `SettingsService`.
+
+## Working in this module
+
+Both concerns share one trait worth keeping in mind: **this module is the maintenance UI, not the
+runtime source of truth's only reader.** When changing either `MailRecipientEntity`/`MailType`/
+`RecipientType` or `StaticValueEntity`/`StaticValueType`, grep for direct repository usage in
+`common.mail`, `household`, and `distribution` before assuming your change is contained here.

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/package-info.java
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/package-info.java
@@ -1,3 +1,6 @@
+/**
+ * Application configuration and mail recipient management.
+ */
 @org.springframework.modulith.ApplicationModule(
         allowedDependencies = {"base::exception"}
 )

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerServiceTest.kt
@@ -1,5 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.checkin.internal
 
+import at.wrk.tafel.admin.backend.database.common.lock.AdvisoryLockKey
+import at.wrk.tafel.admin.backend.database.common.lock.AdvisoryLockService
 import at.wrk.tafel.admin.backend.database.model.checkin.ScannerRegistrationEntity
 import at.wrk.tafel.admin.backend.database.model.checkin.ScannerRegistrationRepository
 import io.mockk.every
@@ -10,6 +12,7 @@ import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifySequence
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDateTime
@@ -20,8 +23,18 @@ internal class ScannerServiceTest {
     @RelaxedMockK
     private lateinit var scannerRegisteredRepository: ScannerRegistrationRepository
 
+    @RelaxedMockK
+    private lateinit var advisoryLockService: AdvisoryLockService
+
     @InjectMockKs
     private lateinit var service: ScannerService
+
+    @BeforeEach
+    fun setUp() {
+        every { advisoryLockService.withLock(any(), any<() -> Any?>()) } answers {
+            secondArg<() -> Any?>().invoke()
+        }
+    }
 
     @Test
     fun `register new scanner`() {
@@ -38,11 +51,10 @@ internal class ScannerServiceTest {
 
         val savedEntitySlot = slot<ScannerRegistrationEntity>()
         verifySequence {
-            scannerRegisteredRepository.acquireLock()
+            advisoryLockService.withLock(AdvisoryLockKey.SCANNER_REGISTRATION, any<() -> Any?>())
             scannerRegisteredRepository.getNextScannerId()
             scannerRegisteredRepository.findByScannerId(newScannerId)
             scannerRegisteredRepository.save(capture(savedEntitySlot))
-            scannerRegisteredRepository.releaseLock()
         }
 
         val savedEntity = savedEntitySlot.captured
@@ -68,11 +80,10 @@ internal class ScannerServiceTest {
 
         val savedEntitySlot = slot<ScannerRegistrationEntity>()
         verifySequence {
-            scannerRegisteredRepository.acquireLock()
+            advisoryLockService.withLock(AdvisoryLockKey.SCANNER_REGISTRATION, any<() -> Any?>())
             scannerRegisteredRepository.getNextScannerId()
             scannerRegisteredRepository.findByScannerId(existingScannerId)
             scannerRegisteredRepository.save(capture(savedEntitySlot))
-            scannerRegisteredRepository.releaseLock()
         }
 
         val savedEntity = savedEntitySlot.captured

--- a/frontend/src/main/webapp/src/app/modules/checkin/README.md
+++ b/frontend/src/main/webapp/src/app/modules/checkin/README.md
@@ -1,0 +1,97 @@
+# Checkin Module
+
+This module implements customer check-in during a distribution: registering physical QR scanners, reading the scans, looking up the scanned customer, assigning a ticket number, and driving the customer-facing "ticket monitor" screen.
+
+It's mounted at `/anmeldung` (`checkin.routes.ts`) and gated in `app.routes.ts` with `data: { anyPermissionOf: ['SCANNER', 'CHECKIN'] }` — note this is **two** permissions, not one, because the module serves two different physical roles (see below).
+
+## Components
+
+```
+modules/checkin/
+  ├── services/qrcode-reader/qrcode-reader.service.ts   # wraps @zxing/browser, decodes QR from a <video> element
+  ├── views/scanner/scanner.component.ts                # kiosk screen: registers a scanner device, decodes QR codes
+  ├── views/checkin/checkin.component.ts                 # staff screen: "Kunden-Annahme", assigns ticket numbers
+  ├── views/ticket-screen-control/...                     # staff screen: drives the customer-facing monitor
+  ├── views/ticket-screen-fullscreen/...                  # thin wrapper mounted at the standalone monitor route
+  └── components/ticket-screen/ticket-screen.component.ts # the actual monitor display, reused by both views above
+```
+
+### QRCodeReaderService
+
+Despite what the top-level `AGENTS.md` says (`html5-qrcode`), this module does **not** use `html5-qrcode` anywhere. It uses `@zxing/browser`'s `BrowserQRCodeReader` — check `package.json` (`@zxing/browser`, `@zxing/library`) and `qrcode-reader.service.ts` if in doubt. Treat the `AGENTS.md` line as stale.
+
+The service is a thin wrapper: `getCameras()` lists video devices, `init(elementId, successCallback)` remembers which `<video>` element and callback to use, and `start(cameraId)` / `restart(cameraId)` / `stop()` manage the actual `decodeFromVideoDevice` call. The last-used camera id is persisted to `localStorage` under `TAFEL_LAST_CAMERA_ID` so a kiosk reopening the page reuses the same camera.
+
+### ScannerComponent (`/anmeldung/scanner`) — the kiosk device
+
+This is what runs on the physical scanning station (handheld scanner or webcam kiosk). On load it does two things concurrently (`initEffect`):
+
+1. **Registers itself** as a scanner: reads an existing scanner id from `localStorage['scanner-id']` if present and calls `ScannerApiService.registerScanner(existingScannerId)` (`POST /scanners/register`). The backend either confirms the existing id or issues a new one, which is written back to `localStorage`. Clearing that key (or using a different browser) gets you a *new* scanner id.
+2. **Starts the camera**: lists cameras, picks the last-used one (or the first), and starts decoding.
+
+Decoded QR text is parsed as a plain number (`+decodedText`) — the QR payload is just the customer/household id, nothing more structured. Sending the scan result to the backend is **deliberately decoupled** from the decode callback:
+
+```ts
+// Scanner registration and camera startup happen concurrently, so a scan can be decoded
+// before scannerId() resolves. Route through this effect (instead of sending directly from
+// the callback) so it fires once scannerId becomes available too, instead of dropping the
+// scan or posting to `/scanners/undefined/results`.
+sendScanResultEffect = effect(() => {
+  const scannerId = this.scannerId();
+  const lastScanResult = this.lastScanResult();
+  if (scannerId !== undefined && lastScanResult !== undefined) {
+    this.scannerApiService.sendScanResult(scannerId, lastScanResult).subscribe();
+  }
+});
+```
+If you're debugging "scans get lost right after page load," this is the place to look.
+
+### CheckinComponent (`/anmeldung/annahme`) — the staff screen
+
+This is where check-in staff sit. It has its own concept of "scanner" that's easy to confuse with the one above: `scannerIds` (loaded via `ScannerApiService.getScanners()`, `GET /scanners`) is the list of *already-registered* scanner devices, and `currentScannerId` is simply which one this staff member has chosen to listen to from a dropdown — no registration happens here.
+
+Selecting a scanner subscribes to SSE:
+```ts
+this.scannerSubscription = this.sseService.listen<ScanResult>(`/sse/scanners/${scannerId}/results`)
+  .subscribe((result: ScanResult) => {
+    this.customerId.set(result.value);
+    this.searchForCustomerId();
+  });
+```
+So the full round trip for a physical scan is: kiosk decodes QR → `POST /scanners/{id}/results` → backend outbox → SSE push on `/sse/scanners/{id}/results` → staff screen picks it up and looks up the customer. A staff member can also just type a customer id directly into the `customerIdInput` field (autofocused via `tafelAutofocus`) without any scanner involved — the scanner path and the manual path both funnel into `searchForCustomerId()`.
+
+Once a customer resolves, the component loads their notes (`CustomerNoteApiService`) and any already-assigned ticket for the *current* distribution (`DistributionTicketApiService.getCurrentTicketForCustomer`). Customer validity is bucketed into `CustomerState` (`LOCKED` / `INVALID` / `VALID_WARN` / `VALID`, the last based on an 8-week `VALID_UNTIL_WARNLIMIT_WEEKS` window) which drives badge color and which control gets focused next (`cancelButtonRef` on locked/invalid, `ticketNumberInputRef` otherwise) — both done via `setTimeout` after the signal update, not `effect()`.
+
+There's also a redirect guard worth knowing about:
+```ts
+effect(() => {
+  if (this.connectionState() && this.currentDistribution() === null) {
+    this.router.navigate(['uebersicht']);
+  }
+});
+```
+It only fires once `connectionState()` (from `GlobalStateService`, backed by SSE) is `true` — this avoids bouncing the user back to the dashboard during the brief window before the SSE connection is even established, when `currentDistribution()` is still `null` by default.
+
+### Ticket monitor: TicketScreenComponent / TicketScreenControlComponent / TicketScreenFullscreenComponent
+
+`TicketScreenComponent` is a dumb display component — it just renders whatever the backend currently wants shown (a start time, or a ticket number), driven entirely by SSE:
+```ts
+private readonly ticketScreenData = toSignal(
+  this.sseService.listen<TicketScreenText>('/sse/distributions/ticket-screen/current')
+);
+```
+It's reused in two places: embedded as a small live preview inside `TicketScreenControlComponent` (`/anmeldung/ticketmonitor-steuerung`), and full-screen via `TicketScreenFullscreenComponent`.
+
+`TicketScreenControlComponent` is the staff control panel: buttons call `DistributionTicketScreenApiService` (`showText`, `showCurrentTicket`, `showPreviousTicket`, `showNextTicket(costContributionPaid)`), each a `POST` that causes the backend to broadcast a new SSE message picked up by every open `TicketScreenComponent`. It uses the newer `@angular/forms/signals` API (`form()`, `FormField`, `required`) for the start-time field rather than classic `FormGroup`.
+
+`openScreenInNewTab()` opens `/#/anmeldung/ticketmonitor` in a new tab via `UrlHelperService.getBaseUrl()` — this is meant to be projected onto a second monitor in the waiting area.
+
+**Important routing detail:** `TicketScreenFullscreenComponent` is *not* a child of the `anmeldung` route group in `app.routes.ts`. It's registered as its own top-level route (`path: 'anmeldung/ticketmonitor'`, guarded only by the plain `authGuard`), so it requires being logged in but **not** the `SCANNER`/`CHECKIN` permission that gates the rest of this module. That's intentional — the monitor is a public-facing display, and whoever's logged into the kiosk running it may not hold either permission.
+
+## Gotchas
+
+- The `AGENTS.md` claim of `html5-qrcode` is wrong for this codebase today; it's `@zxing/browser`.
+- Two unrelated notions of "scanner id" exist side by side: the physical device's registered id (`ScannerComponent`, persisted in `localStorage['scanner-id']`) and the id a staff member picks to *listen to* (`CheckinComponent.currentScannerId`, no persistence). Don't conflate them when debugging.
+- `sendScanResultEffect` exists specifically to avoid a race between scanner registration and camera startup — don't "simplify" it back into the QR decode callback.
+- The ticket monitor's full-screen route deliberately sits outside the `SCANNER`/`CHECKIN` permission gate; if you move it under `checkin.routes.ts` you'll break the "unattended second monitor" use case.
+- `CheckinComponent`'s delete-ticket button (`ticketNumberEdit()`) only appears when a ticket already existed for the customer at lookup time — it's not shown for a fresh, not-yet-assigned ticket number.

--- a/frontend/src/main/webapp/src/app/modules/customer/README.md
+++ b/frontend/src/main/webapp/src/app/modules/customer/README.md
@@ -1,0 +1,229 @@
+# Customer Module
+
+Search, create, edit, view, and review customers: master data, income validation,
+duplicate review, PDF generation (ID card / master data), notes, locking, and
+ticket assignment during an active distribution. Routed under `/kunden/*`.
+
+**Read the section below before touching anything in this module.** It documents a
+naming/data-shape decision that is easy to violate by accident and hard to notice in
+review.
+
+## The household/customer naming trap
+
+The backend's `household` module renamed its domain model: a **household** is the case
+record (business number, address, contact info, validity/lock/cost-contribution state)
+containing one or more **persons**, exactly one of which is flagged `isMainPerson`. See
+`AGENTS.md` ("Backend Architecture" / `households`+`persons` tables) for the full
+picture.
+
+This frontend module was **deliberately not renamed** to match. Routes
+(`/kunden/...`), the folder name (`modules/customer/`), every component/view/resolver
+class name, and the two DTOs (`CustomerData`, `CustomerAddPersonData`) all still use
+the old flat "customer + additional persons" shape:
+
+- The main person's fields (`firstname`, `lastname`, `birthDate`, `gender`, `country`,
+  `employer`, `income`, `incomeDue`) live directly on `CustomerData`, alongside
+  household-level fields (`address`, `telephoneNumber`, `email`, `validUntil`,
+  `locked`/`lockedAt`/`lockedBy`/`lockReason`, `pendingCostContribution`, `issuer`,
+  `issuedAt`).
+- Every other household member is a `CustomerAddPersonData` in
+  `CustomerData.additionalPersons[]`.
+
+**`app/api/customer-api.service.ts` is the only file in the whole frontend that is
+allowed to know the backend's household/person wire shape.** It defines its own
+`HouseholdData`/`PersonData`/etc. interfaces and — critically — **does not export
+them**. Nothing outside that file can even `import` them; the translation is enforced
+by the type system, not just convention. Every component, view, resolver and dialog in
+`modules/customer/` (and everywhere else) only ever sees `CustomerData` /
+`CustomerAddPersonData`.
+
+The translation happens in two functions at the bottom of `customer-api.service.ts`:
+
+```ts
+// Backend -> frontend
+function mapHouseholdToCustomer(household: HouseholdData | null | undefined): CustomerData {
+  const persons = household?.persons ?? [];
+  const mainPerson = persons.find(person => person.isMainPerson);
+  const additionalPersons = persons
+    .filter(person => !person.isMainPerson)
+    .map(person => ({ /* person fields, minus isMainPerson */ }) as CustomerAddPersonData);
+
+  return {
+    // household-level fields copied as-is (id, issuer, issuedAt, address,
+    // telephoneNumber, email, validUntil, locked*, pendingCostContribution)
+    // main person's fields flattened onto the customer (firstname, lastname,
+    // birthDate, gender, country, employer, income, incomeDue)
+    additionalPersons,
+  };
+}
+
+// Frontend -> backend
+function mapCustomerToHousehold(customer: CustomerData): HouseholdData {
+  const mainPerson: PersonData = {
+    isMainPerson: true,
+    // ...customer's flat fields moved back onto a person...
+    excludeFromHousehold: false,
+    receivesFamilyBonus: false,
+  };
+  const additionalPersons: PersonData[] = (customer.additionalPersons ?? [])
+    .map(person => ({ ...person, isMainPerson: false }));
+
+  return { /* household-level fields */ persons: [mainPerson, ...additionalPersons] };
+}
+```
+
+Gotchas worth knowing before you change either direction:
+
+- `excludeFromHousehold` and `receivesFamilyBonus` only exist on
+  `CustomerAddPersonData`/`PersonData`. The main person is always sent with both
+  hardcoded to `false` — the flat `CustomerData` has no field to carry them for the
+  main person.
+- The main person's own `persons[].id` is **not** round-tripped: the flat
+  `CustomerData` shape has nowhere to keep it. The backend re-resolves the existing
+  main person from the household's stored id instead, so an update still lands on the
+  same row rather than creating a new person.
+- `CustomerAddPersonData.key` is a form-only field (a stable identifier for Angular's
+  `@for` tracking while editing additional persons). It is never present on the wire in
+  either direction — `customer-form.component.ts` invents one with
+  `crypto.randomUUID()` when it doesn't already have one.
+
+**When adding a new field:** decide first whether it belongs to the household
+(case-level) or to a specific person, then update it in up to four places —
+`CustomerData`/`CustomerAddPersonData`, the matching (non-exported) `HouseholdData`/
+`PersonData` field, and both `mapHouseholdToCustomer`/`mapCustomerToHousehold`. **Do
+not** add a shortcut that reaches past `customer-api.service.ts` to talk to
+`/api/households` directly, and do not export `HouseholdData`/`PersonData`/etc. from
+that file — that export is the thing standing between "quirky but contained" and "the
+whole module has to learn the household/person model."
+
+## Folder structure
+
+```
+modules/customer/
+  ├── components/
+  │   ├── confirm-customer-save-dialog/   # generic "force save anyway?" confirm dialog
+  │   └── customer-form/                  # the big reactive form, shared by create + edit views
+  ├── views/
+  │   ├── customer-above-limit/           # list of customers whose income exceeds the limit
+  │   ├── customer-detail/                # detail page + its dialogs/ (notes, lock, delete)
+  │   ├── customer-duplicates/            # list of already-flagged duplicate customer pairs
+  │   ├── customer-edit/                  # create (no id) / edit (:id) — hosts customer-form + its dialogs/
+  │   └── customer-search/                # search by id or lastname/firstname + filters
+  ├── resolver/
+  │   ├── customerdata-resolver.component.ts
+  │   ├── customernotes-resolver.component.ts
+  │   ├── customer-duplicates-data-resolver.component.ts
+  │   └── customer-above-limit-data-resolver.component.ts
+  └── customer.routes.ts
+```
+
+There is no `services/` subfolder here (unlike the generic module convention in
+`AGENTS.md`) — this module has no feature-specific service beyond the shared
+`CustomerApiService`/`CustomerNoteApiService` in `app/api/`, which every module can
+use.
+
+Resolvers follow the `-resolver.component.ts` suffix convention and use `@Service()`
+(this codebase's DI decorator, seen on every injectable across the app — not specific
+to this module) rather than a class with an `@Injectable()`-style suffix.
+
+### Routing (`customer.routes.ts`)
+
+| Path | Component | Resolvers |
+|---|---|---|
+| `anlegen` | `CustomerEditComponent` (create mode, no input) | — |
+| `detail/:id` | `CustomerDetailComponent` | `CustomerDataResolver`, `CustomerNotesResolver` |
+| `bearbeiten/:id` | `CustomerEditComponent` (edit mode) | `CustomerDataResolver` |
+| `suchen` | `CustomerSearchComponent` | — |
+| `duplikate` | `CustomerDuplicatesComponent` | `CustomerDuplicatesDataResolver` |
+| `ueber-limit` | `CustomerAboveLimitComponent` | `CustomerAboveLimitDataResolver` |
+
+`CustomerEditComponent` doubles as both the create and edit view: `editMode` is a
+`computed()` off whether the `customerData` input is set, not a separate component.
+
+## Duplicate handling — two distinct flows
+
+There are two separate duplicate-related UI paths in this module; don't conflate them:
+
+1. **Save-time duplicate warning (the "review candidates before creating" flow from
+   `AGENTS.md`'s Special Considerations).** When `CustomerApiService.createCustomer`/
+   `updateCustomer` gets a `409` from the backend (a likely-duplicate match on
+   lastname/firstname/birthdate), `CustomerEditComponent.save()` opens
+   `ConfirmCustomerSaveDialog` with the backend's message ("Trotzdem speichern?"). If
+   the user confirms, the same call is retried with `force: true`, which the API
+   service passes through as a query param on `POST /households`/`POST
+   /households/{id}`.
+2. **Standalone duplicate review list**, `views/customer-duplicates/` +
+   `CustomerDuplicatesDataResolver`. Backed by `GET /households/duplicates` (via
+   `CustomerApiService.getCustomerDuplicates()`), it lists pairs of *already saved*
+   customers the backend considers duplicates so staff can review them later: open a
+   candidate's detail, delete one outright (`deleteCustomer`), or merge one or more
+   candidates into a surviving customer (`mergeCustomers(targetId, sourceIds)` → `POST
+   /households/{id}/merge`, deleting the merged-away records).
+
+Both ultimately go through `customer-api.service.ts`'s translation layer — the
+duplicates response has the same `HouseholdDuplicatesResponse` → `{customer,
+similarCustomers}` mapping as everything else.
+
+## Income validation feedback
+
+Two independent layers, both scoped to the flat `CustomerData`/form model:
+
+- **Client-side, per-field:** `components/customer-form/customer-form.component.ts`
+  builds a `form()` (Angular signal forms) with a schema that calls `validate(schemaPath.income,
+  min(0, {message: 'Einkommen muss mindestens 0 sein'}))` for the main person and for
+  each entry of `additionalPersons` (via `applyEach`). Errors surface using the shared
+  helpers in `common/util/signal-form-helper.ts`:
+  `visibleErrorMessages(fieldState)`/`fieldStateClasses(fieldState)`, both gated on
+  `touched()` (not `dirty()`) so messages don't flash while typing — the signal-forms
+  equivalent of `updateOn: 'blur'`.
+- **Server-side, against the configured income limit:** the "Prüfen" action on
+  `CustomerEditComponent.validate()` calls `CustomerApiService.validate(data)` → `POST
+  /households/validate`, which runs the backend's `IncomeValidatorService` and returns
+  `{valid, totalSum, limit, toleranceValue, amountExceededLimit}`. The result is shown
+  in `views/customer-edit/dialogs/validation-result-dialog.component.ts` — green
+  "Anspruch vorhanden" or red "Kein Anspruch vorhanden" — including the limit
+  (incl. tolerance), total income, and amount over the limit.
+- There's also a standalone review list for customers already over the limit,
+  `views/customer-above-limit/` + `CustomerAboveLimitDataResolver`, backed by `GET
+  /households/above-limit` — the same list-for-manual-review pattern as the duplicates
+  view above.
+
+## Angular idioms used here
+
+- Standalone components everywhere, no `NgModule`.
+- Views that receive resolver data use an aliased `input()`/`input.required()` (alias
+  matches the resolver key in `customer.routes.ts`) paired with a `linkedSignal()` of
+  the same name (without the `Input` suffix) so the page can locally mutate what
+  started as router data (pagination, post-save updates, etc.) without losing the
+  "reset when the route re-resolves" behavior:
+
+  ```ts
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  readonly customerDuplicatesDataInput = input<CustomerDuplicatesResponse>(undefined, {alias: 'customerDuplicatesData'});
+  readonly customerDuplicatesData = linkedSignal(() => this.customerDuplicatesDataInput());
+  ```
+- `customer-form.component.ts` uses Angular's signal-based reactive forms
+  (`@angular/forms/signals`: `form()`, `FormField`, `required()`, `validate()`,
+  `applyEach()`) rather than `FormGroup`/`FormBuilder` — `customer-search.component.ts`
+  is the exception, still on classic `ReactiveFormsModule`/`FormBuilder` since it's a
+  simple filter bar, not a validated data-entry form.
+- `effect()` in the form component's constructor both pushes external `customerData`
+  input changes into the form model and pushes form changes back out via
+  `customerDataChange` (`output()`) — there's no two-way binding, just two one-way
+  effects.
+- `CustomerEditComponent` reads `customerFormComponent().valid()` (a `viewChild.required()`
+  plus `computed()`) to gate the Save button, and calls `markAllAsTouched()` before
+  attempting to save so validation messages show up even if the user never blurred a
+  field.
+
+## What not to do
+
+- Don't import or recreate `HouseholdData`/`PersonData` shapes outside
+  `customer-api.service.ts`. If you find yourself needing a household/person-only field
+  in a component, that's a sign it needs to be added to `CustomerData`/
+  `CustomerAddPersonData` and threaded through the two mapping functions instead.
+- Don't call `/api/households*` endpoints directly from a component — always go through
+  `CustomerApiService`.
+- Don't rename this module's routes, folders, classes or DTOs to "household"/"person"
+  in a partial PR. The mismatch with the backend is intentional and repo-wide (see
+  `AGENTS.md`); a half-renamed module would be worse than a consistently old-named one.

--- a/frontend/src/main/webapp/src/app/modules/dashboard/README.md
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/README.md
@@ -1,0 +1,141 @@
+# Dashboard Module
+
+This module renders the "Übersicht" (overview) landing page — the operational cockpit shown
+while a food distribution ("Ausgabe") is running. It shows whether a distribution is currently
+open, how many customers have registered, how many tickets have been processed, how much food
+has been recorded/collected, and lets staff enter end-of-day statistics (employee count, shelter
+occupancy) and free-text notes. Almost everything on this page is either live (pushed via SSE) or
+gated behind an active distribution.
+
+## Live data: two independent SSE channels
+
+The page is driven by **two separate SSE subscriptions with two separate consumers** — this is
+the single most important thing to understand before touching this module.
+
+### 1. `/sse/dashboard` — owned by `DashboardComponent`
+
+[`dashboard.component.ts`](dashboard.component.ts) injects the shared
+[`SseService`](../../common/sse/sse.service.ts) directly and converts the observable into a
+signal with `toSignal()`:
+
+```ts
+readonly data: Signal<DashboardData | undefined> = toSignal(
+  this.sseService.listen<DashboardData>('/sse/dashboard')
+);
+```
+
+`DashboardData` carries everything that isn't already tracked globally: `registeredCustomers`,
+`tickets` (processed/total), `logistics` (food collection + food amount counters) and `statistics`
+(current employee count / selected shelter names) plus free-text `notes`. The template
+(`dashboard.component.html`) reads `data()` and passes slices of it down as `@Input`-style
+signal inputs to the presentational child components (`tafel-registered-customers`,
+`tafel-tickets-processed`, `tafel-recorded-food-collections`, `tafel-food-amount`,
+`tafel-distribution-statistics-input`, `tafel-distribution-notes-input`). None of those children
+know about SSE at all — they are pure `input()`-driven display/edit components. This keeps the
+"how do we get fresh data" concern in exactly one place (`DashboardComponent`) and the "how do we
+render it" concern in the leaf components.
+
+Because the SSE stream only pushes deltas the backend decides are relevant, several template
+bindings use the `$safeNavigationMigration()` helper to tolerate `undefined` fields on
+partial/initial payloads (e.g. `$safeNavigationMigration(data()?.registeredCustomers)`).
+
+### 2. `/sse/distributions` — owned by `GlobalStateService`, consumed app-wide
+
+The **current distribution** (open/closed state, id, start/end timestamps) is *not* part of
+`DashboardData`. It's tracked globally by
+[`GlobalStateService`](../../common/state/global-state.service.ts), which listens to
+`/sse/distributions` once for the whole app and exposes it as a signal:
+
+```ts
+this.sseService.listen<DistributionItemUpdate>('/sse/distributions', connectionStateCallback)
+  .subscribe({ next: (u) => this._currentDistribution.set(u.distribution) });
+```
+
+Several dashboard components inject `GlobalStateService` and call `getCurrentDistribution()`
+directly, independently of `DashboardComponent`:
+
+- `DistributionStateComponent` — derives `isDistributionActive` (`computed()`) from it to show
+  "Geöffnet"/"Geschlossen" and toggle the start/close-distribution buttons.
+- `RecordedFoodCollectionsComponent` — uses it only to decide the card's color (`panelColor`)
+  when there's no active distribution yet.
+- `DistributionStatisticsInputComponent` and `DistributionNotesInputComponent` — use it to
+  enable/disable their form controls via an `effect()` that resets the form back to empty
+  whenever the distribution closes (see `distributionEffect` in
+  `distribution-statistics-input.component.ts`).
+
+So: **"is a distribution open" flows through `GlobalStateService`/`/sse/distributions`; "what are
+the current numbers" flows through `DashboardComponent`/`/sse/dashboard`.** Don't be tempted to
+duplicate distribution state inside `/sse/dashboard` payloads or vice versa — the split exists so
+other modules (e.g. `checkin`, `logistics`) can reuse `GlobalStateService` without depending on
+this module.
+
+`SseService.listen()` auto-reconnects on `EventSource` errors (1s backoff, see
+`common/sse/sse.service.ts`) and reports connection health via an optional callback —
+`GlobalStateService` wires that into `_connectionState`, but `DashboardComponent` currently
+ignores the callback param entirely for `/sse/dashboard`.
+
+## Folder structure
+
+```
+dashboard/
+  dashboard.component.ts / .html / .spec.ts   # page shell, owns the /sse/dashboard subscription
+  dashboard.routes.ts                          # single '' route, resolves sheltersData
+  resolver/
+    dashboard-shelters-resolver-component.service.ts  # DashboardSheltersDataResolver
+  components/
+    distribution-state/                # open/close distribution card + its 2 confirm dialogs
+    registered-customers/               # customer count card + PDF customer-list download
+    tickets-processed/                  # processed/total ticket count card
+    recorded-food-collections/          # recorded/total food-collection count card
+    food-amount/                        # total recorded food weight (kg) card
+    distribution-statistics-input/      # end-of-day form: employee count + shelter occupancy
+    distribution-notes-input/           # free-text notes form for the distribution
+    select-shelters/                    # multi-select shelter picker + its dialog, used by
+                                         # distribution-statistics-input only
+```
+
+Every component under `components/` is a standalone, presentational-ish component using
+`input()`/`output()`/`computed()`/`linkedSignal()`/`effect()` — none use NgModules, `@Input`, or
+`ngOnInit`. Only `DashboardComponent` itself deals with the SSE stream; everything else is either
+pure presentation (`FoodAmountComponent`, `TicketsProcessedComponent`) or talks to
+`DistributionApiService`/`GlobalStateService` for actions and shared state.
+
+### `resolver/`
+
+`DashboardSheltersDataResolver` (registered in `dashboard.routes.ts`) pre-fetches the active
+shelter list via `ShelterApiService.getActiveShelters()` before the route activates, so
+`sheltersData` is available as a route-resolved `input()` on `DashboardComponent` immediately —
+no loading spinner needed for the shelter picker used by `distribution-statistics-input`.
+
+## Notable component details
+
+- **`DistributionStateComponent`**: the only component that *writes* distribution state
+  (`createNewDistribution()` / `closeDistribution()` via `DistributionApiService`). Closing shows
+  a confirmation dialog first (`CloseDistributionDialogComponent`); if the backend returns
+  validation errors/warnings, a second dialog (`CloseDistributionValidationDialogComponent`)
+  lets the user force-close anyway.
+- **`DistributionStatisticsInputComponent`**: reconciles three signal sources — the SSE-pushed
+  `employeeCountInput`/`initialSelectedShelterNames` (from `DashboardData.statistics`), the
+  resolver-provided `sheltersData`, and locally-typed form state — using a
+  `initialIdsProcessed` guard flag so the SSE-provided initial shelter *names* (not IDs) are only
+  applied to the form once, matched against `sheltersData()` by name.
+- **`RegisteredCustomersComponent`**: the customer-list download button is only visible while a
+  distribution is active (`*tafelIfDistributionActive`), and downloads a PDF by parsing the
+  filename out of the `Content-Disposition` response header.
+- Every panel card visually communicates "warning" vs "success" vs "primary" via `computed()`
+  color functions comparing recorded vs. total counts (e.g. `TicketsProcessedComponent
+  .panelColor`, `RecordedFoodCollectionsComponent.panelColor`) — no shared logic between them, so
+  if you change the color rule, check both.
+
+## Gotchas
+
+- `DashboardComponent` calls `toSignal()` on the SSE observable **without an `initialValue`**, so
+  `data()` is `undefined` until the first message arrives — every template binding that reads
+  `data()?.foo` must handle that (hence the widespread `$safeNavigationMigration()` / `?? null`
+  usage in `dashboard.component.html`).
+- Don't add a new "is a distribution active" flag scoped to this module — always go through
+  `GlobalStateService.getCurrentDistribution()` so `checkin`/`logistics`/other modules stay in
+  sync with the same `/sse/distributions` stream.
+- `distribution-statistics-input` and `distribution-notes-input` both reset their own local state
+  via an `effect()` keyed off `GlobalStateService`'s distribution signal — if you add a new input
+  field to the end-of-day form, remember to also reset it in `distributionEffect`.

--- a/frontend/src/main/webapp/src/app/modules/logistics/README.md
+++ b/frontend/src/main/webapp/src/app/modules/logistics/README.md
@@ -1,0 +1,147 @@
+# Logistics Module
+
+Frontend feature module mounted at `/logistik`, gated by the `LOGISTICS` permission
+(`app.routes.ts` → `anyPermissionOf: ['LOGISTICS']`).
+
+## What's actually here (and what isn't)
+
+Despite the module name, and despite `AGENTS.md` describing the backend `logistics`
+module as covering "routes, food collections, shelters, shops, cars, and food
+category management", **this frontend module contains a single screen**:
+**Warenerfassung** (food collection recording), reachable at `/logistik/warenerfassung`
+via `logistics.routes.ts`.
+
+There is no route/shop/car management UI, and shelter and food-category admin
+screens are **not** here — they live in the
+[`settings` module](../settings/README.md) (`views/shelters`,
+`views/food-categories`). This module only *reads* routes, shops, cars and food
+categories to populate the recording form; it never creates or edits them.
+
+## Structure
+
+```
+logistics/
+  components/
+    tafel-employee-search-create.component.ts   # driver/co-driver lookup widget
+    dialogs/
+      create-employee-dialog.component.ts        # shown when search finds 0 matches
+      select-employee-dialog.component.ts         # shown when search finds >1 matches
+  resolver/
+    route-data-resolver.component.ts              # GET /routes
+    car-data-resolver.component.ts                # GET /cars
+    food-categories-data-resolver.component.ts    # GET /food-categories/active
+  views/
+    food-collection-recording/                    # container: route picker + tabs
+    food-collection-recording-basedata/           # tab 1: car/driver/km
+      dialogs/km-diff-dialog.component.ts
+    food-collection-recording-items-desktop/      # tab 2, desktop layout
+    food-collection-recording-items-responsive/   # tab 2, mobile layout
+  logistics.routes.ts
+```
+
+## Food collection recording (`warenerfassung`)
+
+`FoodCollectionRecordingComponent` (`views/food-collection-recording`) is the
+container. It receives `routeList`, `carList` and `foodCategories` as
+`model.required()` inputs, pre-populated by the three resolvers above via
+`logistics.routes.ts`'s `resolve: {...}` block — all three fire in parallel before
+the route activates. Selecting a route from the `<select>` triggers
+`onSelectedRouteChange()`, which `forkJoin`s the existing food-collection data for
+that route (`FoodCollectionsApiService.getFoodCollection`) with the shops assigned
+to it (`RouteApiService.getShopsOfRoute`) and publishes both as a
+`SelectedRouteData` signal. That signal — and the `SelectedRouteData` interface
+itself, exported from this file — is what the two tabs below consume; there's no
+shared state service, just this one exported interface passed down as `input()`.
+
+The component redirects back to `uebersicht` via an `effect()` if no distribution
+is currently active (`GlobalStateService.getCurrentDistribution()`), consistent
+with the `tafelIfDistributionActive` pattern described in `AGENTS.md`.
+
+### Tab 1 — Basedata (`food-collection-recording-basedata`)
+
+Car selection, driver/co-driver assignment, and start/end odometer (`km`) entry
+for the route/vehicle combination.
+
+- Driver and co-driver are each picked via a
+  `TafelEmployeeSearchCreateComponent` (in `components/`). Typing a personnel
+  number and triggering the search (`triggerSearch()`) branches three ways:
+  exactly one match auto-emits `selectedEmployee`; more than one opens
+  `SelectEmployeeDialogComponent` (paginated picker); zero matches opens
+  `CreateEmployeeDialogComponent` (inline employee creation). Both dialogs close
+  with the chosen/created `EmployeeData`, which the parent's
+  `setSelectedDriver`/`setSelectedCoDriver` then feeds into a
+  `CustomValidator.hasValue(...)` validator on the corresponding search-input
+  control — so the text field itself is what's marked invalid until a concrete
+  employee has actually been resolved, not just typed.
+- `km` fields carry a form-level cross-field validator
+  (`createKmValidation()`) that sets an error on `kmEnd` whenever
+  `kmStart >= kmEnd`.
+- If `kmEnd - kmStart > 350`, saving opens `KmDiffDialogComponent` for
+  confirmation before actually persisting (`save(overrideKmDiff = true)` on
+  confirm) — a sanity check against fat-fingered odometer entry.
+- When switching routes, the effect resets the whole form and, if a saved
+  `FoodCollectionData` exists for the new route, re-populates it — including
+  re-triggering the employee search via `setTimeout(...)` so the search-create
+  component's internal state re-syncs after view stabilization (zoneless mode
+  means this can't rely on a digest cycle).
+
+### Tab 2 — Items (desktop vs. responsive)
+
+Both `FoodCollectionRecordingItemsDesktopComponent` and
+`FoodCollectionRecordingItemsResponsiveComponent` are **always both instantiated**
+in `food-collection-recording.component.html`; there's no `@if` switching between
+them. Visibility is purely a Tailwind class toggle:
+
+```html
+<div class="hidden md:block"><tafel-food-collection-recording-items-desktop .../></div>
+<div class="block md:hidden"><tafel-food-collection-recording-items-responsive .../></div>
+```
+
+This is a gotcha for anyone touching either component: **both run their
+`effect()`s and fire their own API calls simultaneously**, even though only one is
+visible at a given viewport width. There's no lazy instantiation based on actual
+breakpoint detection.
+
+- **Desktop** (`items-desktop`): a full grid — one `FormArray` row per food
+  category, each containing a nested `FormArray` of per-shop amount inputs — saved
+  in one batch via `FoodCollectionsApiService.saveItems()`.
+- **Responsive** (`items-responsive`): a one-shop-at-a-time flow using
+  `TafelCounterInputComponent`, with prev/next navigation between shops
+  (`selectPreviousShop`/`selectNextShop`) and `findNextUnfilledShop()` to jump to
+  the first incomplete shop on load. Every keystroke triggers an individual PATCH
+  (`FoodCollectionsApiService.patchItems`) rather than a batch save. These patches
+  are queued and sent **one at a time** (`itemPatchQueue` / `itemPatchInFlight`)
+  instead of firing in parallel — a fix for a race condition where a slower
+  earlier request could overwrite a value typed afterward (see commit
+  `01e32338`, "Fix race condition overwriting food collection amounts on rapid
+  input"). If you touch this queuing logic, keep the serialization: parallel
+  PATCHes reintroduce the bug it fixed.
+
+## Resolvers
+
+`RouteDataResolver`, `FoodCategoriesDataResolver` and `CarDataResolver`
+(`resolver/`) are plain data-fetching resolvers wired into
+`logistics.routes.ts`'s `resolve` map. Note they're decorated with `@Service()`
+(this repo's convention/alias, imported from `@angular/core` — not
+`@Injectable()`), consistent with every other resolver and API service in the
+codebase.
+
+## API services
+
+All HTTP calls go through services in `app/api/` (per the project convention —
+API services live outside `modules/`, suffixed `-api.service.ts`), not inside
+this module:
+
+- `route-api.service.ts` — `RouteApiService` (`GET /routes`,
+  `GET /routes/{id}/shops`), exports the `Shop`/`RouteData`/`RouteList` shapes
+  used throughout this module.
+- `car-api.service.ts` — `CarApiService` (`GET /cars` only — no create/update).
+- `food-categories-api.service.ts` — `FoodCategoriesApiService`; this module only
+  calls `getActiveFoodCategories()` (enabled categories for the recording form).
+  The full CRUD + reorder methods (`getAllFoodCategories`, `createFoodCategory`,
+  `updateFoodCategory`, `reorderFoodCategories`) exist on the same service but are
+  only consumed from `settings/views/food-categories`.
+- `food-collections-api.service.ts` — `FoodCollectionsApiService`, the
+  read/save/patch endpoints described above.
+- `employee-api.service.ts` — used by the driver/co-driver search-and-create
+  flow.

--- a/frontend/src/main/webapp/src/app/modules/settings/README.md
+++ b/frontend/src/main/webapp/src/app/modules/settings/README.md
@@ -1,0 +1,149 @@
+# Settings Module
+
+Frontend feature module mounted at `/einstellungen`, gated by the `SETTINGS`
+permission (`app.routes.ts` → `anyPermissionOf: ['SETTINGS']`).
+
+Per `AGENTS.md` this module owns "system settings and mail recipient
+configuration" — but it has grown into the catch-all admin area for several
+small reference-data screens, **including the food-category admin UI added in
+commit `8f2c11e2`, "Add admin UI to maintain food categories" (#2806)**, which
+lives here under `views/food-categories`, not under `modules/logistics` despite
+food categories conceptually belonging to the logistics/food-collection domain.
+If you're looking for where shelters or food categories are *managed* (as
+opposed to just *read*, which happens in `logistics`), it's here.
+
+## Structure
+
+```
+settings/
+  components/
+    mail-recipients/    # recipient address matrix, used by views/email
+    send-mails/          # re-send mails for a past distribution, used by views/email
+  views/
+    email/                       # route: einstellungen/email
+    shelters/                    # route: einstellungen/notschlafstellen
+      dialogs/
+        shelter-edit-dialog.component.ts
+        shelter-details-dialog.component.ts
+    food-categories/              # route: einstellungen/lebensmittelkategorien
+      dialogs/
+        food-category-create-dialog.component.ts
+    static-values/                 # route: einstellungen/statische-werte
+      static-value-type-labels.ts
+  settings.routes.ts
+```
+
+Note the `views/` folders here nest their own `dialogs/` subfolders directly
+(rather than a top-level `components/` shared across all views) — `components/`
+is reserved for the two pieces shared by the `email` view specifically.
+
+## `email` (`SettingsEmailComponent`)
+
+A thin composition of two independent, self-contained components — the view
+itself has no logic, just `imports: [MailRecipientsComponent, SendMailsComponent]`.
+
+- **`mail-recipients.component.ts`**: builds a nested reactive form —
+  `mailRecipients: FormArray` of `{ mailType, recipients: FormArray of { recipientType, addresses: FormArray<string> } }` —
+  from the cross product of `MailTypeEnum` (`DAILY_REPORT`, `STATISTICS`,
+  `RETURN_BOXES`) and `RecipientTypeEnum` (`TO`, `CC`, `BCC`), both from
+  `settings-api.service.ts`. It's populated inside an `effect()` in the
+  constructor that fetches `getMailRecipients()` once and manually pushes
+  `FormGroup`s into the array — there's no resolver for this one, unlike most
+  other list screens in the app. Labels for both enums are hardcoded as
+  `Record<..., string>` maps on the component (`MailTypeLabels`,
+  `RecipientTypeLabels`) rather than extracted to a separate labels file (contrast
+  with `static-value-type-labels.ts` below).
+- **`send-mails.component.ts`**: lets an admin pick a past distribution
+  (`DistributionApiService.getDistributions()`) and re-trigger its mail
+  post-processors via `DistributionApiService.sendMails(id)` — useful when the
+  automatic send after closing a distribution failed or needs to go out again.
+
+## `shelters` (`SettingsSheltersComponent`)
+
+CRUD + drag-and-drop reordering for shelters (Notschlafstellen), added most
+recently (commit `77d1af19`, "Add sortOrder + drag-and-drop reordering to
+Shelters"). Loads via `ShelterApiService.getAllShelters()` into a signal
+(`_shelters`), with a Material table (`displayedColumns = ['drag', 'active',
+'name', 'address', 'persons', 'actions']`).
+
+- **Reordering** uses Angular CDK drag-and-drop directly on the table rows:
+  `CdkDropList` on the table body, `CdkDrag` per `<tr>`, `CdkDragHandle` on a
+  dedicated grip-icon column (`faGripVertical`) so the whole row isn't
+  draggable from anywhere. The `drop()` handler uses CDK's `moveItemInArray()`
+  helper to reorder the in-memory array **optimistically**, then POSTs the new
+  id order to `ShelterApiService.reorderShelters()`; on success the signal is
+  replaced with the server's authoritative response, on error it's reloaded
+  from scratch (`loadShelters()`) to undo the optimistic move. The
+  `food-categories` view below implements the identical pattern — if you
+  change one, check the other.
+- `sortOrder` itself is present on `ShelterItem` but explicitly **not editable**
+  in `shelter-edit-dialog.component.ts` (see the comment there) — it's
+  server-assigned on create and only changes via drag-and-drop afterwards.
+- **Edit dialog** (`shelter-edit-dialog.component.ts`) manages a nested
+  `contacts: FormArray` of `{ firstname, lastname, phone }` groups
+  (`addContact()`/`removeContact()`), with manual `ChangeDetectorRef.detectChanges()`
+  calls after array mutation — a sign this predates/coexists with signal-based
+  change detection elsewhere in the app.
+- **Details dialog** (`shelter-details-dialog.component.ts`) is a plain read-only
+  view, opened via the table's "view" action.
+- This `sortOrder` is also now respected outside this module: the dashboard
+  shelter listing and the daily-report PDF were updated in a follow-up commit
+  (`9b7dd281`, "Respect shelter sortOrder in dashboard and daily report PDF") to
+  use the same ordering — so reordering here has visible effects well beyond
+  this screen.
+
+## `food-categories` (`SettingsFoodCategoriesComponent`)
+
+CRUD + reordering for food categories, structurally the twin of `shelters`
+above (same `CdkDropList`/`CdkDrag`/`CdkDragHandle` + `moveItemInArray` +
+optimistic-update-then-reconcile pattern against
+`FoodCategoriesApiService.reorderFoodCategories()`).
+
+Differences worth knowing:
+
+- **Inline editing**, not a dialog: clicking edit (`startEdit()`) sets an
+  `editingId` signal and swaps that row's cells for a `nameControl`/
+  `weightPerUnitControl` pair; `saveEdit()`/`cancelEdit()` exit the mode. A
+  `viewChild` + `effect()` auto-focuses the name input whenever it appears —
+  the same focus-on-appear trick is reused in `static-values` below. This
+  replaced an earlier dialog-based editor (commits `907d9cb8`, `80a53516`,
+  `a30b6a36` progressively moved edit inline, dropped the return-item toggle
+  from inline editing, and swapped a manual "Sortierung" number input for
+  drag-and-drop).
+- **Creation still uses a dialog** (`food-category-create-dialog.component.ts`),
+  which does expose `returnItem` (Pfandartikel/deposit-return flag) as a
+  checkbox — inline editing intentionally does not let you touch `returnItem`
+  or `sortOrder` after creation.
+- `enabled`/disabled categories: `toggleFoodCategoryVisibility()` flips
+  `enabled` via the same update endpoint used for name/weight edits. A disabled
+  category is excluded from `FoodCategoriesApiService.getActiveFoodCategories()`,
+  which is what feeds the `logistics` module's food-collection-recording form —
+  so disabling a category here immediately removes it from that form's category
+  list. The edit button is disabled for disabled categories (commit
+  `909ca265`) to avoid editing something that's effectively archived.
+
+## `static-values` (`SettingsStaticValuesComponent`)
+
+Read-mostly table of numeric business constants (income limit, additional
+adult/child amounts, tolerance, family bonus, child tax allowance, sibling
+addition, cost contribution — the full `StaticValueTypeEnum` from
+`settings-api.service.ts`). Same inline-edit-with-autofocus pattern as
+food-categories (`editingId` signal + `viewChild`/`effect()` focus), but no
+create, delete, or reordering — only `amount` is editable per row via
+`updateStaticValue()`. Human-readable labels for the enum are centralized in
+`static-value-type-labels.ts` (`staticValueTypeLabels: Record<StaticValueTypeEnum, string>`)
+rather than inlined on the component, unlike `mail-recipients`' `MailTypeLabels`
+map — if you add a new static value type, update that file, not the component.
+
+## API services
+
+As elsewhere, HTTP access lives in `app/api/`, not under this module:
+
+- `settings-api.service.ts` — mail recipients, static values, and their
+  `MailTypeEnum`/`RecipientTypeEnum`/`StaticValueTypeEnum` definitions.
+- `shelter-api.service.ts` — `ShelterApiService`, including `reorderShelters()`.
+- `food-categories-api.service.ts` — `FoodCategoriesApiService`, shared with
+  `logistics` (which only calls its read side; full CRUD + reorder is only
+  exercised from this module).
+- `distribution-api.service.ts` — used by `send-mails` to list distributions and
+  trigger re-sends.

--- a/frontend/src/main/webapp/src/app/modules/statistics/README.md
+++ b/frontend/src/main/webapp/src/app/modules/statistics/README.md
@@ -1,0 +1,118 @@
+# Statistics Module
+
+This module ("Statistiken" in the nav, route `statistiken`) is the historical/aggregate
+reporting screen — as opposed to the `dashboard` module's live, per-distribution cockpit. It lets
+staff pick a date range (or a specific past distribution, or "current month", or a whole year),
+fetches aggregated counters for that range from the backend, renders them as small Chart.js line
+charts, and offers a CSV export of the same range.
+
+It is unrelated to the `dashboard` module's "statistics" input card (`distribution-statistics-input`,
+which records *today's* employee count / shelter occupancy for the currently open distribution).
+This module reports on *closed* distributions over arbitrary time ranges — see "Relationship to
+the dashboard module" below.
+
+## Folder structure
+
+```
+statistics/
+  statistics.component.ts / .html / .spec.ts   # page: date-range picker + CSV export + panels
+  statistics.routes.ts                         # single '' route, provides ng2-charts + resolver
+  resolver/
+    statistics-settings-resolver.component.ts  # StatisticsSettingsResolver -> StatisticsSettings
+  components/
+    statistics-panel.component.ts / .html / .spec.ts  # one Chart.js line-chart "tile"
+```
+
+Only 6 source files (+ specs) — there is no `components/` subfolder split beyond the single
+reusable panel, since `StatisticsComponent` itself is the only page-level view.
+
+## How the date range drives data
+
+`StatisticsComponent` keeps the range as two signals, `_dateRangeFrom` / `_dateRangeTo`, exposed
+as a combined `computed()` called `dateRange`. Four mutually exclusive input modes
+(`year` / `currentMonth` / `distribution` / `custom`, a `mat-button-toggle-group` in the template)
+all funnel into setting those two signals — e.g. picking a year computes Jan 1–now (current year)
+or Jan 1–Dec 31 (past year) via `dayjs`; picking a past distribution copies its
+`startDate`/`endDate` straight from `StatisticsSettings.distributions` (supplied by the resolver).
+
+The actual data fetch is reactive, not imperative — no manual `.subscribe()` call on range change:
+
+```ts
+statisticsData = toSignal(
+  toObservable(this.dateRange).pipe(
+    switchMap(range => this.statisticsApiService.getData(range.from, range.to))
+  )
+);
+```
+
+`toObservable(this.dateRange)` re-emits whenever any of the mode-switching methods above updates
+`_dateRangeFrom`/`_dateRangeTo`, `switchMap` cancels any in-flight request for the previous range,
+and `toSignal()` turns the result back into a signal the template reads directly with
+`statisticsData()`. There is no SSE involved anywhere in this module — everything here is a plain
+resolved HTTP `GET` (`/statistics/data`, `/statistics/settings`, `/statistics/generate-csv`), since
+it reports on data that has already settled (past or closing distributions), unlike `dashboard`'s
+live counters.
+
+## Charts: `StatisticsPanelComponent`
+
+Each of the nine tiles rendered in `statistics.component.html` (see below) is one
+`<tafel-statistics-panel [data]="...">`, wrapping a single `ng2-charts` `<canvas baseChart>` line
+chart. `StatisticsPanelComponent` just reshapes the incoming `StatisticsDetailData` (`title`,
+`subTitle`, `labels`, `dataPoints`) into the Chart.js `data`/`options` shape via a `computed()`
+(`chartData`), and applies one fixed, shared `optionsDefault` object: no axes, no legend, no
+gridlines — these are meant to read as compact sparklines with a big number/title overlaid via
+plain HTML (`data()?.title` / `data()?.subTitle`), not as analytical charts with tickable axes.
+`ng2-charts`' `provideCharts(withDefaultRegisterables())` is registered as a route-level provider
+in `statistics.routes.ts` rather than app-wide, so Chart.js is only pulled in when this route is
+actually navigated to.
+
+`StatisticsComponent`'s template feeds all nine `StatisticsData` fields from the
+`/statistics/data` response into panels, grouped under three headings:
+
+- **Kunden und Personen** (customers/persons): `beneficiaryCustomers`, `beneficiaryPersons`,
+  `beneficiaryCustomersWithChildren`
+- **Notschlafstellen** (shelters): `sheltersCount`, `sheltersAverage`, `sheltersPersonsCount`
+- **Transport- / Logistik**: `shopsCount`, `shopItemsTotal`, `shopItemsAverage`
+
+All nine are typed in `app/api/statistics-api.service.ts` as `StatisticsDetailData` — the same
+shape for every panel (`title`/`subTitle`/`labels`/`dataPoints`), so adding a tenth metric on the
+backend just means adding one more field to `StatisticsData` and one more
+`<tafel-statistics-panel>` in the template; `StatisticsPanelComponent` needs no changes.
+
+## `resolver/`
+
+`StatisticsSettingsResolver` pre-fetches `/statistics/settings` (available years +
+past-distribution date ranges) before the route activates, so `StatisticsComponent.settings` is
+populated as a route-resolved `input()` before first render — used to populate the year dropdown
+(`yearOptions`, deduplicated + sorted descending, always includes the current year even if the
+backend hasn't recorded it yet) and the distribution dropdown.
+
+## Relationship to the dashboard module
+
+There are **no cross-imports** between `modules/dashboard` and `modules/statistics` — confirmed:
+neither module's components, services, or routes reference the other. They're loaded as fully
+independent lazy routes in `app.routes.ts` (`uebersicht` vs `statistiken`), gated by different
+permissions (`anyPermission: true` for dashboard, `anyPermissionOf: ['STATISTICS']` here), and
+talk to entirely different backend API surfaces (`DistributionApiService`/`ShelterApiService` for
+dashboard vs. `StatisticsApiService` here). The naming overlap is coincidental:
+
+- `dashboard`'s "statistics" (`distribution-statistics-input`) = data *entry* for the
+  **currently open** distribution (employee count, shelter occupancy), pushed live via
+  `/sse/dashboard`.
+- `statistics` module (this one) = historical *reporting* across arbitrary/past date ranges,
+  fetched via plain HTTP, visualized as Chart.js line charts, exportable as CSV.
+
+If you're looking for where an "average shelter occupancy over the last quarter" type feature
+would go, it belongs here, not in `dashboard`.
+
+## Gotchas
+
+- `dateRangeFrom`/`dateRangeTo` getters/setters on `StatisticsComponent` exist only to bridge the
+  `Date`-typed signals to the `<input type="date">` two-way `[(ngModel)]` binding (which needs
+  `'YYYY-MM-DD'` strings) — don't replace the signals themselves with strings, the `dateRange`
+  `computed()` and the API calls expect `Date` objects.
+- Switching to `'custom'` mode doesn't reset `_dateRangeFrom`/`_dateRangeTo` — it keeps whatever
+  the previous mode left behind, so the date inputs start prefilled with the last active range.
+- `statisticsData()` is `undefined` until the first response arrives; the results card
+  (`@if (statisticsData())`) is entirely absent from the DOM until then — there's no loading
+  spinner, so a slow `/statistics/data` response just shows nothing below the range picker.

--- a/frontend/src/main/webapp/src/app/modules/user/README.md
+++ b/frontend/src/main/webapp/src/app/modules/user/README.md
@@ -1,0 +1,157 @@
+# User Module
+
+Administration of application users: search, create, edit (including permission assignment and password
+reset-by-admin), enable/disable, delete. Mounted at `/benutzer` (`user.routes.ts`) and gated in `app.routes.ts`
+with `data: { anyPermissionOf: ['USER_MANAGEMENT'] }` — the module manages the very permission that unlocks it.
+
+## Components
+
+```
+modules/user/
+  ├── resolver/userdata-resolver.component.ts          # UserDataResolver: GET /users/{id}
+  ├── resolver/permissionsdata-resolver.component.ts    # PermissionsDataResolver: GET /users/permissions
+  ├── views/user-search/user-search.component.ts        # search + paginated result list/table
+  ├── views/user-edit/user-edit.component.ts             # thin shell used for BOTH create and edit
+  ├── views/user-detail/user-detail.component.ts         # read-only detail + enable/disable/delete menu
+  ├── components/user-form/user-form.component.ts        # the actual reactive form (fields + permissions grid)
+  └── components/user-passwordchange/user-passwordchange.component.ts # wraps the shared password-change form
+```
+
+Despite the `-resolver.component.ts` filename suffix (an `AGENTS.md`-documented convention shared across the whole
+frontend), `UserDataResolver` and `PermissionsDataResolver` are plain injectable classes with a `resolve()` method —
+not components.
+
+### Routes and how create vs. edit is decided
+
+`user.routes.ts` reuses the *same* `UserEditComponent` for both `erstellen` (create) and `bearbeiten/:id` (edit); the
+only difference is which resolvers run:
+
+```ts
+{ path: 'bearbeiten/:id', component: UserEditComponent, resolve: { userData: UserDataResolver, permissionsData: PermissionsDataResolver } },
+{ path: 'erstellen', component: UserEditComponent, resolve: { permissionsData: PermissionsDataResolver } },
+```
+
+`UserEditComponent.userData` is an `input<UserData>()` that simply stays `undefined` on the create route (no
+resolver populates it). Everything downstream — "am I creating or editing?", which API call `save()` makes,
+whether fields start pre-filled and touched — hinges on that single `undefined` check:
+
+```ts
+if (!this.userData()) {
+  this.userApiService.createUser(this.userUpdated()!).subscribe(observer);
+} else {
+  this.userApiService.updateUser(this.userUpdated()!).subscribe(observer);
+}
+```
+
+### UserFormComponent — the actual form
+
+This is where the interesting form handling lives, and it's worth knowing it uses the newer
+`@angular/forms/signals` API (`form()`, `FormField`, `required`, `maxLength`, `validate`) rather than a classic
+`FormGroup`/`FormBuilder` — the same pattern used in `checkin`'s `ticket-screen-control` and in the shared
+`passwordchange-form`. `AGENTS.md` just says "reactive forms for all form handling," which is true but doesn't
+tell you which flavor to expect.
+
+Two things worth calling out:
+
+- **Permissions are not part of the signal form at all.** `permissions = signal<UserPermissionFormItem[]>([])` is a
+  plain array signal, populated/reset by an `effect()` whenever `userData`/`permissionsData` inputs change, and
+  each checkbox is toggled manually via `togglePermission(index)` — there's no `FormField` binding for it. That
+  means `isValid()` (which only reads `this.userForm().valid()`) never reflects the permissions grid: a user can
+  be saved with every permission unchecked and the form still reports valid.
+- **Blank password fields mean "don't change it," not "clear it."** `derivedUserData` explicitly coerces empty
+  strings to `undefined` before emitting:
+  ```ts
+  password: formValue.password || undefined,
+  passwordRepeat: formValue.passwordRepeat || undefined,
+  ```
+  `generatePassword()` (`GET /users/generate-password`) writes the generated value directly into both password
+  field values and flips the show/hide signals so the generated password is visible in the clear — useful to know
+  when writing a Cypress test against this button.
+
+### UserEditComponent glue
+
+`userUpdated = linkedSignal<UserData | undefined>(() => this.userData())` holds the live edited value, updated via
+the form's `(userDataChange)` output. An `afterRenderEffect()` marks the whole form touched once real `userData`
+arrives (so an existing user's validation state — e.g. a field that's actually invalid — shows immediately), but
+this deliberately does *not* fire on the blank create form, so a brand-new form doesn't show a wall of "required"
+errors before the user has typed anything.
+
+### UserSearchComponent
+
+Two independent search paths in one screen:
+
+- **Direct lookup**: `searchForPersonnelNumber()` → `UserApiService.getUserForPersonnelNumber(...)` →
+  navigates straight to `/benutzer/detail/:id` on a hit, toasts "Benutzer nicht gefunden!" on 404.
+- **Filtered/paginated search**: `searchForDetails(page?)` → `UserApiService.searchUser(username, enabled,
+  lastname, firstname, page)` → renders a `mat-table` on desktop and a card list below the `md` breakpoint, both
+  driven by the same `mat-paginator`.
+
+The filter fields also use `@angular/forms/signals`' `form()`, but with no validators — it's a query, not
+data entry. Minor naming nit if you go digging: `editUser(personnelNumber: number | undefined)` is actually called
+with `user.id` from the template (`editUser(user.id)`), and both `detail/:id` and `bearbeiten/:id` route on the
+numeric user id — the parameter name is just misleading, there's no functional bug.
+
+### UserDetailComponent
+
+Read-only view plus a `mat-menu` with enable/disable/delete actions.
+`currentUserData = linkedSignal(() => this.userData())` lets `disableUser()`/`enableUser()` update the screen
+immediately from the `updateUser()` response, without re-resolving the route.
+
+### UserPasswordChangeComponent — a different password-change path entirely
+
+This wraps the **shared** `common/views/passwordchange-form/passwordchange-form.component.ts`
+(`PasswordChangeFormComponent`), and it's mounted **outside** the `USER_MANAGEMENT`-gated route tree: as
+`path: 'passwortaendern'` directly under the top-level authenticated layout in `app.routes.ts`, so *any* logged-in
+user can change their own password regardless of whether they hold `USER_MANAGEMENT`. The same
+`PasswordChangeFormComponent` is also reused by the login module's forced-password-change flow
+(`login/passwortaendern`). It talks to a completely separate endpoint/shape
+(`UserApiService.changePassword` → `POST /users/change-password` with `ChangePasswordRequest`) than the
+admin-edits-someone-else's-password flow in `UserFormComponent` (which just sets `password`/`passwordRepeat` on
+the `UserData` object and goes through `createUser`/`updateUser`). Two distinct password-change code paths live
+under this module's directory tree — don't assume there's only one.
+
+## Permission model (USER_MANAGEMENT)
+
+Access control for this whole module is enforced **once, at the router boundary**, not per-component:
+
+```ts
+{
+  path: 'benutzer',
+  loadChildren: () => import('./modules/user/user.routes').then(m => m.routes),
+  data: { anyPermissionOf: ['USER_MANAGEMENT'] }
+}
+```
+
+`authGuardChild` → `AuthGuardService.canActivate()` (`common/security/authguard.service.ts`) reads that
+`anyPermissionOf` route data and checks it against `AuthenticationService.hasAnyPermissionOf(...)`, redirecting to
+login on failure. Note the guard class lives in `common/security/`, not `common/directive/` — worth knowing if
+`AGENTS.md`'s grouping of "custom directives" leads you to go looking for it there.
+
+There is **no** use of the `tafelIfPermission` directive (`common/security/tafel-if-permission.directive.ts`)
+anywhere inside this module — that directive is for toggling individual pieces of UI within an already-permitted
+page (e.g. dashboard widgets), whereas here the entire route subtree is already gated, so nothing inside needs a
+second check.
+
+The list of assignable permissions (including `USER_MANAGEMENT` itself) is **not** hardcoded in the frontend — it
+comes from the backend at runtime via `PermissionsDataResolver` → `GET /users/permissions`. Per `AGENTS.md`'s
+"Adding a New Permission" workflow, once a new permission is added to the backend enum and given a description in
+`application.yml`, a corresponding checkbox appears in `UserFormComponent`'s permission grid automatically —
+no frontend change needed for that part.
+
+## API surface (`api/user-api.service.ts`, all under `/api/users`)
+
+`changePassword`, `getUserForId`, `getUserForPersonnelNumber`, `searchUser` (paginated), `updateUser`,
+`deleteUser`, `createUser`, `generatePassword`, `getPermissions`.
+
+## Gotchas
+
+- `*-resolver.component.ts` files here are not components — just injectable resolver classes.
+- `UserFormComponent`'s validity check ignores the permissions grid entirely; don't assume "form valid" implies
+  "at least one permission selected."
+- Empty password fields are intentionally converted to `undefined`, not `''`, before being sent to the backend.
+- There are two unrelated password-change flows under this module: admin-sets-password-for-another-user (via
+  `UserFormComponent`/`createUser`/`updateUser`) and self-service change-my-own-password (via
+  `UserPasswordChangeComponent` → shared `PasswordChangeFormComponent` → `/users/change-password`), and only the
+  first one lives inside the `USER_MANAGEMENT`-gated route tree.
+- `UserEditComponent.save()` decides create vs. update purely from whether `userData()` is `undefined` — there is
+  no explicit "mode" flag.


### PR DESCRIPTION
## Summary

Closes #2810 — the repo had almost no per-module documentation beyond the top-level `README.md`/`AGENTS.md`.

- Add a `README.md` to every backend Spring Modulith module (household, distribution, logistics, checkin, dashboard, reporting, settings, base) and every frontend Angular feature module (customer, checkin, logistics, dashboard, statistics, user, settings) — purpose, key components, real usage examples, and gotchas, matching the style of the pre-existing `database/common/lock/README.md`.
- Add Javadoc summaries to all `package-info.java` files (rendered into Spring Modulith's generated module docs).
- Add KDoc to non-obvious backend classes: `HouseholdDuplicationService` (fuzzy duplicate matching), `IncomeValidatorServiceImpl` (income limit algorithm), `SseOutboxService`/`SseOutboxListenerService` (outbox pattern), `DistributionPostProcessorService`/`DistributionPostProcessor` (post-close side-effect chain).
- Add `CONTRIBUTING.md` distilling setup, enforced conventions, and PR/commit style out of `AGENTS.md`/`README.md`.
- Fix the existing `lock/README.md`, which documented lock keys (`DISTRIBUTION_MANAGEMENT`, `CUSTOMER_TICKET_ASSIGNMENT`, `FOOD_COLLECTION_UPDATE`) that no longer exist in the real `AdvisoryLockKey` enum, and referenced a nonexistent `isLockHeld` method.
- Fix stale facts in `AGENTS.md` found while writing the module READMEs: the frontend `logistics` module only does food collection recording (shelter/food-category admin actually live under `settings`), scanner QR decoding uses `@zxing/browser` not `html5-qrcode`, and the active-distribution check is `@TafelActiveDistributionRequired` enforced by a `HandlerInterceptor`, not an AOP aspect. Also dropped a dangling reference to a nonexistent `ANGULAR_SIGNAL_PATTERNS.md`.

## Follow-up fixes found while documenting

A few things surfaced during research that were real bugs, not just doc gaps. Fixed here since they were simple and well-contained:

- **Advisory-lock id collision**: `checkin`'s `ScannerRegistrationRepository` used a raw `pg_advisory_lock(1000)`, colliding with `AdvisoryLockKey.CREATE_DISTRIBUTION` (also `1000`, via `pg_try_advisory_xact_lock`) — Postgres advisory locks share one keyspace regardless of session vs. transaction scope. Registered a dedicated `AdvisoryLockKey.SCANNER_REGISTRATION(5000L)` and moved `ScannerService.registerScanner()` onto the shared `AdvisoryLockService`.
- **Permission inconsistency**: `SheltersController` only checked `isAuthenticated()` on every endpoint, including create/update/reorder, even though its admin screen lives behind the `SETTINGS`-gated settings module and its sibling `FoodCategoriesController` already required `SETTINGS` on the equivalent endpoints. Any authenticated user could create/update/reorder shelters via the API. Now requires `SETTINGS` on the mutating endpoints, keeping the read-only `/active` endpoint at `isAuthenticated()` (it's used broadly, e.g. from the dashboard).
- **Dead code**: removed the unused, misnamed `RouteShopRepository` (`JpaRepository<RouteStopEntity, Long>` despite its name — `ShopService` goes through `RouteRepository` instead).

## Test plan

- [x] `./gradlew :backend:compileKotlin` / `:backend:compileTestKotlin` and `:backend:ktlintCheck` pass
- [x] `./gradlew :backend:test` for the touched classes (`ScannerServiceTest`, `SheltersControllerTest`, `FoodCategoriesControllerTest`, and the wider `logistics`/`checkin` test packages) passes
- [x] Updated `ScannerServiceTest` to mock the shared `AdvisoryLockService` instead of the removed raw repository lock methods