### PR TITLE
Add KDoc to non-obvious backend Kotlin classes

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthProvider.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthProvider.kt
@@ -18,6 +18,11 @@ class TafelJwtAuthProvider(
 
     override fun supports(authentication: Class<*>): Boolean = authentication == TafelJwtAuthentication::class.java
 
+    /**
+     * A validly-signed, unexpired JWT is not sufficient on its own - the referenced user may have
+     * been disabled or deleted after the token was issued, so this re-checks the user's `enabled`
+     * state in the DB on every authenticated request rather than trusting the token's claims alone.
+     */
     override fun authenticate(authentication: Authentication): TafelJwtAuthentication {
         try {
             val tafelJwtAuthentication = authentication as TafelJwtAuthentication
@@ -28,8 +33,6 @@ class TafelJwtAuthProvider(
                 throw CredentialsExpiredException("Token not valid")
             }
 
-            // a valid signature is not enough - the user may have been disabled or deleted
-            // after the token was issued
             val userEntity = claims.subject?.let { userRepository.findByUsername(it) }
             if (userEntity?.enabled != true) {
                 throw DisabledException("User '${claims.subject}' is disabled or doesn't exist")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
@@ -53,6 +53,12 @@ class TafelLoginFilter(
 
     public override fun obtainPassword(request: HttpServletRequest): String = basicAuthConverter.convert(request)?.credentials as String
 
+    /**
+     * When [TafelUser.passwordChangeRequired] is true, the issued JWT is deliberately weaker: no
+     * authorities at all, and a shorter `expirationTimePwdChangeInSeconds` expiration instead of
+     * the normal one - a security gate that forces the user through the change-password flow
+     * before any real permissions are granted.
+     */
     public override fun successfulAuthentication(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginProvider.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginProvider.kt
@@ -17,9 +17,11 @@ class TafelLoginProvider(
     private val loginAttemptService: LoginAttemptService,
 ) : AbstractUserDetailsAuthenticationProvider() {
 
-    // A login for an unknown username would fail without running Argon2 and therefore respond
-    // measurably faster than a wrong password, allowing username enumeration via timing.
-    // Comparing against this throwaway hash equalizes both paths.
+    /**
+     * A login for an unknown username would fail without running Argon2 and therefore respond
+     * measurably faster than a wrong password, allowing username enumeration via timing.
+     * Comparing against this throwaway hash in [retrieveUser] equalizes both paths.
+     */
     private val unknownUserFallbackHash: String = passwordEncoder.encode(UUID.randomUUID().toString())!!
 
     override fun supports(authenticationClass: Class<*>): Boolean = authenticationClass == UsernamePasswordAuthenticationToken::class.java

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelUserDetailsManager.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelUserDetailsManager.kt
@@ -158,6 +158,13 @@ class TafelUserDetailsManager(
         passwordChangeRequired = userEntity.passwordChangeRequired!!,
     )
 
+    /**
+     * Diffs `userEntity.authorities` against `tafelUser.authorities` (remove-then-add) instead of
+     * replacing the collection outright, because JPA's `orphanRemoval` on that relation only
+     * deletes stale [UserAuthorityEntity] rows when they're mutated out of the existing managed
+     * collection - swapping in a brand-new list would leave the old rows orphaned in the DB rather
+     * than removed.
+     */
     private fun mapToUserEntity(userEntity: UserEntity, tafelUser: TafelUser) {
         val existingEmployee = employeeRepository.findByPersonnelNumber(tafelUser.personnelNumber) ?: EmployeeEntity()
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/mail/MailSenderService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/mail/MailSenderService.kt
@@ -45,6 +45,11 @@ class MailSenderService(
         sendMail(mailType, subject, content, attachments, isHtmlMail = true)
     }
 
+    /**
+     * `mailSender` is `@Autowired(required = false)` - when no mail server is configured (e.g.
+     * dev/test profiles), this silently no-ops instead of failing, so callers don't need to guard
+     * every mail-sending call site against a missing mail configuration.
+     */
     private fun sendMail(
         mailType: MailType,
         subject: String,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/pdf/PDFService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/pdf/PDFService.kt
@@ -30,6 +30,11 @@ class PDFService {
             return confParser.fopFactoryBuilder.build()
         }
 
+        /**
+         * Apache FOP needs real filesystem paths for font registration, not classpath streams, so
+         * the bundled Liberation Sans fonts are copied out to a temp directory at factory-build
+         * time (once, since [fopFactory] is lazy) purely to satisfy that requirement.
+         */
         private fun extractBundledFonts(): File {
             val targetDirectory = Files.createTempDirectory("tafel-pdf-fonts").toFile()
             targetDirectory.deleteOnExit()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/checkin/ScannerRegistrationRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/checkin/ScannerRegistrationRepository.kt
@@ -7,6 +7,13 @@ import java.time.LocalDateTime
 
 interface ScannerRegistrationRepository : JpaRepository<ScannerRegistrationEntity, Long> {
 
+    /**
+     * Finds the smallest gap in the existing `scanner_id` sequence, falling back to `MAX + 1`
+     * only if there is none. Scanner ids are reused, not monotonically increasing: combined with
+     * the hourly cleanup of registrations older than 2 days, an id freed up two days ago will be
+     * handed out again to the next new registration - don't assume a higher id was registered
+     * more recently.
+     */
     @Query(
         value = """
                 SELECT COALESCE(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionRepository.kt
@@ -14,6 +14,11 @@ interface DistributionRepository : JpaRepository<DistributionEntity, Long> {
     fun getDistributionEntityByEndedAtIsNotNullOrderByStartedAtDesc(): List<DistributionEntity>
 }
 
+/**
+ * There is no `active` boolean column - a distribution is "current" purely by data shape: the row
+ * with the highest id, and only if its `endedAt` is still null. Only one distribution can ever be
+ * open at a time; once the latest one is closed, this returns null until a new one is created.
+ */
 fun DistributionRepository.getCurrentDistribution(): DistributionEntity? {
     val latest = findFirstByOrderByIdDesc()
     return if (latest?.endedAt == null) latest else null

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdRepository.kt
@@ -12,13 +12,20 @@ interface HouseholdRepository :
     JpaRepository<HouseholdEntity, Long>,
     JpaSpecificationExecutor<HouseholdEntity> {
 
+    /**
+     * The human-facing `household_id` business number, drawn from a dedicated Postgres sequence -
+     * distinct from the entity's own JPA-generated primary key.
+     */
     @Query("SELECT nextval('household_id_sequence')", nativeQuery = true)
     fun getNextHouseholdSequenceValue(): Long
 
-    // overrides the inherited findAll(Specification) with an eager fetch of persons - without this,
-    // HouseholdConverter.mapEntityToHousehold() accessing the lazy persons collection triggers one
-    // extra query per household (only used by getHouseholdsAboveLimit(), which loads every valid
-    // household up front rather than a paginated slice, so the N+1 cost is otherwise unbounded)
+    /**
+     * Overrides the inherited `findAll(Specification)` with an eager fetch of `persons`. Without
+     * this, `HouseholdConverter.mapEntityToHousehold()` accessing the lazy `persons` collection
+     * would trigger one extra query per household - the only caller,
+     * `HouseholdService.getHouseholdsAboveLimit()`, loads every valid household up front rather
+     * than a paginated slice, so the N+1 cost would otherwise be unbounded.
+     */
     @EntityGraph(attributePaths = ["persons"])
     override fun findAll(spec: Specification<HouseholdEntity>): List<HouseholdEntity>
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/FoodCollectionItemEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/logistics/FoodCollectionItemEntity.kt
@@ -22,6 +22,12 @@ class FoodCollectionItemEntity {
     @Column(name = "amount")
     var amount: Int? = null
 
+    /**
+     * If the shop's [FoodUnit] is `KG`, `amount` already *is* the weight; otherwise the weight is
+     * derived as `amount * category.weightPerUnit` (e.g. boxes of a known per-box weight). Get the
+     * shop's unit wrong and every weight-based report/statistic derived from this collection is
+     * wrong too.
+     */
     fun calculateWeight(): BigDecimal {
         val amount = amount ?: 0
         val unit = shop?.foodUnit ?: FoodUnit.BOX

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/staticdata/StaticValueRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/staticdata/StaticValueRepository.kt
@@ -8,12 +8,17 @@ import java.time.LocalDate
 
 interface StaticValueRepository : JpaRepository<StaticValueEntity, Long> {
 
-    // static values are cached for the process lifetime (see CacheConfig) since getHouseholdsAboveLimit()
-    // would otherwise re-query these same rows once per household validated - SettingsService evicts
-    // these caches on every static-value create/update, so this is safe despite values now being
-    // editable at runtime through the settings UI. Each method gets its own cache name since the
-    // default key generator only considers arguments, not the method itself, and
-    // findSingleValueOfType/findValuesOfType share the same argument shape
+    /**
+     * Static values are cached for the process lifetime (see `CacheConfig`) since
+     * `HouseholdService.getHouseholdsAboveLimit()` would otherwise re-query these same rows once
+     * per household validated. `SettingsService` evicts all three caches below on every
+     * static-value create/update, so this is safe despite values being editable at runtime
+     * through the settings UI - if you add another cached query method here, add its cache name
+     * to that eviction list too, or edits will appear to silently not take effect. Each method
+     * needs its *own* cache name because the default key generator only considers arguments, not
+     * the method itself, and [findSingleValueOfType]/[findValuesOfType] share the same argument
+     * shape and would otherwise collide.
+     */
     @Cacheable("staticValueLatestForPersonCount")
     @Query("select il from StaticValue il where il.type = :type and il.countAdults = :countAdults and il.countChildren = :countChildren and :currentDate between il.validFrom and il.validTo")
     fun findLatestForPersonCount(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -74,6 +74,14 @@ class GenericExceptionHandler(
         )
     }
 
+    /**
+     * Builds the error response, special-casing SSE requests.
+     *
+     * If the incoming request's `Accept` header contains `text/event-stream`, a normal JSON error
+     * body would not be understood by the open `EventSource` - it's written instead as an
+     * `event: error` SSE frame so an in-flight SSE connection doesn't just look like it silently
+     * broke.
+     */
     private fun createErrorResponse(
         exception: Exception,
         status: HttpStatus,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/TafelExceptions.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/TafelExceptions.kt
@@ -3,6 +3,14 @@ package at.wrk.tafel.admin.backend.modules.base.exception
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import org.springframework.http.HttpStatus
 
+/**
+ * Signals an unexpected/internal failure (e.g. a downstream dependency misbehaving).
+ *
+ * Structurally identical to [TafelValidationException] - both carry an optional [status]
+ * ([GenericExceptionHandler] defaults to [org.springframework.http.HttpStatus.BAD_REQUEST] when
+ * null). The distinction is intent/log severity only: [GenericExceptionHandler] logs this one at
+ * `warn`, not the expected-failure `debug` level used for [TafelValidationException].
+ */
 @ExcludeFromTestCoverage
 class TafelException(
     override val message: String?,
@@ -10,6 +18,11 @@ class TafelException(
     val status: HttpStatus? = null,
 ) : RuntimeException()
 
+/**
+ * Signals an expected, user-facing business-rule violation (e.g. "Ticketnummer bereits
+ * vergeben!"). See [TafelException] for how the two differ - only in the log level
+ * [GenericExceptionHandler] uses for them.
+ */
 @ExcludeFromTestCoverage
 class TafelValidationException(
     override val message: String?,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/internal/ScannerService.kt
@@ -24,6 +24,20 @@ class ScannerService(
         const val SCANNER_RESULT_NOTIFICATION_NAME = "scanner_results"
     }
 
+    /**
+     * Registers a new scanner, or refreshes/re-claims an existing one.
+     *
+     * If [existingScannerId] is given and its registration hasn't expired yet, this is a
+     * heartbeat: the registration's timestamp is refreshed and the same id is returned. If it
+     * *has* expired (cleaned up by [cleanupScannerRegistrations]), the caller silently gets a
+     * brand-new, possibly different id back instead of an error - callers must always use the
+     * returned id, never assume they keep the one they asked for.
+     *
+     * Wrapped in [AdvisoryLockKey.SCANNER_REGISTRATION] because `scanner_id` is `UNIQUE NOT NULL`
+     * at the DB level and [getNextScannerId][at.wrk.tafel.admin.backend.database.model.checkin.ScannerRegistrationRepository.getNextScannerId]
+     * is a check-then-act gap lookup - without serializing, two concurrent registrations could
+     * compute and insert the same free id.
+     */
     @Transactional
     fun registerScanner(existingScannerId: Int? = null): Int = advisoryLockService.withLock(AdvisoryLockKey.SCANNER_REGISTRATION) {
         val nextScannerId = scannerRegisteredRepository.getNextScannerId()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
@@ -83,6 +83,12 @@ class DistributionController(
         return ResponseEntity.ok().build()
     }
 
+    /**
+     * `forceClose` only overrides validation *warnings*, never hard errors: if
+     * [DistributionCloseValidationResult.hasOnlyWarnings] is false (i.e. there's at least one real
+     * error), the distribution is not closed regardless of `forceClose`, and the validation
+     * result is returned instead so the caller can see why.
+     */
     @PostMapping("/distributions/close")
     @PreAuthorize("hasAuthority('DISTRIBUTION_LCM')")
     @TafelActiveDistributionRequired

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/MissingCostContributionPostProcessor.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/MissingCostContributionPostProcessor.kt
@@ -14,6 +14,16 @@ import org.springframework.stereotype.Component
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/**
+ * Unlike its sibling [DistributionPostProcessor]s, which only send mail, this one mutates
+ * persistent household state as a side effect of closing a distribution: for every household
+ * whose [at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseholdEntity.costContributionPaid]
+ * is false, it adds the current [StaticValueType.COST_CONTRIBUTION] amount to
+ * [HouseholdEntity.pendingCostContribution] so it can be collected next time. Deliberately not
+ * re-run by [at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService.sendMails]
+ * (the manual mail re-send), since re-running it would double-count pending contributions for
+ * households that already had them added when the distribution originally closed.
+ */
 @Component
 class MissingCostContributionPostProcessor(
     private val householdRepository: HouseholdRepository,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/ReturnBoxesMailPostProcessor.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/postprocessors/ReturnBoxesMailPostProcessor.kt
@@ -42,6 +42,13 @@ class ReturnBoxesMailPostProcessor(
         logger.info("Mail for return boxes '$mailSubject' sent!")
     }
 
+    /**
+     * Builds the route -> shop -> return-category hierarchy for the mail by re-filtering
+     * `distribution.foodCollections` at each nesting level (by route, then by route+shop) rather
+     * than grouping once, and drops any route/shop with no return items via `null` filtering. Not
+     * the cheapest possible approach, but distribution-sized data volumes make this fine, and it
+     * keeps each level's filter self-contained.
+     */
     private fun createReturnBoxesData(distribution: DistributionEntity): ReturnBoxesDataModel {
         val uniqueRoutes = distribution.foodCollections.mapNotNull { it.route }
             .distinctBy { it.id }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
@@ -49,6 +49,12 @@ class DistributionStatisticService(
         return statistic
     }
 
+    /**
+     * `countCustomersUpdated` is derived by subtraction, not a dedicated query: it's every
+     * household updated in the window ([HouseholdRepository.countByUpdatedAtBetween]) minus the
+     * ones already counted as new or prolonged, since those also touch `updated_at` and would
+     * otherwise be double-counted across the three statistics.
+     */
     private fun fillHouseholdStatistics(
         distribution: DistributionEntity,
         statisticStartTime: LocalDateTime,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
@@ -24,6 +24,12 @@ class DailyReportService(
         return pdfService.generatePdf(pdfModel, "/pdf-templates/daily-report/dailyreport-document.xsl")
     }
 
+    /**
+     * Reads shelter data straight off `statistic.shelters` - a historized snapshot captured at
+     * statistic-save time - rather than a live `Shelter` lookup, so renaming or deleting a shelter
+     * later doesn't change already-generated PDFs. Same reasoning as the dashboard module's own
+     * `DashboardService`, which reads the same kind of snapshot for the same reason.
+     */
     private fun createPdfModel(statistic: DistributionStatisticEntity): DailyReportPdfModel {
         val logoBytes =
             IOUtils.toByteArray(javaClass.getResourceAsStream("/assets/logo.png"))

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/AgeDistributionExporter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/AgeDistributionExporter.kt
@@ -26,6 +26,13 @@ class AgeDistributionExporter : StatisticExporter {
         return headerRows + dataRows
     }
 
+    /**
+     * `household.additionalPersons()` deliberately excludes the household's own main person, so
+     * `householdsBirthDates` (the main persons) has to be derived separately and spliced back into
+     * `personsBirthDates` to get correct *person*-level age buckets - while the *household*-level
+     * buckets (`groupedCustomers`) use `householdsBirthDates` alone. The same list is reused once
+     * on its own and once merged; that's intentional, not redundant.
+     */
     private fun calculateDistribution(statistic: DistributionStatisticEntity): List<List<String>> {
         val households = statistic.distribution
             ?.households


### PR DESCRIPTION
## Summary

Closes #2815 — a follow-up to #2813, which intentionally scoped backend KDoc to a handful of the most non-obvious classes (`HouseholdDuplicationService`, `IncomeValidatorServiceImpl`, the SSE outbox pattern, the distribution post-processor chain) to keep that PR reviewable, plus adding module `README.md` files across all 8 backend modules.

This does the fuller pass proposed in #2815: KDoc on classes/functions across the remaining modules and `database`/`common`/`config` packages where the *why*, not the *what*, isn't obvious from the name and isn't already covered by a module README. Straightforward CRUD controllers/services/converters/DTOs were left alone.

- **`base`**: the near-identical `TafelException`/`TafelValidationException` distinction (log-level only); `GenericExceptionHandler`'s SSE-vs-JSON error response branching.
- **`checkin`**: `ScannerService.registerScanner`'s heartbeat-vs-silent-reassignment behavior; `ScannerRegistrationRepository.getNextScannerId`'s gap-filling query.
- **`distribution`**: `closeDistribution`'s `forceClose`-only-overrides-warnings asymmetry; `DistributionStatisticService`'s derived-by-subtraction "updated" count; `ReturnBoxesMailPostProcessor`'s repeated re-filtering; `MissingCostContributionPostProcessor`'s state-mutating (not just mail-sending) role in the post-processor chain.
- **`reporting`**: `DailyReportService`'s historic shelter-snapshot read (mirrors `DashboardService`'s existing comment); `AgeDistributionExporter`'s dual use of the main-persons list for household- vs. person-level buckets.
- **`database`**: `StaticValueRepository`'s per-method cache-name/eviction invariant; `HouseholdRepository`'s sequence-backed household id and `EntityGraph` override; `DistributionRepository`'s "current distribution" definition; `FoodCollectionItemEntity`'s unit-dependent weight formula.
- **`common`**: `PDFService`'s FOP font-extraction workaround; the login timing-attack mitigation and disabled-user re-check in the auth providers; the reduced-privilege JWT issued during forced password changes; `MailSenderService`'s optional-mail-sender no-op; `TafelUserDetailsManager`'s in-place authority diffing (required for `orphanRemoval` to work).

`logistics`, `household`, `settings`, and `dashboard` modules were surveyed but turned up no further candidates — their non-obvious logic is already covered by the existing module READMEs and inline comments.

## Test plan

- [x] `./gradlew :backend:compileKotlin` passes
- [x] `./gradlew :backend:ktlintCheck` passes
- [x] `./gradlew :backend:test` passes (doc-only change, no behavior touched)