### PR TITLE
Resolve ArchUnit exemptions for CountryController and EmployeeController

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryController.kt
@@ -1,6 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.base.country
 
-import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
+import at.wrk.tafel.admin.backend.modules.base.country.internal.CountryService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -10,17 +10,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/countries")
 @PreAuthorize("isAuthenticated()")
 class CountryController(
-    private val countryRepository: CountryRepository,
+    private val countryService: CountryService,
 ) {
 
     @GetMapping
     fun listCountries(): CountryListResponse = CountryListResponse(
-        items = countryRepository.findAll().map {
-            Country(
-                id = it.id!!,
-                code = it.code!!,
-                name = it.name!!,
-            )
-        },
+        items = countryService.listCountries(),
     )
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
@@ -1,0 +1,19 @@
+package at.wrk.tafel.admin.backend.modules.base.country.internal
+
+import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
+import at.wrk.tafel.admin.backend.modules.base.country.Country
+import org.springframework.stereotype.Service
+
+@Service
+class CountryService(
+    private val countryRepository: CountryRepository,
+) {
+
+    fun listCountries(): List<Country> = countryRepository.findAll().map {
+        Country(
+            id = it.id!!,
+            code = it.code!!,
+            name = it.name!!,
+        )
+    }
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
@@ -9,10 +9,14 @@ class CountryService(
     private val countryRepository: CountryRepository,
 ) {
 
+    // static_countries.code/name are NOT NULL in the DB, but CountryEntity models both as String? for the
+    // JPA no-arg constructor, so the assertions below are genuinely required (removing either is a compile
+    // error). Sonar (kotlin:S6619) flags the `code` assertion as dead regardless of which null-check syntax
+    // is used - confirmed false positive, suppressed rather than reworded.
     fun listCountries(): List<Country> = countryRepository.findAll().map {
         Country(
             id = it.id!!,
-            code = it.code!!,
+            code = it.code!!, // NOSONAR kotlin:S6619
             name = it.name!!,
         )
     }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
@@ -1,11 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.base.employee
 
-import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
-import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
-import org.springframework.data.domain.PageRequest
+import at.wrk.tafel.admin.backend.modules.base.employee.internal.EmployeeService
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -17,50 +13,15 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/employees")
 @PreAuthorize("hasAuthority('LOGISTICS')")
 class EmployeeController(
-    private val employeeRepository: EmployeeRepository,
+    private val employeeService: EmployeeService,
 ) {
 
     @GetMapping
     fun findEmployees(
         @RequestParam searchInput: String? = null,
         @RequestParam page: Int? = null,
-    ): EmployeeListResponse {
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 5)
-        val pagedResult = if (searchInput != null) {
-            employeeRepository.findBySearchInput(searchInput, pageRequest)
-        } else {
-            employeeRepository.findAll(pageRequest)
-        }
-
-        return EmployeeListResponse(
-            items = pagedResult.map { mapEntityToEmployee(it) }.toList(),
-            totalCount = pagedResult.totalElements,
-            currentPage = page ?: 1,
-            totalPages = pagedResult.totalPages,
-            pageSize = pageRequest.pageSize,
-        )
-    }
+    ): EmployeeListResponse = employeeService.findEmployees(searchInput, page)
 
     @PostMapping
-    @Transactional
-    fun saveEmployee(@RequestBody employeeCreateRequest: EmployeeCreateRequest): Employee {
-        if (employeeRepository.existsByPersonnelNumber(employeeCreateRequest.personnelNumber)) {
-            throw TafelValidationException("Mitarbeiter ${employeeCreateRequest.personnelNumber} ist bereits vorhanden!")
-        }
-
-        val employeeEntity = EmployeeEntity().apply {
-            personnelNumber = employeeCreateRequest.personnelNumber.trim()
-            firstname = employeeCreateRequest.firstname.trim()
-            lastname = employeeCreateRequest.lastname.trim()
-        }
-        employeeRepository.save(employeeEntity)
-        return mapEntityToEmployee(employeeRepository.findByPersonnelNumber(employeeCreateRequest.personnelNumber)!!)
-    }
-
-    private fun mapEntityToEmployee(it: EmployeeEntity) = Employee(
-        id = it.id!!,
-        personnelNumber = it.personnelNumber!!,
-        firstname = it.firstname!!,
-        lastname = it.lastname!!,
-    )
+    fun saveEmployee(@RequestBody employeeCreateRequest: EmployeeCreateRequest): Employee = employeeService.saveEmployee(employeeCreateRequest)
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
@@ -1,0 +1,56 @@
+package at.wrk.tafel.admin.backend.modules.base.employee.internal
+
+import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
+import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
+import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
+import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class EmployeeService(
+    private val employeeRepository: EmployeeRepository,
+) {
+
+    fun findEmployees(searchInput: String? = null, page: Int? = null): EmployeeListResponse {
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 5)
+        val pagedResult = if (searchInput != null) {
+            employeeRepository.findBySearchInput(searchInput, pageRequest)
+        } else {
+            employeeRepository.findAll(pageRequest)
+        }
+
+        return EmployeeListResponse(
+            items = pagedResult.map { mapEntityToEmployee(it) }.toList(),
+            totalCount = pagedResult.totalElements,
+            currentPage = page ?: 1,
+            totalPages = pagedResult.totalPages,
+            pageSize = pageRequest.pageSize,
+        )
+    }
+
+    @Transactional
+    fun saveEmployee(employeeCreateRequest: EmployeeCreateRequest): Employee {
+        if (employeeRepository.existsByPersonnelNumber(employeeCreateRequest.personnelNumber)) {
+            throw TafelValidationException("Mitarbeiter ${employeeCreateRequest.personnelNumber} ist bereits vorhanden!")
+        }
+
+        val employeeEntity = EmployeeEntity().apply {
+            personnelNumber = employeeCreateRequest.personnelNumber.trim()
+            firstname = employeeCreateRequest.firstname.trim()
+            lastname = employeeCreateRequest.lastname.trim()
+        }
+        employeeRepository.save(employeeEntity)
+        return mapEntityToEmployee(employeeRepository.findByPersonnelNumber(employeeCreateRequest.personnelNumber)!!)
+    }
+
+    private fun mapEntityToEmployee(it: EmployeeEntity) = Employee(
+        id = it.id!!,
+        personnelNumber = it.personnelNumber!!,
+        firstname = it.firstname!!,
+        lastname = it.lastname!!,
+    )
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
@@ -3,7 +3,6 @@ package at.wrk.tafel.admin.backend.modules.distribution
 import at.wrk.tafel.admin.backend.common.api.TafelActiveDistributionRequired
 import at.wrk.tafel.admin.backend.common.sse.SseUtil
 import at.wrk.tafel.admin.backend.database.common.sseoutbox.SseOutboxService
-import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.*
 import org.springframework.core.io.InputStreamResource
@@ -28,16 +27,12 @@ class DistributionController(
 
     @GetMapping("/distributions")
     @PreAuthorize("isAuthenticated()")
-    fun getDistributions(): DistributionListResponse {
-        val distributions = service.getDistributions().map { mapDistribution(it) }
-        return DistributionListResponse(items = distributions)
-    }
+    fun getDistributions(): DistributionListResponse = DistributionListResponse(items = service.getDistributionItems())
 
     @PostMapping("/distributions/new")
     @PreAuthorize("hasAuthority('DISTRIBUTION_LCM')")
     fun createNewDistribution(): DistributionItemUpdate {
-        val distribution = service.createNewDistribution()
-        val update = DistributionItemUpdate(distribution = mapDistribution(distribution))
+        val update = DistributionItemUpdate(distribution = service.createNewDistributionItem())
 
         sseOutboxService.saveOutboxEntry(
             notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
@@ -52,10 +47,9 @@ class DistributionController(
         val sseEmitter = SseUtil.createSseEmitter()
 
         // initial data
-        val distribution = service.getCurrentDistribution()
         sseOutboxService.sendEvent(
             sseEmitter,
-            DistributionItemUpdate(distribution = distribution?.let { mapDistribution(it) }),
+            DistributionItemUpdate(distribution = service.getCurrentDistributionItem()),
         )
 
         sseOutboxService.forwardNotificationEventsToSse(
@@ -157,10 +151,4 @@ class DistributionController(
         service.sendMails(distributionId)
         return ResponseEntity.ok().build()
     }
-
-    private fun mapDistribution(distribution: DistributionEntity): DistributionItem = DistributionItem(
-        id = distribution.id!!,
-        startedAt = distribution.startedAt!!,
-        endedAt = distribution.endedAt,
-    )
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
@@ -12,6 +12,7 @@ import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionCloseValidationResult
+import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListPdfModel
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListPdfResult
@@ -56,6 +57,8 @@ class DistributionService(
 
     fun getDistributions(): List<DistributionEntity> = distributionRepository.getDistributionEntityByEndedAtIsNotNullOrderByStartedAtDesc()
 
+    fun getDistributionItems(): List<DistributionItem> = getDistributions().map { mapDistribution(it) }
+
     @Transactional
     fun createNewDistribution(): DistributionEntity {
         var result: DistributionEntity? = null
@@ -87,8 +90,14 @@ class DistributionService(
         return result!!
     }
 
+    fun createNewDistributionItem(): DistributionItem = mapDistribution(createNewDistribution())
+
     @Transactional
     fun getCurrentDistribution(): DistributionEntity? = distributionRepository.getCurrentDistribution()
+
+    fun getCurrentDistributionItem(): DistributionItem? = getCurrentDistribution()?.let { mapDistribution(it) }
+
+    fun hasCurrentDistribution(): Boolean = getCurrentDistribution() != null
 
     @Transactional
     fun assignHouseholdToDistribution(
@@ -156,6 +165,9 @@ class DistributionService(
         logger.info("Ticket-Log - Fetched current ticket-number (service): ${distributionHouseholdEntity?.ticketNumber}")
         return distributionHouseholdEntity
     }
+
+    @Transactional
+    fun getCurrentTicketNumberValue(householdId: Long? = null): Int? = getCurrentTicketNumber(householdId)?.ticketNumber
 
     @Transactional
     fun reopenAndGetPreviousTicket(): Int? {
@@ -288,6 +300,12 @@ class DistributionService(
 
         return result!!
     }
+
+    private fun mapDistribution(distribution: DistributionEntity): DistributionItem = DistributionItem(
+        id = distribution.id!!,
+        startedAt = distribution.startedAt!!,
+        endedAt = distribution.endedAt,
+    )
 
     private fun getLastProcessedDistributionHouseholdEntity(
         distribution: DistributionEntity,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketController.kt
@@ -25,10 +25,10 @@ class DistributionTicketController(
     fun getCurrentTicketForHouseholdId(
         @PathVariable householdId: Long,
     ): TicketNumberResponse {
-        val distributionHouseholdEntity = service.getCurrentTicketNumber(householdId)
-        logger.info("Ticket-Log - Fetched current ticket-number: $distributionHouseholdEntity")
+        val ticketNumber = service.getCurrentTicketNumberValue(householdId)
+        logger.info("Ticket-Log - Fetched current ticket-number: $ticketNumber")
         return TicketNumberResponse(
-            ticketNumber = distributionHouseholdEntity?.ticketNumber,
+            ticketNumber = ticketNumber,
         )
     }
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenController.kt
@@ -34,12 +34,12 @@ class DistributionTicketScreenController(
     @PostMapping("/distributions/ticket-screen/show-current")
     @PreAuthorize("hasAnyAuthority('CHECKIN', 'SCANNER')")
     fun showCurrentTicket() {
-        val distribution = service.getCurrentDistribution()
-
-        val response = distribution?.let {
-            val ticketNumber = service.getCurrentTicketNumber(null)?.ticketNumber
+        val response = if (service.hasCurrentDistribution()) {
+            val ticketNumber = service.getCurrentTicketNumberValue()
             logger.info("Ticket-Log - Fetched current ticket-number: $ticketNumber")
             ticketNumber
+        } else {
+            null
         }
 
         saveToOutbox(text = TICKET_SCREEN_TITLE, response?.toString())
@@ -71,8 +71,8 @@ class DistributionTicketScreenController(
 
         // send initial state
         var currentTicketNumber: Int? = null
-        service.getCurrentDistribution()?.let {
-            currentTicketNumber = service.getCurrentTicketNumber()?.ticketNumber
+        if (service.hasCurrentDistribution()) {
+            currentTicketNumber = service.getCurrentTicketNumberValue()
         }
         val payload = TicketScreenShowText(TICKET_SCREEN_TITLE, currentTicketNumber?.toString())
         sseOutboxService.sendEvent(sseEmitter, payload)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
@@ -1,9 +1,6 @@
 package at.wrk.tafel.admin.backend.architecture
 
 import at.wrk.tafel.admin.backend.architecture.conditions.HaveApiRequestMappingPathCondition
-import at.wrk.tafel.admin.backend.modules.distribution.DistributionController
-import at.wrk.tafel.admin.backend.modules.distribution.internal.ticket.DistributionTicketController
-import at.wrk.tafel.admin.backend.modules.distribution.internal.ticket.DistributionTicketScreenController
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
@@ -30,13 +27,6 @@ internal class ProjectSpecificRulesTest {
     @ArchTest
     val `rest controllers should not depend on database entities directly` = noClasses()
         .that().areAnnotatedWith(RestController::class.java)
-        .and().areNotAssignableTo(DistributionController::class.java)
-        .and().areNotAssignableTo(DistributionTicketController::class.java)
-        .and().areNotAssignableTo(DistributionTicketScreenController::class.java)
         .should().dependOnClassesThat().resideInAPackage("..database.model..")
-        .because(
-            "controllers should map entities to DTOs instead of exposing/depending on them directly - " +
-                "DistributionController, DistributionTicketController and DistributionTicketScreenController " +
-                "are exempted for now as they still access entities directly",
-        )
+        .because("controllers should map entities to DTOs instead of exposing/depending on them directly")
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/architecture/ProjectSpecificRulesTest.kt
@@ -1,12 +1,14 @@
 package at.wrk.tafel.admin.backend.architecture
 
 import at.wrk.tafel.admin.backend.architecture.conditions.HaveApiRequestMappingPathCondition
-import at.wrk.tafel.admin.backend.modules.base.country.CountryController
-import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeController
+import at.wrk.tafel.admin.backend.modules.distribution.DistributionController
+import at.wrk.tafel.admin.backend.modules.distribution.internal.ticket.DistributionTicketController
+import at.wrk.tafel.admin.backend.modules.distribution.internal.ticket.DistributionTicketScreenController
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods
 import org.springframework.web.bind.annotation.RestController
 
@@ -22,11 +24,19 @@ internal class ProjectSpecificRulesTest {
     val `rest controllers should not expose database entities directly` = noMethods()
         .that().arePublic()
         .and().areDeclaredInClassesThat().areAnnotatedWith(RestController::class.java)
-        .and().areDeclaredInClassesThat().areNotAssignableTo(CountryController::class.java)
-        .and().areDeclaredInClassesThat().areNotAssignableTo(EmployeeController::class.java)
         .should().haveRawReturnType(resideInAPackage("..database.model.."))
+        .because("controllers should map entities to DTOs instead of returning them directly from an endpoint")
+
+    @ArchTest
+    val `rest controllers should not depend on database entities directly` = noClasses()
+        .that().areAnnotatedWith(RestController::class.java)
+        .and().areNotAssignableTo(DistributionController::class.java)
+        .and().areNotAssignableTo(DistributionTicketController::class.java)
+        .and().areNotAssignableTo(DistributionTicketScreenController::class.java)
+        .should().dependOnClassesThat().resideInAPackage("..database.model..")
         .because(
-            "controllers should map entities to DTOs instead of returning them directly from an endpoint - " +
-                "CountryController and EmployeeController are exempted for now as they still access repositories directly",
+            "controllers should map entities to DTOs instead of exposing/depending on them directly - " +
+                "DistributionController, DistributionTicketController and DistributionTicketScreenController " +
+                "are exempted for now as they still access entities directly",
         )
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryControllerTest.kt
@@ -1,7 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.base.country
 
-import at.wrk.tafel.admin.backend.database.model.staticdata.CountryEntity
-import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
+import at.wrk.tafel.admin.backend.modules.base.country.internal.CountryService
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -14,35 +13,22 @@ import org.junit.jupiter.api.extension.ExtendWith
 class CountryControllerTest {
 
     @RelaxedMockK
-    private lateinit var countryRepository: CountryRepository
+    private lateinit var countryService: CountryService
 
     @InjectMockKs
     private lateinit var countryController: CountryController
 
     @Test
     fun `list countries`() {
-        val country1 = CountryEntity()
-        country1.id = 1
-        country1.code = "AA"
-        country1.name = "Name A"
+        val country1 = Country(id = 1, code = "AA", name = "Name A")
+        val country2 = Country(id = 2, code = "BB", name = "Name B")
 
-        val country2 = CountryEntity()
-        country2.id = 2
-        country2.code = "BB"
-        country2.name = "Name B"
-
-        every { countryRepository.findAll() } returns listOf(country1, country2)
+        every { countryService.listCountries() } returns listOf(country1, country2)
 
         val response = countryController.listCountries()
 
-        assertThat(response).isNotNull
-        assertThat(response.items).hasSize(2)
-
-        assertThat(response.items).hasSameElementsAs(
-            listOf(
-                Country(id = 1, code = "AA", name = "Name A"),
-                Country(id = 2, code = "BB", name = "Name B"),
-            ),
+        assertThat(response).isEqualTo(
+            CountryListResponse(items = listOf(country1, country2)),
         )
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryServiceTest.kt
@@ -1,0 +1,37 @@
+package at.wrk.tafel.admin.backend.modules.base.country.internal
+
+import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
+import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
+import at.wrk.tafel.admin.backend.modules.base.country.testCountry2
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class CountryServiceTest {
+
+    @RelaxedMockK
+    private lateinit var countryRepository: CountryRepository
+
+    @InjectMockKs
+    private lateinit var countryService: CountryService
+
+    @Test
+    fun `list countries`() {
+        every { countryRepository.findAll() } returns listOf(testCountry1, testCountry2)
+
+        val countries = countryService.listCountries()
+
+        assertThat(countries).isEqualTo(
+            listOf(
+                Country(id = testCountry1.id!!, code = testCountry1.code!!, name = testCountry1.name!!),
+                Country(id = testCountry2.id!!, code = testCountry2.code!!, name = testCountry2.name!!),
+            ),
+        )
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeControllerTest.kt
@@ -1,120 +1,55 @@
 package at.wrk.tafel.admin.backend.modules.base.employee
 
-import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
-import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
+import at.wrk.tafel.admin.backend.modules.base.employee.internal.EmployeeService
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 
 @ExtendWith(MockKExtension::class)
 class EmployeeControllerTest {
 
     @RelaxedMockK
-    private lateinit var employeeRepository: EmployeeRepository
+    private lateinit var employeeService: EmployeeService
 
     @InjectMockKs
     private lateinit var employeeController: EmployeeController
 
     @Test
-    fun `find employees with searchInput and page`() {
-        val pageRequest = PageRequest.of(0, 5)
-        val searchInput = "test-input"
-
-        val employee1 = EmployeeEntity()
-        employee1.id = 1
-        employee1.personnelNumber = "00001"
-        employee1.firstname = "first 1"
-        employee1.lastname = "last 1"
-
-        val employee2 = EmployeeEntity()
-        employee2.id = 2
-        employee2.personnelNumber = "00002"
-        employee2.firstname = "first 2"
-        employee2.lastname = "last 2"
-
-        val pagedResult = PageImpl(listOf(employee1, employee2), pageRequest, 123)
-        every { employeeRepository.findBySearchInput(searchInput, pageRequest) } returns pagedResult
-
-        val response = employeeController.findEmployees(searchInput = searchInput, page = 1)
-
-        assertThat(response).isNotNull
-        assertThat(response.items).hasSize(2)
-
-        assertThat(response.items).hasSameElementsAs(
-            listOf(
-                Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
-                Employee(id = 2, personnelNumber = "00002", firstname = "first 2", lastname = "last 2"),
-            ),
-        )
-    }
-
-    @Test
-    fun `find employees without searchInput and page`() {
-        val employee1 = EmployeeEntity()
-        employee1.id = 1
-        employee1.personnelNumber = "00001"
-        employee1.firstname = "first 1"
-        employee1.lastname = "last 1"
-
-        val pageRequest = PageRequest.of(0, 5)
-        val pagedResult = PageImpl(listOf(employee1), pageRequest, 123)
-        every { employeeRepository.findAll(pageRequest) } returns pagedResult
-
-        val response = employeeController.findEmployees()
-
-        assertThat(response).isNotNull
-        assertThat(response.items).hasSize(1)
-
-        assertThat(response.items).hasSameElementsAs(
-            listOf(
+    fun `find employees`() {
+        val response = EmployeeListResponse(
+            items = listOf(
                 Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
             ),
+            totalCount = 1,
+            currentPage = 1,
+            totalPages = 1,
+            pageSize = 5,
         )
-    }
+        every { employeeService.findEmployees("test-input", 1) } returns response
 
-    @Test
-    fun `find employee by searchInput not found`() {
-        every { employeeRepository.findBySearchInput(any(), any()) } returns Page.empty()
+        val result = employeeController.findEmployees(searchInput = "test-input", page = 1)
 
-        val response = employeeController.findEmployees(searchInput = "0000X")
-
-        assertThat(response).isNotNull
-        assertThat(response.items).isEmpty()
+        assertThat(result).isEqualTo(response)
     }
 
     @Test
     fun `save employee`() {
         val employeeCreateRequest = EmployeeCreateRequest(
-            personnelNumber = "   00001",
-            firstname = "first 1  ",
-            lastname = "last 1    ",
+            personnelNumber = "00001",
+            firstname = "first 1",
+            lastname = "last 1",
         )
-        val entity = EmployeeEntity().apply {
-            id = 1
-            personnelNumber = "00001"
-            firstname = "first 1"
-            lastname = "last 1"
-        }
-        every { employeeRepository.save(any()) } returns entity
-        every { employeeRepository.findByPersonnelNumber(employeeCreateRequest.personnelNumber) } returns entity
+        val savedEmployee = Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1")
+        every { employeeService.saveEmployee(employeeCreateRequest) } returns savedEmployee
 
-        employeeController.saveEmployee(employeeCreateRequest)
+        val result = employeeController.saveEmployee(employeeCreateRequest)
 
-        val entitySlot = slot<EmployeeEntity>()
-        verify { employeeRepository.save(capture(entitySlot)) }
-
-        val savedEntity = entitySlot.captured
-        assertThat(savedEntity.personnelNumber).isEqualTo(employeeCreateRequest.personnelNumber.trim())
-        assertThat(savedEntity.firstname).isEqualTo(employeeCreateRequest.firstname.trim())
-        assertThat(savedEntity.lastname).isEqualTo(employeeCreateRequest.lastname.trim())
+        assertThat(result).isEqualTo(savedEmployee)
+        verify { employeeService.saveEmployee(employeeCreateRequest) }
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
@@ -1,0 +1,122 @@
+package at.wrk.tafel.admin.backend.modules.base.employee.internal
+
+import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
+import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
+import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+@ExtendWith(MockKExtension::class)
+class EmployeeServiceTest {
+
+    @RelaxedMockK
+    private lateinit var employeeRepository: EmployeeRepository
+
+    @InjectMockKs
+    private lateinit var employeeService: EmployeeService
+
+    @Test
+    fun `find employees with searchInput and page`() {
+        val pageRequest = PageRequest.of(0, 5)
+        val searchInput = "test-input"
+
+        val employee1 = EmployeeEntity()
+        employee1.id = 1
+        employee1.personnelNumber = "00001"
+        employee1.firstname = "first 1"
+        employee1.lastname = "last 1"
+
+        val employee2 = EmployeeEntity()
+        employee2.id = 2
+        employee2.personnelNumber = "00002"
+        employee2.firstname = "first 2"
+        employee2.lastname = "last 2"
+
+        val pagedResult = PageImpl(listOf(employee1, employee2), pageRequest, 123)
+        every { employeeRepository.findBySearchInput(searchInput, pageRequest) } returns pagedResult
+
+        val response = employeeService.findEmployees(searchInput = searchInput, page = 1)
+
+        assertThat(response).isEqualTo(
+            EmployeeListResponse(
+                items = listOf(
+                    Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
+                    Employee(id = 2, personnelNumber = "00002", firstname = "first 2", lastname = "last 2"),
+                ),
+                totalCount = 123,
+                currentPage = 1,
+                totalPages = pagedResult.totalPages,
+                pageSize = pageRequest.pageSize,
+            ),
+        )
+    }
+
+    @Test
+    fun `find employees without searchInput and page`() {
+        val employee1 = EmployeeEntity()
+        employee1.id = 1
+        employee1.personnelNumber = "00001"
+        employee1.firstname = "first 1"
+        employee1.lastname = "last 1"
+
+        val pageRequest = PageRequest.of(0, 5)
+        val pagedResult = PageImpl(listOf(employee1), pageRequest, 123)
+        every { employeeRepository.findAll(pageRequest) } returns pagedResult
+
+        val response = employeeService.findEmployees()
+
+        assertThat(response.items).isEqualTo(
+            listOf(
+                Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
+            ),
+        )
+    }
+
+    @Test
+    fun `find employee by searchInput not found`() {
+        every { employeeRepository.findBySearchInput(any(), any()) } returns Page.empty()
+
+        val response = employeeService.findEmployees(searchInput = "0000X")
+
+        assertThat(response.items).isEmpty()
+    }
+
+    @Test
+    fun `save employee`() {
+        val employeeCreateRequest = EmployeeCreateRequest(
+            personnelNumber = "   00001",
+            firstname = "first 1  ",
+            lastname = "last 1    ",
+        )
+        val entity = EmployeeEntity().apply {
+            id = 1
+            personnelNumber = "00001"
+            firstname = "first 1"
+            lastname = "last 1"
+        }
+        every { employeeRepository.save(any()) } returns entity
+        every { employeeRepository.findByPersonnelNumber(employeeCreateRequest.personnelNumber) } returns entity
+
+        employeeService.saveEmployee(employeeCreateRequest)
+
+        val entitySlot = slot<EmployeeEntity>()
+        verify { employeeRepository.save(capture(entitySlot)) }
+
+        val savedEntity = entitySlot.captured
+        assertThat(savedEntity.personnelNumber).isEqualTo(employeeCreateRequest.personnelNumber.trim())
+        assertThat(savedEntity.firstname).isEqualTo(employeeCreateRequest.firstname.trim())
+        assertThat(savedEntity.lastname).isEqualTo(employeeCreateRequest.lastname.trim())
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
@@ -35,21 +35,16 @@ internal class DistributionControllerTest {
 
     @Test
     fun `create new distribution`() {
-        val distributionEntity = DistributionEntity()
-        distributionEntity.id = 123
-        distributionEntity.startedAt = LocalDateTime.now()
-        distributionEntity.endedAt = null
-        every { service.createNewDistribution() } returns distributionEntity
+        val distributionItem = DistributionItem(
+            id = 123,
+            startedAt = LocalDateTime.now(),
+            endedAt = null,
+        )
+        every { service.createNewDistributionItem() } returns distributionItem
 
         controller.createNewDistribution()
 
-        val distributionItemResponse = DistributionItemUpdate(
-            distribution = DistributionItem(
-                id = distributionEntity.id!!,
-                startedAt = distributionEntity.startedAt!!,
-                endedAt = distributionEntity.endedAt,
-            ),
-        )
+        val distributionItemResponse = DistributionItemUpdate(distribution = distributionItem)
 
         verify {
             sseOutboxService.saveOutboxEntry(
@@ -61,31 +56,24 @@ internal class DistributionControllerTest {
 
     @Test
     fun `get distributions`() {
-        val distributionEntity = DistributionEntity()
-        distributionEntity.id = 123
-        distributionEntity.startedAt = LocalDateTime.now()
-        distributionEntity.endedAt = null
-        every { service.getDistributions() } returns listOf(distributionEntity)
+        val distributionItem = DistributionItem(
+            id = 123,
+            startedAt = LocalDateTime.now(),
+            endedAt = null,
+        )
+        every { service.getDistributionItems() } returns listOf(distributionItem)
 
         val response = controller.getDistributions()
 
         assertThat(response).isEqualTo(
-            DistributionListResponse(
-                items = listOf(
-                    DistributionItem(
-                        id = distributionEntity.id!!,
-                        startedAt = distributionEntity.startedAt!!,
-                        endedAt = distributionEntity.endedAt,
-                    ),
-                ),
-            ),
+            DistributionListResponse(items = listOf(distributionItem)),
         )
     }
 
     @Test
     fun `create new distribution with existing ongoing distribution`() {
         val message = "MSG"
-        every { service.createNewDistribution() } throws TafelException(message)
+        every { service.createNewDistributionItem() } throws TafelException(message)
 
         val exception = assertThrows(TafelException::class.java) {
             controller.createNewDistribution()
@@ -96,11 +84,12 @@ internal class DistributionControllerTest {
 
     @Test
     fun `listen for distribution updates with active distribution`() {
-        val distributionEntity = DistributionEntity()
-        distributionEntity.id = 123
-        distributionEntity.startedAt = LocalDateTime.now()
-        distributionEntity.endedAt = null
-        every { service.getCurrentDistribution() } returns distributionEntity
+        val distributionItem = DistributionItem(
+            id = 123,
+            startedAt = LocalDateTime.now(),
+            endedAt = null,
+        )
+        every { service.getCurrentDistributionItem() } returns distributionItem
 
         val sseEmitter = controller.listenForDistributionUpdates()
         assertThat(sseEmitter).isNotNull
@@ -108,13 +97,7 @@ internal class DistributionControllerTest {
         verifySequence {
             sseOutboxService.sendEvent(
                 sseEmitter,
-                DistributionItemUpdate(
-                    distribution = DistributionItem(
-                        id = distributionEntity.id!!,
-                        startedAt = distributionEntity.startedAt!!,
-                        endedAt = distributionEntity.endedAt,
-                    ),
-                ),
+                DistributionItemUpdate(distribution = distributionItem),
             )
 
             sseOutboxService.forwardNotificationEventsToSse(
@@ -127,7 +110,7 @@ internal class DistributionControllerTest {
 
     @Test
     fun `listen for distribution updates without active distribution`() {
-        every { service.getCurrentDistribution() } returns null
+        every { service.getCurrentDistributionItem() } returns null
 
         val sseEmitter = controller.listenForDistributionUpdates()
         assertThat(sseEmitter).isNotNull

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
@@ -13,6 +13,7 @@ import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListPdfModel
 import at.wrk.tafel.admin.backend.modules.distribution.internal.postprocessors.DailyReportMailPostProcessor
@@ -227,6 +228,23 @@ internal class DistributionServiceTest {
     }
 
     @Test
+    fun `get distribution items`() {
+        every { distributionRepository.getDistributionEntityByEndedAtIsNotNullOrderByStartedAtDesc() } returns listOf(
+            testDistributionEntity,
+        )
+
+        val distributionItems = service.getDistributionItems()
+
+        assertThat(distributionItems).containsExactly(
+            DistributionItem(
+                id = testDistributionEntity.id!!,
+                startedAt = testDistributionEntity.startedAt!!,
+                endedAt = testDistributionEntity.endedAt,
+            ),
+        )
+    }
+
+    @Test
     fun `create new distribution`() {
         every { userRepository.findByUsername(authentication.username!!) } returns testUserEntity
         every { distributionRepository.findFirstByOrderByIdDesc() } returns null
@@ -253,6 +271,32 @@ internal class DistributionServiceTest {
                 },
             )
         }
+    }
+
+    @Test
+    fun `create new distribution item`() {
+        every { userRepository.findByUsername(authentication.username!!) } returns testUserEntity
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns null
+
+        val distributionEntity = DistributionEntity()
+        distributionEntity.id = 123
+        distributionEntity.startedAt = LocalDateTime.now()
+        every { distributionRepository.save(any()) } returns distributionEntity
+        every { advisoryLockService.tryWithLock(any(), any()) } answers {
+            val block = secondArg<() -> Unit>()
+            block.invoke()
+            true
+        }
+
+        val distributionItem = service.createNewDistributionItem()
+
+        assertThat(distributionItem).isEqualTo(
+            DistributionItem(
+                id = distributionEntity.id!!,
+                startedAt = distributionEntity.startedAt!!,
+                endedAt = distributionEntity.endedAt,
+            ),
+        )
     }
 
     @Test
@@ -300,6 +344,45 @@ internal class DistributionServiceTest {
         val distribution = service.getCurrentDistribution()
 
         assertThat(distribution).isNull()
+    }
+
+    @Test
+    fun `current distribution item found`() {
+        val activeDistribution = testDistributionEntity.apply { endedAt = null }
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns activeDistribution
+
+        val distributionItem = service.getCurrentDistributionItem()
+
+        assertThat(distributionItem).isEqualTo(
+            DistributionItem(
+                id = activeDistribution.id!!,
+                startedAt = activeDistribution.startedAt!!,
+                endedAt = activeDistribution.endedAt,
+            ),
+        )
+    }
+
+    @Test
+    fun `current distribution item not found`() {
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns null
+
+        val distributionItem = service.getCurrentDistributionItem()
+
+        assertThat(distributionItem).isNull()
+    }
+
+    @Test
+    fun `has current distribution true`() {
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity.apply { endedAt = null }
+
+        assertThat(service.hasCurrentDistribution()).isTrue()
+    }
+
+    @Test
+    fun `has current distribution false`() {
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns null
+
+        assertThat(service.hasCurrentDistribution()).isFalse()
     }
 
     @Test
@@ -598,6 +681,23 @@ internal class DistributionServiceTest {
         val distributionHouseholdEntity = service.getCurrentTicketNumber()
 
         assertThat(distributionHouseholdEntity?.ticketNumber).isEqualTo(51)
+    }
+
+    @Test
+    fun `get current ticketNumber value with open tickets left`() {
+        val testDistributionEntity = DistributionEntity().apply {
+            id = 123
+            endedAt = null
+            households = listOf(
+                testDistributionHouseholdEntity1,
+                testDistributionHouseholdEntity2,
+            )
+        }
+        every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity
+
+        val ticketNumber = service.getCurrentTicketNumberValue()
+
+        assertThat(ticketNumber).isEqualTo(51)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketControllerTest.kt
@@ -1,11 +1,8 @@
 package at.wrk.tafel.admin.backend.modules.distribution.internal.ticket
 
-import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.TicketNumberResponse
-import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
-import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity3
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -29,7 +26,7 @@ internal class DistributionTicketControllerTest {
     @Test
     fun `get current ticket for household 1`() {
         val householdId = 123L
-        every { service.getCurrentTicketNumber(householdId) } returns testDistributionHouseholdEntity1
+        every { service.getCurrentTicketNumberValue(householdId) } returns 50
 
         val response = controller.getCurrentTicketForHouseholdId(householdId)
 
@@ -41,7 +38,7 @@ internal class DistributionTicketControllerTest {
     @Test
     fun `get current ticket for household 2`() {
         val householdId = 123L
-        every { service.getCurrentTicketNumber(householdId) } returns testDistributionHouseholdEntity3
+        every { service.getCurrentTicketNumberValue(householdId) } returns 52
 
         val response = controller.getCurrentTicketForHouseholdId(householdId)
 
@@ -52,9 +49,6 @@ internal class DistributionTicketControllerTest {
 
     @Test
     fun `delete current ticket for household`() {
-        val distributionEntity = DistributionEntity()
-        distributionEntity.id = 123
-        every { service.getCurrentDistribution() } returns distributionEntity
         every { service.deleteCurrentTicket(any()) } returns true
 
         val householdId = 123L
@@ -66,9 +60,6 @@ internal class DistributionTicketControllerTest {
 
     @Test
     fun `delete current ticket for household failed`() {
-        val distributionEntity = DistributionEntity()
-        distributionEntity.id = 123
-        every { service.getCurrentDistribution() } returns distributionEntity
         every { service.deleteCurrentTicket(any()) } returns false
 
         val householdId = 123L

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenControllerTest.kt
@@ -1,10 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.distribution.internal.ticket
 
 import at.wrk.tafel.admin.backend.database.common.sseoutbox.SseOutboxService
-import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
-import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionEntity
-import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
 import at.wrk.tafel.admin.backend.modules.distribution.internal.ticket.DistributionTicketScreenController.Companion.TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -52,8 +49,8 @@ internal class DistributionTicketScreenControllerTest {
 
     @Test
     fun `show current ticketNumber with active distribution`() {
-        every { service.getCurrentDistribution() } returns testDistributionEntity
-        every { service.getCurrentTicketNumber(null) } returns testDistributionHouseholdEntity1
+        every { service.hasCurrentDistribution() } returns true
+        every { service.getCurrentTicketNumberValue() } returns 50
 
         controller.showCurrentTicket()
 
@@ -70,8 +67,7 @@ internal class DistributionTicketScreenControllerTest {
 
     @Test
     fun `show current ticketNumber without active distribution`() {
-        every { service.getCurrentDistribution() } returns null
-        every { service.getCurrentTicketNumber(null) } returns testDistributionHouseholdEntity1
+        every { service.hasCurrentDistribution() } returns false
 
         controller.showCurrentTicket()
 
@@ -168,8 +164,8 @@ internal class DistributionTicketScreenControllerTest {
     fun `listen for changes with active distribution`() {
         val testValue = TicketScreenShowText(text = "Ticket", value = "50")
 
-        every { service.getCurrentDistribution() } returns DistributionEntity()
-        every { service.getCurrentTicketNumber() } returns testDistributionHouseholdEntity1
+        every { service.hasCurrentDistribution() } returns true
+        every { service.getCurrentTicketNumberValue() } returns 50
 
         val emitter = controller.listenForChanges()
         assertThat(emitter).isNotNull
@@ -196,7 +192,7 @@ internal class DistributionTicketScreenControllerTest {
     fun `listen for changes without active distribution`() {
         val testValue = TicketScreenShowText(text = "Ticket", value = null)
 
-        every { service.getCurrentDistribution() } returns null
+        every { service.hasCurrentDistribution() } returns false
 
         val emitter = controller.listenForChanges()
         assertThat(emitter).isNotNull


### PR DESCRIPTION
## Summary
- Extracted repository/entity access out of `CountryController`, `EmployeeController`, `DistributionController`, `DistributionTicketController`, and `DistributionTicketScreenController` into their services, matching the service-layer pattern used elsewhere in the codebase (e.g. `FoodCategoryService`, `HouseholdService`).
  - `CountryController`/`EmployeeController` now delegate to new internal `CountryService`/`EmployeeService` classes.
  - `DistributionService` gained DTO-returning methods (`getDistributionItems`, `createNewDistributionItem`, `getCurrentDistributionItem`, `hasCurrentDistribution`, `getCurrentTicketNumberValue`) so its three controllers never touch `DistributionEntity`/`DistributionHouseholdEntity` directly anymore.
- Removed the `CountryController`/`EmployeeController` exemption from the `rest controllers should not expose database entities directly` ArchUnit rule.
- Added the previously-proposed `rest controllers should not depend on database entities directly` ArchUnit rule with **no exemptions** — every `@RestController` in the codebase now complies.

Closes #2801

## Test plan
- [x] `./gradlew :backend:test` — full backend suite passes
- [x] `./gradlew :backend:ktlintCheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)