### PR TITLE
Add JSDoc to non-obvious frontend TypeScript code

### DIFF
--- a/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
+++ b/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
@@ -5,6 +5,22 @@ import {catchError} from 'rxjs/operators';
 import {AuthenticationService} from '../security/authentication.service';
 import {TafelToastrService} from '../components/tafel-toastr/tafel-toastr.service';
 
+/**
+ * Central HTTP error handling, applied to every request. Three independent stages are chained
+ * with `catchError`, each re-throwing so the next stage (and finally the caller) still sees the
+ * error - this interceptor never swallows an error, it only reacts to it:
+ *
+ * 1. {@link handleAuthError} - force a logout redirect on a `401` while already authenticated
+ *    (an expired session), so a stale session doesn't silently keep failing requests.
+ * 2. {@link remapErrorBodyOnByteArrayResponseType} - works around
+ *    {@link https://github.com/angular/angular/issues/19148 angular#19148}: for `responseType:
+ *    'blob'` requests (PDF downloads), Angular still delivers a JSON error body as a `Blob`
+ *    instead of parsing it, so this reads the blob as text and re-parses it into the same shape a
+ *    non-blob request would have gotten.
+ * 3. {@link handleErrorMessage} - shows a toast with the backend's error message, unless the
+ *    status is in `ERROR_CODES_WHITELIST` (callers handling those themselves, e.g. inline form
+ *    validation on `400`/`409`, or the login screen on `401`/`404`).
+ */
 export const errorHandlerInterceptor: HttpInterceptorFn = (
   request: HttpRequest<unknown>,
   next: HttpHandlerFn

--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
@@ -10,6 +10,13 @@ export class AuthenticationService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
 
+  /**
+   * Logs in and, on success, also loads the user's permissions before resolving - callers can
+   * treat a resolved `login()` as "userInfo() is already populated", no separate wait needed.
+   * A `423` (account locked) is not treated as a request failure: it resolves with
+   * `{successful: false, locked: true}` rather than rejecting, so the login form can show a
+   * dedicated "account locked" message instead of a generic error.
+   */
   public async login(username: string, password: string): Promise<LoginResult> {
     return firstValueFrom(this.executeLoginRequest(username, password)
       .pipe(map(async response => {

--- a/frontend/src/main/webapp/src/app/common/security/authguard.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authguard.service.ts
@@ -6,6 +6,13 @@ import {AuthenticationService} from './authentication.service';
 export class AuthGuardService {
   private readonly authenticationService = inject(AuthenticationService);
 
+  /**
+   * Route guard combining login state with two independent, route-data-driven permission checks:
+   * `anyPermission: true` only asks "is the user authorized for *something*" (used by shared
+   * screens like the dashboard), while `anyPermissionOf: string[]` requires one specific
+   * permission from that list (used by feature modules gated on e.g. `SCANNER`/`CHECKIN`). A
+   * route can set both; failing either redirects to the login page.
+   */
   async canActivate(childRoute: ActivatedRouteSnapshot): Promise<boolean> {
     const routeData: AuthGuardData = childRoute.data;
 

--- a/frontend/src/main/webapp/src/app/common/sse/sse.service.ts
+++ b/frontend/src/main/webapp/src/app/common/sse/sse.service.ts
@@ -6,6 +6,18 @@ import {UrlHelperService} from '../util/url-helper.service';
 export class SseService {
   private readonly urlHelperService = inject(UrlHelperService);
 
+  /**
+   * Opens a Server-Sent Events connection to `url` and emits each parsed message.
+   *
+   * Wraps the native `EventSource` in an `Observable` so callers can use `toSignal()`/`subscribe()`
+   * like any other stream. If the connection drops (`EventSource` reports `CLOSED`), it is
+   * automatically reconnected after a fixed 1s delay - callers never see the drop as an error on
+   * the observable, only as a transient `false` on `connectionStateCallback` if one was passed.
+   * Unsubscribing closes the underlying `EventSource` and stops any pending reconnect.
+   *
+   * @param url Backend path relative to the API base, e.g. `/sse/dashboard`
+   * @param connectionStateCallback Optional hook fired with `true`/`false` on connect/permanent-close
+   */
   listen<T>(url: string, connectionStateCallback?: (connected: boolean) => void): Observable<T> {
     return new Observable<T>((observer) => {
       const baseUrl = this.urlHelperService.getBaseUrl();

--- a/frontend/src/main/webapp/src/app/common/state/global-state.service.ts
+++ b/frontend/src/main/webapp/src/app/common/state/global-state.service.ts
@@ -2,6 +2,13 @@ import {inject, Service, Signal, WritableSignal, signal} from '@angular/core';
 import {DistributionItem, DistributionItemUpdate} from '../../api/distribution-api.service';
 import {SseService} from '../sse/sse.service';
 
+/**
+ * App-wide "is a distribution currently open" state, kept in sync via a single shared SSE
+ * subscription to `/sse/distributions` (see `common/sse/sse.service.ts`). Any module that needs
+ * to know whether a distribution is active (checkin, logistics, dashboard, ...) should read it
+ * from here rather than opening its own subscription or re-deriving the state locally, so they
+ * all agree on the same value.
+ */
 @Service()
 export class GlobalStateService {
   private readonly sseService = inject(SseService);
@@ -10,6 +17,13 @@ export class GlobalStateService {
   private readonly _connectionState: WritableSignal<boolean> = signal(false);
 
 
+  /**
+   * Starts the `/sse/distributions` subscription. Called once from `default-layout-resolver`
+   * (which runs for every authenticated route) before any consumer reads {@link getCurrentDistribution}/
+   * {@link getConnectionState} - until the first SSE message arrives, `getCurrentDistribution()`
+   * stays `null`, which looks identical to "no distribution is open". Consumers that need to tell
+   * "not loaded yet" apart from "confirmed closed" should gate on {@link getConnectionState}.
+   */
   init() {
     const connectionStateCallback = (connected: boolean) => {
       this._connectionState.set(connected);

--- a/frontend/src/main/webapp/src/app/common/util/german-paginator-intl.ts
+++ b/frontend/src/main/webapp/src/app/common/util/german-paginator-intl.ts
@@ -1,5 +1,12 @@
 import {MatPaginatorIntl} from '@angular/material/paginator';
 
+/**
+ * German-language `MatPaginatorIntl` for `mat-paginator`, registered app-wide as its provider.
+ * `getRangeLabel` mirrors Angular Material's own default implementation (just German-translated),
+ * including its edge-case handling: a `0`/`0` result when there's nothing to page through, and an
+ * `endIndex` past `normalizedLength` on the last page when `page * pageSize` already exceeds the
+ * total (avoids showing a shrinking, out-of-range end index while items are still loading).
+ */
 export function getGermanPaginatorIntl(): MatPaginatorIntl {
   const paginatorIntl = new MatPaginatorIntl();
 

--- a/frontend/src/main/webapp/src/app/common/validator/CustomValidator.ts
+++ b/frontend/src/main/webapp/src/app/common/validator/CustomValidator.ts
@@ -1,6 +1,12 @@
 import {AbstractControl, ValidationErrors, ValidatorFn} from '@angular/forms';
 import dayjs from 'dayjs';
 
+/**
+ * Custom validators for classic `ReactiveFormsModule`/`FormBuilder` forms - the `AbstractControl`
+ * equivalent of `common/validator/signal-form-validators.ts`, which targets the newer
+ * `@angular/forms/signals` API instead. Keep both in sync if you change validation behavior that
+ * exists in each (e.g. `minDate`/`maxDate`).
+ */
 export class CustomValidator {
 
   static minDate(date: Date): ValidatorFn {
@@ -47,6 +53,15 @@ export class CustomValidator {
     };
   }
 
+  /**
+   * Validates the control's value indirectly through `callback()` rather than the value itself -
+   * for a text field that drives a search/lookup elsewhere, where typing something isn't enough,
+   * a match must actually have been resolved. An empty control is always valid (use `required`
+   * separately if the field is mandatory); once it has text, `callback()` must be truthy or the
+   * control is marked invalid with `message`. Typical use: `hasValue(() => this.selectedEntity(),
+   * ...)` on a search-input control, so the input itself shows invalid until a lookup elsewhere
+   * has actually resolved a match, not just once text was typed into it.
+   */
   static hasValue(callback: () => any, message: string): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => !control.value || callback() ? null : {
         'hasValue': {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
@@ -65,6 +65,14 @@ export class CustomerDuplicatesComponent {
     this.customerApiService.deleteCustomer(customerId).subscribe(observer);
   }
 
+  /**
+   * Merges `customer` (the one whose "keep this one" button was clicked) with the rest of its
+   * duplicate pair, deleting the others. Reads the pair from `items[0]` regardless of which
+   * button in the template was clicked - safe only because the backend's duplicates endpoint
+   * hardcodes a page size of 1 (`HouseholdDuplicationService.findDuplicates`), so a page's `items`
+   * array never holds more than one pair. If that page size ever changes, this needs to look up
+   * the specific item `customer` belongs to instead of always taking `items[0]`.
+   */
   mergeCustomers(customer: CustomerData) {
     const duplicatesData = this.customerDuplicatesData()!.items[0];
     const sourceCustomerIds = [duplicatesData.customer, ...duplicatesData.similarCustomers]


### PR DESCRIPTION
## Summary

Closes #2816 — adds JSDoc to frontend functions/services where behavior isn't obvious from the signature and isn't already covered by the relevant module README, mirroring the "non-obvious only" approach used for backend KDoc in #2813.

- `common/sse/sse.service.ts` — the `EventSource` wrapper's auto-reconnect-with-backoff behavior
- `common/state/global-state.service.ts` — the app-wide distribution-state contract and `init()` timing
- `common/http/errorhandler-interceptor.service.ts` — the three chained `catchError` stages (auth redirect, an Angular blob-error workaround, toast whitelist)
- `common/security/authguard.service.ts` — the two independent permission-check flags (`anyPermission` vs `anyPermissionOf`)
- `common/security/authentication.service.ts` — `login()`'s control flow (loads permissions before resolving, folds HTTP 423 into a non-error result)
- `common/validator/CustomValidator.ts` — class-level note that it's the reactive-forms twin of `signal-form-validators.ts`, plus `hasValue`'s indirect-validation contract
- `common/util/german-paginator-intl.ts` — the pagination-label edge-case handling
- `modules/customer/.../customer-duplicates.component.ts` — `mergeCustomers()`'s `items[0]` assumption, which is only safe because the backend hardcodes page size 1 for the duplicates endpoint

## Why these files specifically

Surveyed the rest of the frontend for other non-obvious logic (matching algorithms, tricky RxJS chains, business-rule constants, reused patterns). Several strong candidates — logistics' patch-queue serialization, the employee search/create three-way branch, km-diff validation, dashboard's shelter-name reconciliation effect — turned out to already be documented in detail in their module's `README.md`, so adding JSDoc there would just duplicate prose; left those alone. `customer-api.service.ts`, `signal-form-helper.ts`, and `signal-form-validators.ts`, cited as examples in the issue, already had thorough JSDoc from prior work.

## Test plan

- [x] `ng lint` passes
- [x] `ng test --watch=false` — 574 tests pass
- [x] Doc-only change; confirmed pre-existing `tsc --noEmit` errors in unrelated spec files are unaffected (via `git stash` comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)