### PR TITLE
fix: show the Docker image reference in GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,14 @@ jobs:
         with:
           tag_name: ${{ needs.version.outputs.version }}
           generate_release_notes: true
+          body: |
+            ## Docker image
+
+            ```
+            ghcr.io/wrk-tafel/admin:${{ needs.version.outputs.version }}
+            ```
+
+            Also tagged `latest`. All tags: https://github.com/wrk-tafel/admin/pkgs/container/admin
   deploy-test:
     uses: ./.github/workflows/subflow_deploy.yml
     needs: build-push-image-test


### PR DESCRIPTION
## Summary
- `release.yml`'s `github-release` job now sets a `body:` on the GitHub Release with the actual image name/tag (`ghcr.io/wrk-tafel/admin:<version>`) and a link to the registry page, prepended before the auto-generated PR changelog. Previously the release notes only listed merged PRs with no mention of the deployable artifact.
- Also retroactively fixed the already-published `0.1.0` release the same way (its auto-generated changelog spanned the entire multi-year repo history with no previous tag to diff against, and was too long to prepend to under GitHub's 125KB body limit, so it's replaced with a link to the full commit history instead).

## Test plan
- [x] YAML validated
- [x] Verified live: https://github.com/wrk-tafel/admin/releases/tag/0.1.0 now shows the Docker image block
- [ ] Confirm on the next tagged release that the auto-generated changelog (now diffing against 0.1.0 instead of repo start) renders correctly alongside the new body prefix