### PR TITLE
feat: add alleinerzieher (single-parent) household flag

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionStatisticEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/distribution/DistributionStatisticEntity.kt
@@ -51,6 +51,9 @@ class DistributionStatisticEntity : BaseChangeTrackingEntity() {
     @Column(name = "count_customers_updated")
     var countCustomersUpdated: Int = 0
 
+    @Column(name = "count_single_parent_households")
+    var countSingleParentHouseholds: Int = 0
+
     @Column(name = "shops_total_count")
     var shopsTotalCount: Int = 0
 
@@ -86,6 +89,7 @@ class DistributionStatisticEntity : BaseChangeTrackingEntity() {
             countCustomersProlonged == 0 &&
             countPersonsProlonged == 0 &&
             countCustomersUpdated == 0 &&
+            countSingleParentHouseholds == 0 &&
             shopsTotalCount == 0 &&
             shopsWithFoodCount == 0 &&
             BigDecimal.ZERO.compareTo(foodTotalAmount) == 0 &&

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdEntity.kt
@@ -102,6 +102,9 @@ class HouseholdEntity : BaseChangeTrackingEntity() {
     @Column(name = "pending_cost_contribution")
     var pendingCostContribution: BigDecimal = BigDecimal.ZERO
 
+    @Column(name = "single_parent")
+    var singleParent: Boolean? = null
+
     @OneToMany(mappedBy = "household", cascade = [CascadeType.ALL], orphanRemoval = true)
     var persons: MutableList<PersonEntity> = mutableListOf()
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
@@ -109,6 +109,9 @@ class DistributionStatisticService(
                 statisticEndTime,
             )
         statistic.countCustomersUpdated = countHouseholdsUpdated - countHouseholdsNew - countHouseholdsProlonged
+
+        statistic.countSingleParentHouseholds =
+            distribution.households.count { it.household?.singleParent == true }
     }
 
     private fun fillLogisticsStatistics(distribution: DistributionEntity, statistic: DistributionStatisticEntity) {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
@@ -41,6 +41,7 @@ data class Household(
     val lockedBy: String? = null,
     val lockReason: String? = null,
     val pendingCostContribution: BigDecimal? = null,
+    val singleParent: Boolean? = null,
     val persons: List<Person> = emptyList(),
 ) {
     /**

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverter.kt
@@ -44,6 +44,7 @@ class HouseholdConverter(
         householdEntity.addressCity = householdUpdate.address.city?.trim()
         householdEntity.telephoneNumber = householdUpdate.telephoneNumber
         householdEntity.email = householdUpdate.email?.takeIf { it.isNotBlank() }?.trim()
+        householdEntity.singleParent = householdUpdate.singleParent
 
         val prolongedAt =
             if (storedEntity?.validUntil != null &&
@@ -139,6 +140,7 @@ class HouseholdConverter(
             lockedBy = householdEntity.lockedBy?.let { "${it.employee!!.personnelNumber} ${it.employee!!.firstname} ${it.employee!!.lastname}" },
             lockReason = householdEntity.lockReason,
             pendingCostContribution = householdEntity.pendingCostContribution,
+            singleParent = householdEntity.singleParent,
             persons = listOfNotNull(mainPersonEntity?.let { mapPerson(it) }) + additionalPersons,
         )
     }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportService.kt
@@ -49,6 +49,7 @@ class DailyReportService(
             countCustomersProlonged = statistic.countCustomersProlonged,
             countPersonsProlonged = statistic.countPersonsProlonged,
             countCustomersUpdated = statistic.countCustomersUpdated,
+            countSingleParentHouseholds = statistic.countSingleParentHouseholds,
 
             shopsTotalCount = statistic.shopsTotalCount,
             shopsWithFoodCount = statistic.shopsWithFoodCount,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
@@ -85,6 +85,7 @@ data class StatisticsData(
     val beneficiaryCustomers: StatisticsDetailData,
     val beneficiaryPersons: StatisticsDetailData,
     val beneficiaryCustomersWithChildren: StatisticsDetailData,
+    val singleParentHouseholds: StatisticsDetailData,
     val sheltersCount: StatisticsDetailData,
     val sheltersAverage: StatisticsDetailData,
     val sheltersPersonsCount: StatisticsDetailData,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DailyReportPdfModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DailyReportPdfModel.kt
@@ -21,6 +21,7 @@ data class DailyReportPdfModel(
     val countCustomersProlonged: Int,
     val countPersonsProlonged: Int,
     val countCustomersUpdated: Int,
+    val countSingleParentHouseholds: Int,
 
     val shopsTotalCount: Int,
     val shopsWithFoodCount: Int,
@@ -50,6 +51,7 @@ data class DailyReportPdfModel(
             countCustomersProlonged == other.countCustomersProlonged &&
             countPersonsProlonged == other.countPersonsProlonged &&
             countCustomersUpdated == other.countCustomersUpdated &&
+            countSingleParentHouseholds == other.countSingleParentHouseholds &&
             shopsTotalCount == other.shopsTotalCount &&
             shopsWithFoodCount == other.shopsWithFoodCount &&
             foodTotalAmount == other.foodTotalAmount &&
@@ -73,6 +75,7 @@ data class DailyReportPdfModel(
         result = 31 * result + countCustomersProlonged
         result = 31 * result + countPersonsProlonged
         result = 31 * result + countCustomersUpdated
+        result = 31 * result + countSingleParentHouseholds
         result = 31 * result + shopsTotalCount
         result = 31 * result + shopsWithFoodCount
         result = 31 * result + foodTotalAmount.hashCode()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
@@ -80,6 +80,14 @@ class StatisticsService(
             dataPoints = countBeneficiaryCustomersWithChildren.map { it.value },
         )
 
+        val countSingleParentHouseholds = countSingleParentHouseholds(fromDate, toDate)
+        val countSingleParentHouseholdsData = StatisticsDetailData(
+            title = INTEGER_FORMATTER.format(countSingleParentHouseholds.lastOrNull()?.value?.toLong() ?: 0L),
+            subTitle = "Alleinerzieher (Haushalte)",
+            labels = countSingleParentHouseholds.map { it.label },
+            dataPoints = countSingleParentHouseholds.map { it.value },
+        )
+
         val countShelters = countShelters(fromDate, toDate)
         val countSheltersData = StatisticsDetailData(
             title = INTEGER_FORMATTER.format(countShelters.sumOf { it.value.toLong() }),
@@ -139,6 +147,7 @@ class StatisticsService(
             beneficiaryCustomers = countBeneficiaryCustomersData,
             beneficiaryPersons = countBeneficiaryPersonsData,
             beneficiaryCustomersWithChildren = countBeneficiaryCustomersWithChildrenData,
+            singleParentHouseholds = countSingleParentHouseholdsData,
             sheltersCount = countSheltersData,
             sheltersAverage = averageSheltersData,
             sheltersPersonsCount = countSheltersPersonsData,
@@ -196,6 +205,24 @@ class StatisticsService(
                     AND h.locked IS NOT TRUE
                     AND p.is_main_person = false
                     AND EXTRACT(YEAR FROM AGE(t.start_date, p.birth_date)) <= 15
+                ) as value
+            FROM get_timeline(:fromDate, :toDate) t
+            ORDER BY t.start_date ASC
+        """.trimIndent()
+
+        return executeStatsQuery(sql, fromDate, toDate)
+    }
+
+    fun countSingleParentHouseholds(fromDate: LocalDate, toDate: LocalDate): List<StatisticsResult> {
+        val sql = """
+            SELECT
+                format_by_resolution(t.start_date, t.res_code) as label,
+                (
+                    SELECT COUNT(*)
+                    FROM households h
+                    WHERE h.valid_until >= t.start_date
+                    AND h.locked is not true
+                    AND h.single_parent is true
                 ) as value
             FROM get_timeline(:fromDate, :toDate) t
             ORDER BY t.start_date ASC
@@ -352,6 +379,7 @@ class StatisticsService(
                 "Bezugsberechtigte Haushalte mit Kindern (Alter <= 15)",
                 data.beneficiaryCustomersWithChildren.title,
             ),
+            listOf("Alleinerzieher (Haushalte)", data.singleParentHouseholds.title),
             listOf("Notschlafstellen (Anzahl)", data.sheltersCount.title),
             listOf("Notschlafstellen (Durchschnitt pro Ausgabe)", data.sheltersAverage.title),
             listOf("Notschlafstellen (versorgte Personen pro Ausgabe)", data.sheltersPersonsCount.title),

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/DailyReportsExporter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/DailyReportsExporter.kt
@@ -34,6 +34,7 @@ class DailyReportsExporter(
             "Verlängert (Personen)",
             "Neue Kunden",
             "Neue Personen",
+            "Alleinerzieher (Haushalte)",
             "Ges. Spender",
             "Spender mit Ware",
             "Warenmenge",
@@ -87,6 +88,7 @@ class DailyReportsExporter(
         columns.add(statistic.countPersonsProlonged.toString())
         columns.add(statistic.countCustomersNew.toString())
         columns.add(statistic.countPersonsNew.toString())
+        columns.add(statistic.countSingleParentHouseholds.toString())
         columns.add(statistic.shopsTotalCount.toString())
         columns.add(statistic.shopsWithFoodCount.toString())
         columns.add(statistic.foodTotalAmount.toString())

--- a/backend/src/main/resources/db-migration-testdata/testdata.sql
+++ b/backend/src/main/resources/db-migration-testdata/testdata.sql
@@ -176,9 +176,9 @@ UPDATE households SET main_person_id = 100 WHERE id = 100;
 
 INSERT INTO households (id, created_at, updated_at, household_id, employee_id, main_person_id,
                         address_street, address_housenumber, address_stairway, address_door, address_postalcode,
-                        address_city, telephone_number, email, valid_until, pending_cost_contribution)
+                        address_city, telephone_number, email, valid_until, pending_cost_contribution, single_parent)
 values (101, NOW(), NOW(), 101, 100, null, 'Erdberg', 2, '1', '20', '1010',
-        'Wien', '00436645678953', 'eva.musterfrau@wrk.at', '2999-12-31', 0);
+        'Wien', '00436645678953', 'eva.musterfrau@wrk.at', '2999-12-31', 0, true);
 INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
                      country_id, employer, income, income_due, exclude_household, receives_family_allowance)
 values (101, NOW(), NOW(), 101, true, 'Eva', 'Musterfrau', '1990-01-01', 'FEMALE', 2, 'Rotes Kreuz Wien', 456.00,
@@ -219,9 +219,9 @@ UPDATE households SET main_person_id = 102 WHERE id = 102;
 
 INSERT INTO households (id, created_at, updated_at, household_id, employee_id, main_person_id,
                         address_street, address_housenumber, address_stairway, address_door, address_postalcode,
-                        address_city, telephone_number, email, valid_until, pending_cost_contribution)
+                        address_city, telephone_number, email, valid_until, pending_cost_contribution, single_parent)
 values (103, NOW(), NOW(), 103, 100, null, 'Erdberg', 1, null, null,
-        '1030', 'Wien', null, null, NOW() + interval '1 month', 0);
+        '1030', 'Wien', null, null, NOW() + interval '1 month', 0, true);
 INSERT INTO persons (id, created_at, updated_at, household_id, is_main_person, firstname, lastname, birth_date, gender,
                      country_id, employer, income, income_due, exclude_household, receives_family_allowance)
 values (103, NOW(), NOW(), 103, true, 'John Doe', 'EXPIRES SOON', '1980-01-01', 'MALE', 1, 'Stadt Wien', 123.00,

--- a/backend/src/main/resources/db-migration/R__00076_household_single_parent.sql
+++ b/backend/src/main/resources/db-migration/R__00076_household_single_parent.sql
@@ -1,0 +1,2 @@
+alter table if exists households
+    add column if not exists single_parent boolean null;

--- a/backend/src/main/resources/db-migration/R__00077_backfill_household_single_parent.sql
+++ b/backend/src/main/resources/db-migration/R__00077_backfill_household_single_parent.sql
@@ -1,0 +1,17 @@
+-- Heuristic backfill for the new households.single_parent flag: a household is guessed to be a
+-- single-parent household when exactly one of its members is an adult (>= 18 years, as of today)
+-- and at least one member is a minor. Members with an unknown birth_date are ignored for this
+-- age check (neither counted as adult nor as minor) rather than skewing the counts.
+-- This is a best-effort guess for historic data only, based on ages - the schema has no
+-- relationship type between household members (e.g. partner vs. child vs. other relative), so it
+-- cannot be derived reliably. Staff can correct it per household via the customer form.
+update households h
+set single_parent = (
+    select
+        count(*) filter (where p.birth_date <= current_date - interval '18 years') = 1
+        and count(*) filter (where p.birth_date > current_date - interval '18 years') >= 1
+    from persons p
+    where p.household_id = h.id
+    and p.birth_date is not null
+)
+where h.single_parent is null;

--- a/backend/src/main/resources/db-migration/R__00078_distribution_statistics_single_parent.sql
+++ b/backend/src/main/resources/db-migration/R__00078_distribution_statistics_single_parent.sql
@@ -1,0 +1,2 @@
+alter table if exists distributions_statistics
+    add column if not exists count_single_parent_households integer not null default 0;

--- a/backend/src/main/resources/pdf-templates/daily-report/includes/content.xsl
+++ b/backend/src/main/resources/pdf-templates/daily-report/includes/content.xsl
@@ -92,6 +92,16 @@
                             </fo:block>
                         </fo:table-cell>
                     </fo:table-row>
+                    <fo:table-row>
+                        <fo:table-cell>
+                            <fo:block>davon Alleinerzieher (Haushalte):</fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                            <fo:block>
+                                <xsl:value-of select="countSingleParentHouseholds"/>
+                            </fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
                 </fo:table-body>
             </fo:table>
         </fo:block>

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticServiceTest.kt
@@ -1,8 +1,10 @@
 package at.wrk.tafel.admin.backend.modules.distribution.internal.statistic
 
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
+import at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticRepository
+import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
@@ -110,6 +112,7 @@ internal class DistributionStatisticServiceTest {
         assertThat(savedStatistic.countCustomersProlonged).isEqualTo(testCustomersProlonged.size)
         assertThat(savedStatistic.countPersonsProlonged).isEqualTo(3)
         assertThat(savedStatistic.countCustomersUpdated).isEqualTo(testCountCustomersUpdated - testCustomersNew.size - testCustomersProlonged.size)
+        assertThat(savedStatistic.countSingleParentHouseholds).isEqualTo(0)
 
         assertThat(savedStatistic.shopsTotalCount).isEqualTo(3)
         assertThat(savedStatistic.shopsWithFoodCount).isEqualTo(2)
@@ -148,12 +151,54 @@ internal class DistributionStatisticServiceTest {
         assertThat(savedStatistic.countCustomersProlonged).isEqualTo(0)
         assertThat(savedStatistic.countPersonsProlonged).isEqualTo(0)
         assertThat(savedStatistic.countCustomersUpdated).isEqualTo(0)
+        assertThat(savedStatistic.countSingleParentHouseholds).isEqualTo(0)
 
         assertThat(savedStatistic.shopsTotalCount).isEqualTo(0)
         assertThat(savedStatistic.shopsWithFoodCount).isEqualTo(0)
         assertThat(savedStatistic.foodTotalAmount).isEqualTo(BigDecimal.ZERO)
         assertThat(savedStatistic.foodPerShopAverage).isEqualTo(BigDecimal.ZERO)
         assertThat(savedStatistic.routesLengthKm).isEqualTo(0)
+    }
+
+    @Test
+    fun `count single parent households only counts registered households flagged as such`() {
+        val singleParentHousehold1 = DistributionHouseholdEntity().apply {
+            household = HouseholdEntity().apply { singleParent = true }
+        }
+        val singleParentHousehold2 = DistributionHouseholdEntity().apply {
+            household = HouseholdEntity().apply { singleParent = true }
+        }
+        val nonSingleParentHousehold = DistributionHouseholdEntity().apply {
+            household = HouseholdEntity().apply { singleParent = false }
+        }
+        val unknownHousehold = DistributionHouseholdEntity().apply {
+            household = HouseholdEntity().apply { singleParent = null }
+        }
+
+        val testDistributionEntity = DistributionEntity().apply {
+            id = 123
+            startedAt = LocalDateTime.now().minusHours(2)
+            endedAt = LocalDateTime.now()
+            statistic = DistributionStatisticEntity()
+            households = listOf(
+                singleParentHousehold1,
+                singleParentHousehold2,
+                nonSingleParentHousehold,
+                unknownHousehold,
+            )
+        }
+
+        every { householdRepository.findAllByCreatedAtBetween(any(), any()) } returns emptyList()
+        every { householdRepository.countByUpdatedAtBetween(any(), any()) } returns 0
+        every { householdRepository.findAllByProlongedAtBetween(any(), any()) } returns emptyList()
+        every { distributionStatisticRepository.save(any()) } returns mockk()
+
+        service.saveStatistic(testDistributionEntity)
+
+        val savedStatisticSlot = slot<DistributionStatisticEntity>()
+        verify { distributionStatisticRepository.save(capture(savedStatisticSlot)) }
+
+        assertThat(savedStatisticSlot.captured.countSingleParentHouseholds).isEqualTo(2)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverterTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverterTest.kt
@@ -93,6 +93,7 @@ internal class HouseholdConverterTest {
         validUntil = LocalDate.now(),
         locked = false,
         pendingCostContribution = null,
+        singleParent = true,
         persons = listOf(
             testMainPerson,
             Person(
@@ -138,6 +139,7 @@ internal class HouseholdConverterTest {
         locked = false
         prolongedAt = null
         pendingCostContribution = BigDecimal.TEN
+        singleParent = true
 
         val mainPersonEntity = PersonEntity()
         mainPersonEntity.id = 1
@@ -259,6 +261,7 @@ internal class HouseholdConverterTest {
         assertThat(household.email).isEqualTo(testHousehold.email)
         assertThat(household.validUntil).isEqualTo(testHousehold.validUntil)
         assertThat(household.pendingCostContribution).isEqualTo(BigDecimal.TEN)
+        assertThat(household.singleParent).isTrue()
 
         assertThat(household.locked).isFalse()
         assertThat(household.lockedAt).isNull()
@@ -294,6 +297,7 @@ internal class HouseholdConverterTest {
 
         assertThat(result.householdId).isEqualTo(100)
         assertThat(result.addressStreet).isEqualTo("Test-Straße")
+        assertThat(result.singleParent).isTrue()
         assertThat(result.persons).hasSize(3)
         assertThat(result.persons.count { it.isMainPerson }).isEqualTo(1)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/DailyReportServiceTest.kt
@@ -43,6 +43,7 @@ internal class DailyReportServiceTest {
             countCustomersProlonged = 7
             countPersonsProlonged = 8
             countCustomersUpdated = 9
+            countSingleParentHouseholds = 15
 
             shopsTotalCount = 10
             shopsWithFoodCount = 11
@@ -85,6 +86,7 @@ internal class DailyReportServiceTest {
         assertThat(pdfModel.countCustomersProlonged).isEqualTo(statistic.countCustomersProlonged)
         assertThat(pdfModel.countPersonsProlonged).isEqualTo(statistic.countPersonsProlonged)
         assertThat(pdfModel.countCustomersUpdated).isEqualTo(statistic.countCustomersUpdated)
+        assertThat(pdfModel.countSingleParentHouseholds).isEqualTo(statistic.countSingleParentHouseholds)
 
         assertThat(pdfModel.shopsTotalCount).isEqualTo(statistic.shopsTotalCount)
         assertThat(pdfModel.shopsWithFoodCount).isEqualTo(statistic.shopsWithFoodCount)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
@@ -422,6 +422,12 @@ internal class StatisticsServiceTest {
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
+                singleParentHouseholds = StatisticsDetailData(
+                    title = "30",
+                    subTitle = "Alleinerzieher (Haushalte)",
+                    labels = expectedLabels,
+                    dataPoints = expectedDataPoints,
+                ),
                 sheltersCount = StatisticsDetailData(
                     title = "60",
                     subTitle = "Notschlafstellen (Anzahl)",
@@ -482,18 +488,19 @@ internal class StatisticsServiceTest {
         val csvContent = String(result.bytes, Charsets.UTF_8)
 
         val lines = csvContent.trim().lines()
-        assertThat(lines).hasSize(10)
+        assertThat(lines).hasSize(11)
 
         assertThat(lines[0]).isEqualTo("Statistik-Export;Zeitraum: 01.01.2024 bis 31.12.2024")
         assertThat(lines[1]).isEqualTo("Bezugsberechtigte Haushalte;30")
         assertThat(lines[2]).isEqualTo("Bezugsberechtigte Personen;30")
         assertThat(lines[3]).isEqualTo("Bezugsberechtigte Haushalte mit Kindern (Alter <= 15);30")
-        assertThat(lines[4]).isEqualTo("Notschlafstellen (Anzahl);60")
-        assertThat(lines[5]).isEqualTo("Notschlafstellen (Durchschnitt pro Ausgabe);20,00")
-        assertThat(lines[6]).isEqualTo("Notschlafstellen (versorgte Personen pro Ausgabe);60")
-        assertThat(lines[7]).isEqualTo("Spender (Anzahl);60")
-        assertThat(lines[8]).isEqualTo("Warenmenge (Gesamt);60 kg")
-        assertThat(lines[9]).isEqualTo("Warenmenge (Durchschnitt pro Spender);20,00 kg")
+        assertThat(lines[4]).isEqualTo("Alleinerzieher (Haushalte);30")
+        assertThat(lines[5]).isEqualTo("Notschlafstellen (Anzahl);60")
+        assertThat(lines[6]).isEqualTo("Notschlafstellen (Durchschnitt pro Ausgabe);20,00")
+        assertThat(lines[7]).isEqualTo("Notschlafstellen (versorgte Personen pro Ausgabe);60")
+        assertThat(lines[8]).isEqualTo("Spender (Anzahl);60")
+        assertThat(lines[9]).isEqualTo("Warenmenge (Gesamt);60 kg")
+        assertThat(lines[10]).isEqualTo("Warenmenge (Durchschnitt pro Spender);20,00 kg")
     }
 
     /**

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/DailyReportsExporterTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/statisticexporter/DailyReportsExporterTest.kt
@@ -123,23 +123,23 @@ class DailyReportsExporterTest {
                 listOf("TOeT Auswertung Stand: ${LocalDateTime.now().format(DATE_FORMATTER)} - Tagesreports"),
                 listOf(
                     "Datum", "KW", "Versorgte Personen", "davon in NOST", "davon in Ausgabestelle", "davon Kinder < 3 Jahre", "Haushalte",
-                    "Verlängert (Haushalte)", "Verlängert (Personen)", "Neue Kunden", "Neue Personen", "Ges. Spender", "Spender mit Ware",
+                    "Verlängert (Haushalte)", "Verlängert (Personen)", "Neue Kunden", "Neue Personen", "Alleinerzieher (Haushalte)", "Ges. Spender", "Spender mit Ware",
                     "Warenmenge", "Kilometerleistung", "Anz. MitarbeiterInnen",
                 ),
                 listOf(
                     previousDistribution2.startedAt!!.format(DATE_FORMATTER),
                     previousDistribution2.startedAt!![IsoFields.WEEK_OF_WEEK_BASED_YEAR].toString(),
-                    "25", "3", "22", "11", "10", "9", "8", "7", "6", "5", "4", "3.1", "2", "1",
+                    "25", "3", "22", "11", "10", "9", "8", "7", "6", "0", "5", "4", "3.1", "2", "1",
                 ),
                 listOf(
                     previousDistribution1.startedAt!!.format(DATE_FORMATTER),
                     previousDistribution1.startedAt!![IsoFields.WEEK_OF_WEEK_BASED_YEAR].toString(),
-                    "9", "3", "6", "3", "4", "5", "6", "7", "8", "9", "10", "11.1", "12", "13",
+                    "9", "3", "6", "3", "4", "5", "6", "7", "8", "0", "9", "10", "11.1", "12", "13",
                 ),
                 listOf(
                     currentDistribution.startedAt!!.format(DATE_FORMATTER),
                     currentDistribution.startedAt!![IsoFields.WEEK_OF_WEEK_BASED_YEAR].toString(),
-                    "22", "0", "22", "11", "10", "9", "8", "7", "6", "5", "4", "3.1", "2", "1",
+                    "22", "0", "22", "11", "10", "9", "8", "7", "6", "0", "5", "4", "3.1", "2", "1",
                 ),
             ),
         )
@@ -184,13 +184,13 @@ class DailyReportsExporterTest {
                 listOf("TOeT Auswertung Stand: ${LocalDateTime.now().format(DATE_FORMATTER)} - Tagesreports"),
                 listOf(
                     "Datum", "KW", "Versorgte Personen", "davon in NOST", "davon in Ausgabestelle", "davon Kinder < 3 Jahre", "Haushalte",
-                    "Verlängert (Haushalte)", "Verlängert (Personen)", "Neue Kunden", "Neue Personen", "Ges. Spender", "Spender mit Ware",
+                    "Verlängert (Haushalte)", "Verlängert (Personen)", "Neue Kunden", "Neue Personen", "Alleinerzieher (Haushalte)", "Ges. Spender", "Spender mit Ware",
                     "Warenmenge", "Kilometerleistung", "Anz. MitarbeiterInnen",
                 ),
                 listOf(
                     currentDistribution.startedAt!!.format(DATE_FORMATTER),
                     currentDistribution.startedAt!![IsoFields.WEEK_OF_WEEK_BASED_YEAR].toString(),
-                    "25", "3", "22", "11", "10", "9", "8", "7", "6", "5", "4", "3.1", "2", "1",
+                    "25", "3", "22", "11", "10", "9", "8", "7", "6", "0", "5", "4", "3.1", "2", "1",
                 ),
             ),
         )

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.spec.ts
@@ -34,6 +34,7 @@ describe('CustomerApiService', () => {
     employer: 'test employer',
     income: 1000,
     incomeDue: incomeDue,
+    singleParent: true,
     additionalPersons: [
       {
         key: 'form-only-key',
@@ -64,6 +65,7 @@ describe('CustomerApiService', () => {
     },
     telephoneNumber: '00436644123123123',
     email: 'max.mustermann@gmail.com',
+    singleParent: true,
     persons: [
       {
         id: 1,
@@ -169,6 +171,7 @@ describe('CustomerApiService', () => {
     expect(body.address).toEqual(mockCustomer.address);
     expect(body.telephoneNumber).toEqual('00436644123123123');
     expect(body.email).toEqual('max.mustermann@gmail.com');
+    expect(body.singleParent).toBe(true);
     expect(body.firstname).toBeUndefined();
     expect(body.additionalPersons).toBeUndefined();
 
@@ -219,6 +222,7 @@ describe('CustomerApiService', () => {
     expect(result!.incomeDue).toEqual(incomeDue);
     expect(result!.address).toEqual(mockCustomer.address);
     expect(result!.telephoneNumber).toEqual('00436644123123123');
+    expect(result!.singleParent).toBe(true);
 
     expect(result!.additionalPersons).toHaveLength(1);
     expect(result!.additionalPersons![0].id).toEqual(2);

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.ts
@@ -188,6 +188,7 @@ export interface CustomerData {
   lockedBy?: string | null;
   lockReason?: string | null;
   pendingCostContribution?: number;
+  singleParent?: boolean;
   additionalPersons?: CustomerAddPersonData[];
 }
 
@@ -284,6 +285,7 @@ interface HouseholdData {
   lockedBy?: string | null;
   lockReason?: string | null;
   pendingCostContribution?: number;
+  singleParent?: boolean;
   persons: PersonData[];
 }
 
@@ -398,6 +400,7 @@ function mapHouseholdToCustomer(household: HouseholdData | null | undefined): Cu
     lockedBy: household?.lockedBy,
     lockReason: household?.lockReason,
     pendingCostContribution: household?.pendingCostContribution,
+    singleParent: household?.singleParent,
     additionalPersons: additionalPersons
   };
 }
@@ -453,6 +456,7 @@ function mapCustomerToHousehold(customer: CustomerData): HouseholdData {
     lockedBy: customer.lockedBy,
     lockReason: customer.lockReason,
     pendingCostContribution: customer.pendingCostContribution,
+    singleParent: customer.singleParent,
     persons: [mainPerson, ...additionalPersons]
   };
 }

--- a/frontend/src/main/webapp/src/app/api/statistics-api.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/api/statistics-api.service.spec.ts
@@ -87,6 +87,16 @@ describe('StatisticsApiService', () => {
         ],
         dataPoints: [2, 2, 2]
       },
+      singleParentHouseholds: {
+        title: '1',
+        subTitle: 'Alleinerzieher (Haushalte)',
+        labels: [
+          '2026-01',
+          '2026-02',
+          '2026-03'
+        ],
+        dataPoints: [1, 1, 1]
+      },
       sheltersCount: {
         title: '0',
         subTitle: 'Notschlafstellen (Anzahl)',

--- a/frontend/src/main/webapp/src/app/api/statistics-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/statistics-api.service.ts
@@ -72,6 +72,7 @@ export interface StatisticsData {
   beneficiaryCustomers: StatisticsDetailData
   beneficiaryPersons: StatisticsDetailData
   beneficiaryCustomersWithChildren: StatisticsDetailData
+  singleParentHouseholds: StatisticsDetailData
   sheltersCount: StatisticsDetailData
   sheltersAverage: StatisticsDetailData
   sheltersPersonsCount: StatisticsDetailData

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -193,6 +193,12 @@
             <div class="invalid-feedback">{{errorMessage}}</div>
           }
         </div>
+        <div class="mb-2">
+          <label class="form-label">Alleinerzieher</label>
+          <div>
+            <input testid="singleParentInput" type="checkbox" [formField]="customerForm.singleParent">
+          </div>
+        </div>
       </mat-card-content>
     </mat-card>
     <div class="mt-4 md:mt-0">

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -1,5 +1,5 @@
 <form>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
     <mat-card>
       <mat-card-header>
         <h5>Hauptbezieher</h5>

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -186,18 +186,19 @@
         </div>
         <hr/>
         <div class="mb-2">
+          <label class="form-label">Alleinerzieher</label>
+          <div>
+            <input testid="singleParentInput" type="checkbox" [formField]="customerForm.singleParent">
+          </div>
+        </div>
+        <hr/>
+        <div class="mb-2">
           <label class="form-label">Gültig bis *</label>
           <input testid="validUntilInput" type="date" [formField]="customerForm.validUntil" class="form-control"
                  [ngClass]="fieldStateClasses(customerForm.validUntil())">
           @for (errorMessage of visibleErrorMessages(customerForm.validUntil()); track $index) {
             <div class="invalid-feedback">{{errorMessage}}</div>
           }
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Alleinerzieher</label>
-          <div>
-            <input testid="singleParentInput" type="checkbox" [formField]="customerForm.singleParent">
-          </div>
         </div>
       </mat-card-content>
     </mat-card>

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.ts
@@ -64,6 +64,7 @@ export class CustomerFormComponent {
     income: null,
     incomeDue: null,
     validUntil: null,
+    singleParent: false,
     additionalPersons: []
   });
 
@@ -181,6 +182,7 @@ export class CustomerFormComponent {
           income: customerData.income ?? null,
           incomeDue: customerData.incomeDue ?? null,
           validUntil: customerData.validUntil ?? null,
+          singleParent: customerData.singleParent ?? false,
           additionalPersons: additionalPersonsData
         });
       }
@@ -310,6 +312,7 @@ export interface CustomerFormModel {
   income: number | null;
   incomeDue: Date | null;
   validUntil: Date | null;
+  singleParent: boolean;
   additionalPersons: AdditionalPersonFormItem[];
 }
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
@@ -95,7 +95,7 @@
   <div class="mt-0 lg:mt-3 mb-0 lg:mb-3">
     <mat-tab-group animationDuration="0ms">
       <mat-tab label="Allgemeine Daten">
-        <div class="mt-4 px-4">
+        <div class="mt-4">
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-2">
             <div>
               <mat-card>
@@ -227,7 +227,7 @@
         <ng-template mat-tab-label>
           <fa-icon [icon]="faUsers"></fa-icon>&nbsp;Weitere Personen ({{ customerData()?.additionalPersons?.length }})
         </ng-template>
-        <div class="px-4">
+        <div class="mt-4">
           @if (customerData()?.additionalPersons?.length === 0) {
             <h6 testid="nopersons-label" class="mt-4">Keine Personen vorhanden</h6>
           }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
@@ -157,13 +157,14 @@
                   </div>
                   <hr>
                   <div class="flex justify-between">
+                    <span class="font-bold">Alleinerzieher</span>
+                    <span testid="singleParentText">{{ customerData()?.singleParent === true ? 'Ja' : 'Nein' }}</span>
+                  </div>
+                  <hr>
+                  <div class="flex justify-between">
                     <span class="font-bold">Angelegt</span>
                     <span
                       testid="issuedInformation">am {{ $safeNavigationMigration(customerData()?.issuedAt) | date : 'dd.MM.yyyy' }} {{ $safeNavigationMigration(customerData()?.issuer) | formatIssuer }}</span>
-                  </div>
-                  <div class="flex justify-between">
-                    <span class="font-bold">Alleinerzieher</span>
-                    <span testid="singleParentText">{{ customerData()?.singleParent === true ? 'Ja' : 'Nein' }}</span>
                   </div>
                   <div class="flex justify-between">
                     <span class="font-bold text-white px-2"
@@ -174,10 +175,10 @@
                           [ngClass]="{'bg-green-600': customerData()?.validUntil && isValid(), 'bg-red-600': customerData()?.validUntil && !isValid()}">{{ $safeNavigationMigration(customerData()?.validUntil) | date : 'dd.MM.yyyy' }}</span>
                   </div>
                   <div class="flex justify-between">
-                    <span class="font-bold px-2"
-                          [ngClass]="{'bg-red-600': (customerData()?.pendingCostContribution ?? 0) > 0, 'text-white': (customerData()?.pendingCostContribution ?? 0) > 0}">Unkostenbeitrag ausstehend:</span>
-                    <span testid="pendingCostContributionText" class="px-2"
-                          [ngClass]="{'bg-red-600': (customerData()?.pendingCostContribution ?? 0) > 0, 'text-white': (customerData()?.pendingCostContribution ?? 0) > 0}">
+                    <span class="font-bold"
+                          [ngClass]="{'bg-red-600 text-white px-2': (customerData()?.pendingCostContribution ?? 0) > 0}">Unkostenbeitrag ausstehend:</span>
+                    <span testid="pendingCostContributionText"
+                          [ngClass]="{'bg-red-600 text-white px-2': (customerData()?.pendingCostContribution ?? 0) > 0}">
                       {{ $safeNavigationMigration(customerData()?.pendingCostContribution) | currency }}
                     </span>
                   </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
@@ -162,6 +162,10 @@
                       testid="issuedInformation">am {{ $safeNavigationMigration(customerData()?.issuedAt) | date : 'dd.MM.yyyy' }} {{ $safeNavigationMigration(customerData()?.issuer) | formatIssuer }}</span>
                   </div>
                   <div class="flex justify-between">
+                    <span class="font-bold">Alleinerzieher</span>
+                    <span testid="singleParentText">{{ customerData()?.singleParent === true ? 'Ja' : 'Nein' }}</span>
+                  </div>
+                  <div class="flex justify-between">
                     <span class="font-bold text-white px-2"
                           [ngClass]="{'bg-green-600': customerData()?.validUntil && isValid(), 'bg-red-600': customerData()?.validUntil && !isValid()}">
                       Gültig bis:

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
@@ -71,6 +71,7 @@ describe('CustomerDetailComponent', () => {
     income: 1000,
     incomeDue: dayjs().add(1, 'years').startOf('day').toDate(),
     pendingCostContribution: 123,
+    singleParent: true,
 
     validUntil: dayjs().add(1, 'years').startOf('day').toDate(),
 
@@ -262,6 +263,7 @@ describe('CustomerDetailComponent', () => {
     expect(getTextByTestId(fixture, 'issuedInformation'))
       .toBe('am ' + dayjs(mockCustomer.issuedAt).format('DD.MM.YYYY') + ' von 12345 first last');
     expect(getTextByTestId(fixture, 'pendingCostContributionText').trim()).toBe('123,00 €');
+    expect(getTextByTestId(fixture, 'singleParentText')).toBe('Ja');
 
     expect(getTextByTestId(fixture, 'note-text')).toBe('note from author 2');
 

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.html
@@ -25,7 +25,7 @@
           <ng-template mat-tab-label>
             <span testid="select-route-tab">Route</span>
           </ng-template>
-          <div class="p-4">
+          <div class="pt-4">
             <tafel-food-collection-recording-basedata [carList]="carList()"
                                                       [selectedRouteData]="selectedRouteData()">
             </tafel-food-collection-recording-basedata>

--- a/frontend/src/main/webapp/src/app/modules/settings/components/mail-recipients/mail-recipients.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/components/mail-recipients/mail-recipients.component.html
@@ -18,7 +18,7 @@
                 {{ getMailTypeLabel(recipientOfMailType.value.mailType) }}
               </span>
             </ng-template>
-            <div class="p-4" [formGroupName]="i">
+            <div class="py-4" [formGroupName]="i">
               <div formArrayName="recipients" class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 @for (recipient of getRecipientsForMailTypeIndex(i).controls; track recipient; let j = $index; ) {
                   <div [formGroupName]="j">

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/general/statistics-general.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/general/statistics-general.component.html
@@ -96,6 +96,9 @@
           <tafel-statistics-panel
             [data]="statisticsData()!.beneficiaryCustomersWithChildren"></tafel-statistics-panel>
         </div>
+        <div class="mt-2 md:mt-0">
+          <tafel-statistics-panel [data]="statisticsData()!.singleParentHouseholds"></tafel-statistics-panel>
+        </div>
       </div>
       <div class="mt-4">
         <h5>Notschlafstellen</h5>


### PR DESCRIPTION
## Summary
- Add a nullable `singleParent` flag on households (DB column + entity + API model), household-level rather than per-person
- Backfill existing households with an age-based heuristic (exactly one adult member + at least one minor); no relationship-type data exists to derive it reliably, so it's a best-effort default staff can correct
- Mark two seeded testdata households as single-parent examples
- Surface it as a checkbox in the customer form (above "Gültig bis", with its own divider) and show it on the customer detail page
- Add a matching statistics metric (count of single-parent households among currently valid ones) to the "Statistik" dashboard and its CSV export
- Add a single-parent household count to the daily report: new `distributions_statistics.count_single_parent_households` column, computed at distribution-close time, shown in the daily report PDF and the "Tagesreports" CSV export

## Test plan
- [x] `./gradlew :backend:test` (full suite - migrations against real Postgres, HouseholdConverterTest, StatisticsServiceTest, DistributionStatisticServiceTest, DailyReportServiceTest, DailyReportsExporterTest, PDF rendering)
- [x] `ng test` (full frontend suite, 586 tests)

Closes #2778

🤖 Generated with [Claude Code](https://claude.com/claude-code)