### PR TITLE
Switch Gradle CI caching from basic to enhanced provider

### DIFF
--- a/.github/workflows/dependabot_gradle_lockfile.yml
+++ b/.github/workflows/dependabot_gradle_lockfile.yml
@@ -40,8 +40,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
       - name: Regenerate lock file and verification metadata
         run: ./gradlew --write-locks --write-verification-metadata sha256 :backend:build --console=plain
       - name: Commit changes if any

--- a/.github/workflows/subflow_build.yml
+++ b/.github/workflows/subflow_build.yml
@@ -20,8 +20,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
       - name: Backend build
         run: ./gradlew :backend:bootJar
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/subflow_lint.yml
+++ b/.github/workflows/subflow_lint.yml
@@ -20,8 +20,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
       - name: Backend lint
         run: ./gradlew :backend:ktlintCheck
 

--- a/.github/workflows/subflow_sonar.yml
+++ b/.github/workflows/subflow_sonar.yml
@@ -27,8 +27,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: backend-jacoco-report

--- a/.github/workflows/subflow_test.yml
+++ b/.github/workflows/subflow_test.yml
@@ -20,8 +20,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
       - name: Backend test
         run: ./gradlew :backend:test
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary
- Removes the explicit `cache-provider: basic` pin from all 5 workflows using `gradle/actions/setup-gradle` (`subflow_build.yml`, `subflow_lint.yml`, `subflow_test.yml`, `subflow_sonar.yml`, `dependabot_gradle_lockfile.yml`), letting the action fall back to its `enhanced` default.

## Investigation (closes #2823)
- **Why `basic` was chosen originally:** no documented rationale found. It was added in `512c5049` ("updated gradle") alongside an unrelated `setup-gradle` version bump — looks incidental, not a deliberate licensing call.
- **Enhanced vs basic:** enhanced gives fine-grained, deduplicated caching of more of the Gradle User Home plus smarter cleanup, vs. one coarse blob for `modules-2` only with basic.
- **Licensing/privacy:** enhanced is proprietary but free for public repos indefinitely. Per the action's `DISTRIBUTION.md` Safe Harbor clause, it only collects cache-key metadata — build artifacts and source remain fully owned by this repo, so it doesn't conflict with this project's existing supply-chain hygiene practices (dependency verification checksums, lockfiles).

## Test plan
- [ ] Watch the CI runs on this PR to confirm the enhanced cache provider activates cleanly and jobs succeed
- [ ] Compare build times / cache hit behavior against recent basic-cache runs on `main`
- [ ] If no regressions, merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)