### PR TITLE
fix: migrate remaining CoreUI-style forms to Angular Material

### DIFF
--- a/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
@@ -167,8 +167,10 @@ describe('Customer Creation', () => {
     cy.byTestId('lastnameInput').type('Mustermann');
     cy.byTestId('firstnameInput').type('Max');
     cy.byTestId('birthDateInput').type(dayjs(getBirthDateForAge(25)).format('YYYY-MM-DD'));
-    cy.byTestId('genderInput').select('Männlich');
-    cy.byTestId('countryInput').select('Österreich');
+    cy.byTestId('genderInput').click();
+    cy.byTestId('genderInput-option-MALE').click();
+    cy.byTestId('countryInput').click();
+    cy.byTestId('countryInput-option-165').click();
     cy.byTestId('telephoneNumberInput').type('0664123132123');
     cy.byTestId('emailInput').type('test@gmail.com');
     cy.byTestId('streetInput').type('Teststreet');
@@ -188,8 +190,14 @@ describe('Customer Creation', () => {
       cy.byTestId('lastnameInput').type(data.lastname);
       cy.byTestId('firstnameInput').type(data.firstname);
       cy.byTestId('birthDateInput').type(dayjs(data.birthDate).format('YYYY-MM-DD'));
-      cy.byTestId('genderInput').select(data.gender);
-      cy.byTestId('countryInput').select(data.country!.name);
+      cy.byTestId('genderInput').click();
+    });
+    cy.byTestId('genderInput-option-' + data.gender).click();
+    cy.byTestId('personform-' + index).within(() => {
+      cy.byTestId('countryInput').click();
+    });
+    cy.byTestId('countryInput-option-' + data.country!.id).click();
+    cy.byTestId('personform-' + index).within(() => {
       if (data.employer) {
         cy.byTestId('employerInput').type(data.employer);
       }
@@ -197,7 +205,7 @@ describe('Customer Creation', () => {
         cy.byTestId('incomeInput').type(data.income.toString());
       }
       if (data.excludeFromHousehold) {
-        cy.byTestId('excludeFromHouseholdInput').check();
+        cy.byTestId('excludeFromHouseholdInput').click();
       }
     });
   }

--- a/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
@@ -36,7 +36,8 @@ describe('Customer Edit', () => {
       typeInto('houseNumberInput', updatedHouseNumber);
       typeInto('cityInput', updatedCity);
       typeInto('postalCodeInput', updatedPostalCode);
-      cy.byTestId('genderInput').select('Weiblich');
+      cy.byTestId('genderInput').click();
+      cy.byTestId('genderInput-option-FEMALE').click();
 
       cy.byTestId('validate-button').click();
 

--- a/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
@@ -98,7 +98,8 @@ describe('Food Collection Recording', () => {
 
   function enterRouteData() {
     cy.byTestId('routeInput').select('Route 2');
-    cy.byTestId('carInput').select('W-NC-123 (Nice Car 123)');
+    cy.byTestId('carInput').click();
+    cy.get('mat-option').contains('W-NC-123 (Nice Car 123)').click();
     cy.byTestId('kmStartInput').type('1000');
     cy.byTestId('kmEndInput').type('2000');
   }

--- a/frontend/src/main/webapp/src/app/common/views/login/login.component.html
+++ b/frontend/src/main/webapp/src/app/common/views/login/login.component.html
@@ -14,13 +14,19 @@
         <div class="flex flex-col gap-2 m-6">
           <div class="flex flex-row items-center">
             <fa-icon [icon]="faUser" class="mr-2"></fa-icon>
-            <input [formField]="loginForm.username" matInput testid="username" type="text" class="form-control"
-                   placeholder="Benutzername" autocomplete="username" tafelAutofocus>
+            <mat-form-field>
+              <mat-label>Benutzername</mat-label>
+              <input [formField]="loginForm.username" matInput testid="username" type="text"
+                     autocomplete="username" tafelAutofocus>
+            </mat-form-field>
           </div>
           <div class="flex flex-row items-center">
             <fa-icon [icon]="faKey" class="mr-2"></fa-icon>
-            <input [formField]="loginForm.password" matInput testid="password" type="password"
-                   class="form-control" placeholder="Passwort" autocomplete="current-password">
+            <mat-form-field>
+              <mat-label>Passwort</mat-label>
+              <input [formField]="loginForm.password" matInput testid="password" type="password"
+                     autocomplete="current-password">
+            </mat-form-field>
           </div>
         </div>
 

--- a/frontend/src/main/webapp/src/app/common/views/login/login.component.ts
+++ b/frontend/src/main/webapp/src/app/common/views/login/login.component.ts
@@ -7,6 +7,7 @@ import {TafelAutofocusDirective} from '../../directive/tafel-autofocus.directive
 import {MatCard, MatCardContent} from '@angular/material/card';
 import {MatButton} from '@angular/material/button';
 import {MatInput} from '@angular/material/input';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faKey, faUser} from '@fortawesome/free-solid-svg-icons';
 
@@ -20,6 +21,8 @@ import {faKey, faUser} from '@fortawesome/free-solid-svg-icons';
     MatCardContent,
     MatButton,
     MatInput,
+    MatFormField,
+    MatLabel,
     FaIconComponent
   ]
 })

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -7,14 +7,14 @@
       <mat-card-content>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
           <mat-form-field>
-            <mat-label>Nachname *</mat-label>
+            <mat-label>Nachname</mat-label>
             <input matInput testid="lastnameInput" type="text" [formField]="customerForm.lastname" tafelAutofocus>
             @for (errorMessage of visibleErrorMessages(customerForm.lastname()); track $index) {
               <mat-error>{{errorMessage}}</mat-error>
             }
           </mat-form-field>
           <mat-form-field>
-            <mat-label>Vorname *</mat-label>
+            <mat-label>Vorname</mat-label>
             <input matInput testid="firstnameInput" type="text" [formField]="customerForm.firstname">
             @for (errorMessage of visibleErrorMessages(customerForm.firstname()); track $index) {
               <mat-error>{{errorMessage}}</mat-error>
@@ -23,7 +23,7 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
           <mat-form-field>
-            <mat-label>Geburtsdatum *</mat-label>
+            <mat-label>Geburtsdatum</mat-label>
             <input matInput testid="birthDateInput" type="date" [formField]="customerForm.birthDate">
             @for (errorMessage of visibleErrorMessages(customerForm.birthDate()); track $index) {
               <mat-error>{{errorMessage}}</mat-error>
@@ -31,7 +31,7 @@
           </mat-form-field>
           <div class="flex items-center gap-2">
             <mat-form-field class="w-full">
-              <mat-label>Geschlecht *</mat-label>
+              <mat-label>Geschlecht</mat-label>
               <mat-select testid="genderInput" [formField]="customerForm.gender">
                 @for (genderOption of genders; track genderOption) {
                   <mat-option [value]="genderOption" [attr.testid]="'genderInput-option-' + genderOption">
@@ -47,7 +47,7 @@
         </div>
         <div class="mb-2 flex items-center gap-2">
           <mat-form-field class="w-full">
-            <mat-label>Nationalität *</mat-label>
+            <mat-label>Nationalität</mat-label>
             <mat-select testid="countryInput" [formField]="customerForm.country" [compareWith]="compareCountry">
               @for (countryItem of countries(); track countryItem.id) {
                 <mat-option [value]="countryItem" [attr.testid]="'countryInput-option-' + countryItem.id">
@@ -63,7 +63,7 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
           <div class="flex items-center gap-2">
             <mat-form-field class="w-full">
-              <mat-label>Telefonnummer *</mat-label>
+              <mat-label>Telefonnummer</mat-label>
               <input matInput testid="telephoneNumberInput" type="text" [formField]="customerForm.telephoneNumber">
               @for (errorMessage of visibleErrorMessages(customerForm.telephoneNumber()); track $index) {
                 <mat-error>{{errorMessage}}</mat-error>
@@ -85,7 +85,7 @@
         <hr>
         <div>
           <mat-form-field class="w-full mb-2">
-            <mat-label>Straße *</mat-label>
+            <mat-label>Straße</mat-label>
             <input matInput testid="streetInput" type="text" [formField]="customerForm.address.street">
             @for (errorMessage of visibleErrorMessages(customerForm.address.street()); track $index) {
               <mat-error>{{errorMessage}}</mat-error>
@@ -93,7 +93,7 @@
           </mat-form-field>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-2">
             <mat-form-field>
-              <mat-label>Hausnummer *</mat-label>
+              <mat-label>Hausnummer</mat-label>
               <input matInput testid="houseNumberInput" type="text" [formField]="customerForm.address.houseNumber">
               @for (errorMessage of visibleErrorMessages(customerForm.address.houseNumber()); track $index) {
                 <mat-error>{{errorMessage}}</mat-error>
@@ -111,7 +111,7 @@
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
             <div class="flex items-center gap-2">
               <mat-form-field class="w-full">
-                <mat-label>PLZ *</mat-label>
+                <mat-label>PLZ</mat-label>
                 <input matInput testid="postalCodeInput" type="number" [formField]="customerForm.address.postalCode">
                 @for (errorMessage of visibleErrorMessages(customerForm.address.postalCode()); track $index) {
                   <mat-error>{{errorMessage}}</mat-error>
@@ -121,7 +121,7 @@
             </div>
             <div class="flex items-center gap-2">
               <mat-form-field class="w-full">
-                <mat-label>Ort *</mat-label>
+                <mat-label>Ort</mat-label>
                 <input matInput testid="cityInput" type="text" [formField]="customerForm.address.city">
                 @for (errorMessage of visibleErrorMessages(customerForm.address.city()); track $index) {
                   <mat-error>{{errorMessage}}</mat-error>
@@ -134,7 +134,7 @@
         <hr>
         <div class="mb-2 flex items-center gap-2">
           <mat-form-field class="w-full">
-            <mat-label>Arbeitgeber *</mat-label>
+            <mat-label>Arbeitgeber</mat-label>
             <input matInput testid="employerInput" type="text" [formField]="customerForm.employer">
             @for (errorMessage of visibleErrorMessages(customerForm.employer()); track $index) {
               <mat-error>{{errorMessage}}</mat-error>
@@ -167,7 +167,7 @@
         </div>
         <hr/>
         <mat-form-field class="w-full mb-2">
-          <mat-label>Gültig bis *</mat-label>
+          <mat-label>Gültig bis</mat-label>
           <input matInput testid="validUntilInput" type="date" [formField]="customerForm.validUntil">
           @for (errorMessage of visibleErrorMessages(customerForm.validUntil()); track $index) {
             <mat-error>{{errorMessage}}</mat-error>
@@ -195,7 +195,7 @@
                 <mat-card-content [attr.testid]="'personform-' + i">
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                     <mat-form-field>
-                      <mat-label>Nachname *</mat-label>
+                      <mat-label>Nachname</mat-label>
                       <input matInput testid="lastnameInput" type="text" [formField]="personField(i).lastname"
                              tafelAutofocus>
                       @for (errorMessage of visibleErrorMessages(personField(i).lastname()); track $index) {
@@ -203,7 +203,7 @@
                       }
                     </mat-form-field>
                     <mat-form-field>
-                      <mat-label>Vorname *</mat-label>
+                      <mat-label>Vorname</mat-label>
                       <input matInput testid="firstnameInput" type="text" [formField]="personField(i).firstname">
                       @for (errorMessage of visibleErrorMessages(personField(i).firstname()); track $index) {
                         <mat-error>{{errorMessage}}</mat-error>
@@ -212,7 +212,7 @@
                   </div>
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-2">
                     <mat-form-field>
-                      <mat-label>Geburtsdatum *</mat-label>
+                      <mat-label>Geburtsdatum</mat-label>
                       <input matInput testid="birthDateInput" type="date" [formField]="personField(i).birthDate">
                       @for (errorMessage of visibleErrorMessages(personField(i).birthDate()); track $index) {
                         <mat-error>{{errorMessage}}</mat-error>
@@ -220,7 +220,7 @@
                     </mat-form-field>
                     <div class="flex items-center gap-2">
                       <mat-form-field class="w-full">
-                        <mat-label>Geschlecht *</mat-label>
+                        <mat-label>Geschlecht</mat-label>
                         <mat-select testid="genderInput" [formField]="personField(i).gender">
                           @for (genderOption of genders; track genderOption) {
                             <mat-option [value]="genderOption" [attr.testid]="'genderInput-option-' + genderOption">
@@ -236,7 +236,7 @@
                   </div>
                   <div class="mt-2 flex items-center gap-2">
                     <mat-form-field class="w-full">
-                      <mat-label>Nationalität *</mat-label>
+                      <mat-label>Nationalität</mat-label>
                       <mat-select testid="countryInput" [formField]="personField(i).country"
                                   [compareWith]="compareCountry">
                         @for (countryItem of countries(); track countryItem.id) {

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -6,200 +6,173 @@
       </mat-card-header>
       <mat-card-content>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
-          <div>
-            <label class="form-label">Nachname *</label>
-            <input testid="lastnameInput" type="text" [formField]="customerForm.lastname" class="form-control" tafelAutofocus
-                   [ngClass]="fieldStateClasses(customerForm.lastname())">
+          <mat-form-field>
+            <mat-label>Nachname *</mat-label>
+            <input matInput testid="lastnameInput" type="text" [formField]="customerForm.lastname" tafelAutofocus>
             @for (errorMessage of visibleErrorMessages(customerForm.lastname()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
+              <mat-error>{{errorMessage}}</mat-error>
             }
-          </div>
-          <div>
-            <label class="form-label">Vorname *</label>
-            <input testid="firstnameInput" type="text" [formField]="customerForm.firstname" class="form-control"
-                   [ngClass]="fieldStateClasses(customerForm.firstname())">
+          </mat-form-field>
+          <mat-form-field>
+            <mat-label>Vorname *</mat-label>
+            <input matInput testid="firstnameInput" type="text" [formField]="customerForm.firstname">
             @for (errorMessage of visibleErrorMessages(customerForm.firstname()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
+              <mat-error>{{errorMessage}}</mat-error>
             }
-          </div>
+          </mat-form-field>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
-          <div>
-            <label class="form-label">Geburtsdatum *</label>
-            <input testid="birthDateInput" type="date" [formField]="customerForm.birthDate" class="form-control"
-                   [ngClass]="fieldStateClasses(customerForm.birthDate())">
+          <mat-form-field>
+            <mat-label>Geburtsdatum *</mat-label>
+            <input matInput testid="birthDateInput" type="date" [formField]="customerForm.birthDate">
             @for (errorMessage of visibleErrorMessages(customerForm.birthDate()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
+              <mat-error>{{errorMessage}}</mat-error>
             }
-          </div>
-          <div>
-            <label class="form-label">Geschlecht *</label>
-            <div class="flex items-center gap-2">
-              <select testid="genderInput" (change)="onGenderChange($event)" class="form-control"
-                      [ngClass]="fieldStateClasses(customerForm.gender())">
-                <option value="" [selected]="!customerForm.gender().value()">Bitte wählen...</option>
+          </mat-form-field>
+          <div class="flex items-center gap-2">
+            <mat-form-field class="w-full">
+              <mat-label>Geschlecht *</mat-label>
+              <mat-select testid="genderInput" [formField]="customerForm.gender">
                 @for (genderOption of genders; track genderOption) {
-                  <option [value]="genderOption" [selected]="genderOption === customerForm.gender().value()">
-                    {{genderOption | genderLabel}}</option>
+                  <mat-option [value]="genderOption" [attr.testid]="'genderInput-option-' + genderOption">
+                    {{genderOption | genderLabel}}</mat-option>
                 }
-              </select>
-              <fa-icon [icon]="faVenusMars"></fa-icon>
-            </div>
-            @for (errorMessage of visibleErrorMessages(customerForm.gender()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
-            }
+              </mat-select>
+              @for (errorMessage of visibleErrorMessages(customerForm.gender()); track $index) {
+                <mat-error>{{errorMessage}}</mat-error>
+              }
+            </mat-form-field>
+            <fa-icon [icon]="faVenusMars"></fa-icon>
           </div>
         </div>
-        <div class="mb-2">
-          <label class="form-label">Nationalität *</label>
-          <div class="flex items-center gap-2">
-            <select testid="countryInput" (change)="onCountryChange($event)" class="form-control"
-                    [ngClass]="fieldStateClasses(customerForm.country())">
-              <option value="" [selected]="!customerForm.country().value()">Bitte wählen...</option>
+        <div class="mb-2 flex items-center gap-2">
+          <mat-form-field class="w-full">
+            <mat-label>Nationalität *</mat-label>
+            <mat-select testid="countryInput" [formField]="customerForm.country" [compareWith]="compareCountry">
               @for (countryItem of countries(); track countryItem.id) {
-                <option [value]="countryItem.id" [selected]="countryItem.id === customerForm.country().value()?.id">
-                  {{countryItem.name}}</option>
+                <mat-option [value]="countryItem" [attr.testid]="'countryInput-option-' + countryItem.id">
+                  {{countryItem.name}}</mat-option>
               }
-            </select>
-            <fa-icon [icon]="faFlag"></fa-icon>
-          </div>
-          @for (errorMessage of visibleErrorMessages(customerForm.country()); track $index) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
-          }
+            </mat-select>
+            @for (errorMessage of visibleErrorMessages(customerForm.country()); track $index) {
+              <mat-error>{{errorMessage}}</mat-error>
+            }
+          </mat-form-field>
+          <fa-icon [icon]="faFlag"></fa-icon>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
-          <div>
-            <label class="form-label">Telefonnummer *</label>
-            <div class="flex items-center gap-2">
-              <input testid="telephoneNumberInput" type="text" [formField]="customerForm.telephoneNumber"
-                     class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.telephoneNumber())">
-              <fa-icon [icon]="faPhone"></fa-icon>
-            </div>
-            @for (errorMessage of visibleErrorMessages(customerForm.telephoneNumber()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
-            }
+          <div class="flex items-center gap-2">
+            <mat-form-field class="w-full">
+              <mat-label>Telefonnummer *</mat-label>
+              <input matInput testid="telephoneNumberInput" type="text" [formField]="customerForm.telephoneNumber">
+              @for (errorMessage of visibleErrorMessages(customerForm.telephoneNumber()); track $index) {
+                <mat-error>{{errorMessage}}</mat-error>
+              }
+            </mat-form-field>
+            <fa-icon [icon]="faPhone"></fa-icon>
           </div>
-          <div>
-            <label class="form-label">E-Mail</label>
-            <div class="flex items-center gap-2">
-              <input testid="emailInput" type="text" [formField]="customerForm.email" class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.email())">
-              <fa-icon [icon]="faEnvelope"></fa-icon>
-            </div>
-            @for (errorMessage of visibleErrorMessages(customerForm.email()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
-            }
+          <div class="flex items-center gap-2">
+            <mat-form-field class="w-full">
+              <mat-label>E-Mail</mat-label>
+              <input matInput testid="emailInput" type="text" [formField]="customerForm.email">
+              @for (errorMessage of visibleErrorMessages(customerForm.email()); track $index) {
+                <mat-error>{{errorMessage}}</mat-error>
+              }
+            </mat-form-field>
+            <fa-icon [icon]="faEnvelope"></fa-icon>
           </div>
         </div>
         <hr>
         <div>
-          <div class="mb-2">
-            <label class="form-label">Straße *</label>
-            <input testid="streetInput" type="text" [formField]="customerForm.address.street" class="form-control"
-                   [ngClass]="fieldStateClasses(customerForm.address.street())">
+          <mat-form-field class="w-full mb-2">
+            <mat-label>Straße *</mat-label>
+            <input matInput testid="streetInput" type="text" [formField]="customerForm.address.street">
             @for (errorMessage of visibleErrorMessages(customerForm.address.street()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
+              <mat-error>{{errorMessage}}</mat-error>
             }
-          </div>
+          </mat-form-field>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-2">
-            <div>
-              <label class="form-label">Hausnummer *</label>
-              <input testid="houseNumberInput" type="text" [formField]="customerForm.address.houseNumber"
-                     class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.address.houseNumber())">
+            <mat-form-field>
+              <mat-label>Hausnummer *</mat-label>
+              <input matInput testid="houseNumberInput" type="text" [formField]="customerForm.address.houseNumber">
               @for (errorMessage of visibleErrorMessages(customerForm.address.houseNumber()); track $index) {
-                <div class="invalid-feedback">{{errorMessage}}</div>
+                <mat-error>{{errorMessage}}</mat-error>
               }
-            </div>
-            <div>
-              <label class="form-label">Stiege</label>
-              <input testid="stairwayInput" type="number" [formField]="customerForm.address.stairway"
-                     class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.address.stairway())">
-            </div>
-            <div>
-              <label class="form-label">Top</label>
-              <input testid="doorInput" type="number" [formField]="customerForm.address.door" class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.address.door())">
-            </div>
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Stiege</mat-label>
+              <input matInput testid="stairwayInput" type="number" [formField]="customerForm.address.stairway">
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Top</mat-label>
+              <input matInput testid="doorInput" type="number" [formField]="customerForm.address.door">
+            </mat-form-field>
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
-            <div>
-              <label class="form-label">PLZ *</label>
-              <div class="flex items-center gap-2">
-                <input testid="postalCodeInput" type="number" [formField]="customerForm.address.postalCode"
-                       class="form-control"
-                       [ngClass]="fieldStateClasses(customerForm.address.postalCode())">
-                <fa-icon [icon]="faLocationDot"></fa-icon>
-              </div>
-              @for (errorMessage of visibleErrorMessages(customerForm.address.postalCode()); track $index) {
-                <div class="invalid-feedback">{{errorMessage}}</div>
-              }
+            <div class="flex items-center gap-2">
+              <mat-form-field class="w-full">
+                <mat-label>PLZ *</mat-label>
+                <input matInput testid="postalCodeInput" type="number" [formField]="customerForm.address.postalCode">
+                @for (errorMessage of visibleErrorMessages(customerForm.address.postalCode()); track $index) {
+                  <mat-error>{{errorMessage}}</mat-error>
+                }
+              </mat-form-field>
+              <fa-icon [icon]="faLocationDot"></fa-icon>
             </div>
-            <div>
-              <label class="form-label">Ort *</label>
-              <div class="flex items-center gap-2">
-                <input testid="cityInput" type="text" [formField]="customerForm.address.city" class="form-control"
-                       [ngClass]="fieldStateClasses(customerForm.address.city())">
-                <fa-icon [icon]="faLocationDot"></fa-icon>
-              </div>
-              @for (errorMessage of visibleErrorMessages(customerForm.address.city()); track $index) {
-                <div class="invalid-feedback">{{errorMessage}}</div>
-              }
+            <div class="flex items-center gap-2">
+              <mat-form-field class="w-full">
+                <mat-label>Ort *</mat-label>
+                <input matInput testid="cityInput" type="text" [formField]="customerForm.address.city">
+                @for (errorMessage of visibleErrorMessages(customerForm.address.city()); track $index) {
+                  <mat-error>{{errorMessage}}</mat-error>
+                }
+              </mat-form-field>
+              <fa-icon [icon]="faLocationDot"></fa-icon>
             </div>
           </div>
         </div>
         <hr>
-        <div class="mb-2">
-          <label class="form-label">Arbeitgeber *</label>
-          <div class="flex items-center gap-2">
-            <input testid="employerInput" type="text" [formField]="customerForm.employer"
-                   class="form-control"
-                   [ngClass]="fieldStateClasses(customerForm.employer())">
-            <fa-icon [icon]="faBuilding"></fa-icon>
-          </div>
-          @for (errorMessage of visibleErrorMessages(customerForm.employer()); track $index) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
-          }
+        <div class="mb-2 flex items-center gap-2">
+          <mat-form-field class="w-full">
+            <mat-label>Arbeitgeber *</mat-label>
+            <input matInput testid="employerInput" type="text" [formField]="customerForm.employer">
+            @for (errorMessage of visibleErrorMessages(customerForm.employer()); track $index) {
+              <mat-error>{{errorMessage}}</mat-error>
+            }
+          </mat-form-field>
+          <fa-icon [icon]="faBuilding"></fa-icon>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-2">
-          <div>
-            <label class="form-label">Einkommen (monatl.)</label>
-            <div class="flex items-center gap-2">
-              <input testid="incomeInput" type="number" [formField]="customerForm.income" class="form-control"
-                     [ngClass]="fieldStateClasses(customerForm.income())">
-              <fa-icon [icon]="faEuroSign"></fa-icon>
-            </div>
-            @for (errorMessage of visibleErrorMessages(customerForm.income()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
-            }
+          <div class="flex items-center gap-2">
+            <mat-form-field class="w-full">
+              <mat-label>Einkommen (monatl.)</mat-label>
+              <input matInput testid="incomeInput" type="number" [formField]="customerForm.income">
+              @for (errorMessage of visibleErrorMessages(customerForm.income()); track $index) {
+                <mat-error>{{errorMessage}}</mat-error>
+              }
+            </mat-form-field>
+            <fa-icon [icon]="faEuroSign"></fa-icon>
           </div>
-          <div>
-            <label class="form-label">nachgewiesen bis</label>
-            <input testid="incomeDueInput" type="date" [formField]="customerForm.incomeDue" class="form-control"
-                   [ngClass]="fieldStateClasses(customerForm.incomeDue())">
+          <mat-form-field>
+            <mat-label>nachgewiesen bis</mat-label>
+            <input matInput testid="incomeDueInput" type="date" [formField]="customerForm.incomeDue">
             @for (errorMessage of visibleErrorMessages(customerForm.incomeDue()); track $index) {
-              <div class="invalid-feedback">{{errorMessage}}</div>
+              <mat-error>{{errorMessage}}</mat-error>
             }
-          </div>
+          </mat-form-field>
         </div>
         <hr/>
         <div class="mb-2">
-          <label class="form-label">Alleinerzieher</label>
-          <div>
-            <input testid="singleParentInput" type="checkbox" [formField]="customerForm.singleParent">
-          </div>
+          <mat-checkbox [formField]="customerForm.singleParent" testid="singleParentInput">Alleinerzieher</mat-checkbox>
         </div>
         <hr/>
-        <div class="mb-2">
-          <label class="form-label">Gültig bis *</label>
-          <input testid="validUntilInput" type="date" [formField]="customerForm.validUntil" class="form-control"
-                 [ngClass]="fieldStateClasses(customerForm.validUntil())">
+        <mat-form-field class="w-full mb-2">
+          <mat-label>Gültig bis *</mat-label>
+          <input matInput testid="validUntilInput" type="date" [formField]="customerForm.validUntil">
           @for (errorMessage of visibleErrorMessages(customerForm.validUntil()); track $index) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
+        </mat-form-field>
       </mat-card-content>
     </mat-card>
     <div class="mt-4 md:mt-0">
@@ -221,126 +194,100 @@
               <mat-card>
                 <mat-card-content [attr.testid]="'personform-' + i">
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                      <label class="form-label">Nachname *</label>
-                      <input testid="lastnameInput" type="text" [formField]="personField(i).lastname"
-                             class="form-control" tafelAutofocus
-                             [ngClass]="fieldStateClasses(personField(i).lastname())">
+                    <mat-form-field>
+                      <mat-label>Nachname *</mat-label>
+                      <input matInput testid="lastnameInput" type="text" [formField]="personField(i).lastname"
+                             tafelAutofocus>
                       @for (errorMessage of visibleErrorMessages(personField(i).lastname()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
+                        <mat-error>{{errorMessage}}</mat-error>
                       }
-                    </div>
-                    <div>
-                      <label class="form-label">Vorname *</label>
-                      <input testid="firstnameInput" type="text" [formField]="personField(i).firstname"
-                             class="form-control"
-                             [ngClass]="fieldStateClasses(personField(i).firstname())">
+                    </mat-form-field>
+                    <mat-form-field>
+                      <mat-label>Vorname *</mat-label>
+                      <input matInput testid="firstnameInput" type="text" [formField]="personField(i).firstname">
                       @for (errorMessage of visibleErrorMessages(personField(i).firstname()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
+                        <mat-error>{{errorMessage}}</mat-error>
                       }
-                    </div>
+                    </mat-form-field>
                   </div>
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-2">
-                    <div>
-                      <label class="form-label">Geburtsdatum *</label>
-                      <input testid="birthDateInput" type="date" [formField]="personField(i).birthDate"
-                             class="form-control"
-                             [ngClass]="fieldStateClasses(personField(i).birthDate())">
+                    <mat-form-field>
+                      <mat-label>Geburtsdatum *</mat-label>
+                      <input matInput testid="birthDateInput" type="date" [formField]="personField(i).birthDate">
                       @for (errorMessage of visibleErrorMessages(personField(i).birthDate()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
+                        <mat-error>{{errorMessage}}</mat-error>
                       }
-                    </div>
-                    <div>
-                      <label class="form-label">Geschlecht *</label>
-                      <div class="flex items-center gap-2">
-                        <select testid="genderInput"
-                                (change)="onPersonGenderChange(i, $event)"
-                                (blur)="onPersonGenderBlur(i)"
-                                class="form-control"
-                                [ngClass]="fieldStateClasses(personField(i).gender())">
-                          <option value="" [selected]="!personField(i).gender().value()">Bitte wählen...</option>
-                          @for (genderOption of genders; track genderOption) {
-                            <option [value]="genderOption" [selected]="genderOption === personField(i).gender().value()">
-                              {{genderOption | genderLabel}}</option>
-                          }
-                        </select>
-                        <fa-icon [icon]="faVenusMars"></fa-icon>
-                      </div>
-                      @for (errorMessage of visibleErrorMessages(personField(i).gender()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
-                      }
-                    </div>
-                  </div>
-                  <div class="mt-2">
-                    <label class="form-label">Nationalität *</label>
+                    </mat-form-field>
                     <div class="flex items-center gap-2">
-                      <select testid="countryInput"
-                              (change)="onPersonCountryChange(i, $event)"
-                              (blur)="onPersonCountryBlur(i)"
-                              class="form-control"
-                              [ngClass]="fieldStateClasses(personField(i).country())">
-                        <option value="" [selected]="!personField(i).country().value()">Bitte wählen...</option>
-                        @for (countryItem of countries(); track countryItem.id) {
-                          <option [value]="countryItem.id" [selected]="countryItem.id === personField(i).country().value()?.id">
-                            {{countryItem.name}}</option>
+                      <mat-form-field class="w-full">
+                        <mat-label>Geschlecht *</mat-label>
+                        <mat-select testid="genderInput" [formField]="personField(i).gender">
+                          @for (genderOption of genders; track genderOption) {
+                            <mat-option [value]="genderOption" [attr.testid]="'genderInput-option-' + genderOption">
+                              {{genderOption | genderLabel}}</mat-option>
+                          }
+                        </mat-select>
+                        @for (errorMessage of visibleErrorMessages(personField(i).gender()); track $index) {
+                          <mat-error>{{errorMessage}}</mat-error>
                         }
-                      </select>
-                      <fa-icon [icon]="faFlag"></fa-icon>
+                      </mat-form-field>
+                      <fa-icon [icon]="faVenusMars"></fa-icon>
                     </div>
-                    @for (errorMessage of visibleErrorMessages(personField(i).country()); track $index) {
-                      <div class="invalid-feedback">{{errorMessage}}</div>
-                    }
+                  </div>
+                  <div class="mt-2 flex items-center gap-2">
+                    <mat-form-field class="w-full">
+                      <mat-label>Nationalität *</mat-label>
+                      <mat-select testid="countryInput" [formField]="personField(i).country"
+                                  [compareWith]="compareCountry">
+                        @for (countryItem of countries(); track countryItem.id) {
+                          <mat-option [value]="countryItem" [attr.testid]="'countryInput-option-' + countryItem.id">
+                            {{countryItem.name}}</mat-option>
+                        }
+                      </mat-select>
+                      @for (errorMessage of visibleErrorMessages(personField(i).country()); track $index) {
+                        <mat-error>{{errorMessage}}</mat-error>
+                      }
+                    </mat-form-field>
+                    <fa-icon [icon]="faFlag"></fa-icon>
                   </div>
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-2">
-                    <div>
-                      <label class="form-label">Arbeitgeber</label>
-                      <div class="flex items-center gap-2">
-                        <input testid="employerInput" type="text" [formField]="personField(i).employer"
-                               class="form-control"
-                               [ngClass]="fieldStateClasses(personField(i).employer())">
-                        <fa-icon [icon]="faBuilding"></fa-icon>
-                      </div>
-                      @for (errorMessage of visibleErrorMessages(personField(i).employer()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
-                      }
+                    <div class="flex items-center gap-2">
+                      <mat-form-field class="w-full">
+                        <mat-label>Arbeitgeber</mat-label>
+                        <input matInput testid="employerInput" type="text" [formField]="personField(i).employer">
+                        @for (errorMessage of visibleErrorMessages(personField(i).employer()); track $index) {
+                          <mat-error>{{errorMessage}}</mat-error>
+                        }
+                      </mat-form-field>
+                      <fa-icon [icon]="faBuilding"></fa-icon>
                     </div>
-                    <div>
-                      <label class="form-label">Einkommen (monatl.)</label>
-                      <div class="flex items-center gap-2">
-                        <input testid="incomeInput" type="number" [formField]="personField(i).income"
-                               class="form-control"
-                               [ngClass]="fieldStateClasses(personField(i).income())">
-                        <fa-icon [icon]="faEuroSign"></fa-icon>
-                      </div>
-                      @for (errorMessage of visibleErrorMessages(personField(i).income()); track $index) {
-                        <div class="invalid-feedback">{{errorMessage}}</div>
-                      }
+                    <div class="flex items-center gap-2">
+                      <mat-form-field class="w-full">
+                        <mat-label>Einkommen (monatl.)</mat-label>
+                        <input matInput testid="incomeInput" type="number" [formField]="personField(i).income">
+                        @for (errorMessage of visibleErrorMessages(personField(i).income()); track $index) {
+                          <mat-error>{{errorMessage}}</mat-error>
+                        }
+                      </mat-form-field>
+                      <fa-icon [icon]="faEuroSign"></fa-icon>
                     </div>
                   </div>
-                  <div class="mt-2">
-                    <label class="form-label">nachgewiesen bis</label>
-                    <input testid="incomeDueInput" type="date" [formField]="personField(i).incomeDue"
-                           class="form-control"
-                           [ngClass]="fieldStateClasses(personField(i).incomeDue())">
+                  <mat-form-field class="w-full mt-2">
+                    <mat-label>nachgewiesen bis</mat-label>
+                    <input matInput testid="incomeDueInput" type="date" [formField]="personField(i).incomeDue">
                     @for (errorMessage of visibleErrorMessages(personField(i).incomeDue()); track $index) {
-                      <div class="invalid-feedback">{{errorMessage}}</div>
+                      <mat-error>{{errorMessage}}</mat-error>
                     }
-                  </div>
+                  </mat-form-field>
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-2">
-                    <div>
-                      <label class="form-label">Bezieht Familienbeihilfe</label>
-                      <div>
-                        <input testid="receivesFamilyAllowanceInput" type="checkbox"
-                               [formField]="personField(i).receivesFamilyAllowance">
-                      </div>
-                    </div>
-                    <div>
-                      <label class="form-label">Nicht im selben Haushalt (keine Berechnung)</label>
-                      <div>
-                        <input testid="excludeFromHouseholdInput" type="checkbox"
-                               [formField]="personField(i).excludeFromHousehold">
-                      </div>
-                    </div>
+                    <mat-checkbox [formField]="personField(i).receivesFamilyAllowance"
+                                  testid="receivesFamilyAllowanceInput">
+                      Bezieht Familienbeihilfe
+                    </mat-checkbox>
+                    <mat-checkbox [formField]="personField(i).excludeFromHousehold"
+                                  testid="excludeFromHouseholdInput">
+                      Nicht im selben Haushalt (keine Berechnung)
+                    </mat-checkbox>
                   </div>
                   <div class="mt-4">
                     <button type="button" [attr.testid]="'remove-personform-' + i" matButton="filled"

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.ts
@@ -5,6 +5,10 @@ import {CustomerData, Gender} from '../../../../api/customer-api.service';
 import {CommonModule} from '@angular/common';
 import {MatCardModule} from '@angular/material/card';
 import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {
   faBuilding,
   faEnvelope,
@@ -17,7 +21,7 @@ import {
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofocus.directive';
 import {GenderLabelPipe} from '../../../../common/pipes/gender-label.pipe';
-import {fieldStateClasses, visibleErrorMessages} from '../../../../common/util/signal-form-helper';
+import {visibleErrorMessages} from '../../../../common/util/signal-form-helper';
 import {email, maxDate, min, minDate, pattern} from '../../../../common/validator/signal-form-validators';
 import {toSignal} from '@angular/core/rxjs-interop';
 import dayjs from 'dayjs';
@@ -30,6 +34,10 @@ import dayjs from 'dayjs';
     MatCardModule,
     CommonModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatCheckboxModule,
     FaIconComponent,
     TafelAutofocusDirective,
     GenderLabelPipe
@@ -206,44 +214,8 @@ export class CustomerFormComponent {
     });
   }
 
-  onCountryChange(event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const selectedId = select.value;
-    const country = this.countries().find(c => c.id.toString() === selectedId);
-    this.customerForm.country().value.set(country ?? null);
-    this.customerForm.country().markAsTouched();
-  }
-
-  onGenderChange(event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const selectedGender = select.value as Gender;
-    this.customerForm.gender().value.set(selectedGender || null);
-    this.customerForm.gender().markAsTouched();
-  }
-
-  onPersonCountryChange(index: number, event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const selectedId = select.value;
-    const country = this.countries().find(c => c.id.toString() === selectedId);
-
-    this.personField(index).country().value.set(country ?? null);
-    this.personField(index).country().markAsTouched();
-  }
-
-  onPersonGenderChange(index: number, event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const selectedGender = select.value as Gender;
-
-    this.personField(index).gender().value.set(selectedGender || null);
-    this.personField(index).gender().markAsTouched();
-  }
-
-  onPersonGenderBlur(index: number) {
-    this.personField(index).gender().markAsTouched();
-  }
-
-  onPersonCountryBlur(index: number) {
-    this.personField(index).country().markAsTouched();
+  compareCountry(a: CountryData | null, b: CountryData | null): boolean {
+    return a?.id === b?.id;
   }
 
   personField(index: number) {
@@ -287,7 +259,6 @@ export class CustomerFormComponent {
 
   // Expose utility functions for template use
   protected readonly visibleErrorMessages = visibleErrorMessages;
-  protected readonly fieldStateClasses = fieldStateClasses;
 
   protected readonly faVenusMars = faVenusMars;
   protected readonly faFlag = faFlag;

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.html
@@ -3,7 +3,7 @@
     <form [formGroup]="createEmployeeForm" autocomplete="off">
       <p class="mb-2"><strong>Neuen Mitarbeiter anlegen</strong></p>
       <mat-form-field class="w-full">
-        <mat-label>Personalnummer *</mat-label>
+        <mat-label>Personalnummer</mat-label>
         <input matInput [attr.testid]="data.testIdPrefix + 'personnelnumber-input'" type="text"
                formControlName="personnelNumber">
         @if (personnelNumber.errors?.required && personnelNumber.touched) {
@@ -16,7 +16,7 @@
         }
       </mat-form-field>
       <mat-form-field class="w-full">
-        <mat-label>Vorname *</mat-label>
+        <mat-label>Vorname</mat-label>
         <input matInput [attr.testid]="data.testIdPrefix + 'firstname-input'" type="text" formControlName="firstname">
         @if (firstname.errors?.required && firstname.touched) {
           <mat-error>Pflichtfeld</mat-error>
@@ -28,7 +28,7 @@
         }
       </mat-form-field>
       <mat-form-field class="w-full">
-        <mat-label>Nachname *</mat-label>
+        <mat-label>Nachname</mat-label>
         <input matInput [attr.testid]="data.testIdPrefix + 'lastname-input'" type="text" formControlName="lastname">
         @if (lastname.errors?.required && lastname.touched) {
           <mat-error>Pflichtfeld</mat-error>

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.html
@@ -2,49 +2,43 @@
   <div tafel-dialog-content>
     <form [formGroup]="createEmployeeForm" autocomplete="off">
       <p class="mb-2"><strong>Neuen Mitarbeiter anlegen</strong></p>
-      <div class="mb-2">
-        <label class="form-label">Personalnummer *</label>
-        <input [attr.testid]="data.testIdPrefix + 'personnelnumber-input'" type="text"
-               formControlName="personnelNumber"
-               class="form-control"
-               [ngClass]="controlStateClasses(personnelNumber)">
+      <mat-form-field class="w-full">
+        <mat-label>Personalnummer *</mat-label>
+        <input matInput [attr.testid]="data.testIdPrefix + 'personnelnumber-input'" type="text"
+               formControlName="personnelNumber">
         @if (personnelNumber.errors?.required && personnelNumber.touched) {
-          <div class="invalid-feedback">Pflichtfeld</div>
+          <mat-error>Pflichtfeld</mat-error>
         }
         @if (personnelNumber.errors?.maxlength && personnelNumber.touched) {
-          <div class="invalid-feedback">
+          <mat-error>
             Personalnummer zu lang (Limit: {{ personnelNumber.errors?.maxlength.requiredLength }})
-          </div>
+          </mat-error>
         }
-      </div>
-      <div class="mb-2">
-        <label class="form-label">Vorname *</label>
-        <input [attr.testid]="data.testIdPrefix + 'firstname-input'" type="text" formControlName="firstname"
-               class="form-control"
-               [ngClass]="controlStateClasses(firstname)">
+      </mat-form-field>
+      <mat-form-field class="w-full">
+        <mat-label>Vorname *</mat-label>
+        <input matInput [attr.testid]="data.testIdPrefix + 'firstname-input'" type="text" formControlName="firstname">
         @if (firstname.errors?.required && firstname.touched) {
-          <div class="invalid-feedback">Pflichtfeld</div>
+          <mat-error>Pflichtfeld</mat-error>
         }
         @if (firstname.errors?.maxlength && firstname.touched) {
-          <div class="invalid-feedback">
+          <mat-error>
             Vorname zu lang (Limit: {{ firstname.errors?.maxlength.requiredLength }})
-          </div>
+          </mat-error>
         }
-      </div>
-      <div class="mb-2">
-        <label class="form-label">Nachname *</label>
-        <input [attr.testid]="data.testIdPrefix + 'lastname-input'" type="text" formControlName="lastname"
-               class="form-control"
-               [ngClass]="controlStateClasses(lastname)">
+      </mat-form-field>
+      <mat-form-field class="w-full">
+        <mat-label>Nachname *</mat-label>
+        <input matInput [attr.testid]="data.testIdPrefix + 'lastname-input'" type="text" formControlName="lastname">
         @if (lastname.errors?.required && lastname.touched) {
-          <div class="invalid-feedback">Pflichtfeld</div>
+          <mat-error>Pflichtfeld</mat-error>
         }
         @if (lastname.errors?.maxlength && lastname.touched) {
-          <div class="invalid-feedback">
+          <mat-error>
             Nachname zu lang (Limit: {{ lastname.errors?.maxlength.requiredLength }})
-          </div>
+          </mat-error>
         }
-      </div>
+      </mat-form-field>
     </form>
   </div>
   <div tafel-dialog-actions>

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/create-employee-dialog.component.ts
@@ -1,12 +1,13 @@
 import {Component, inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
 import {FormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {EmployeeApiService, EmployeeData} from '../../../../api/employee-api.service';
 import {TafelDialogComponent} from '../../../../common/components/tafel-dialog/tafel-dialog.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
-import {controlStateClasses} from '../../../../common/util/reactive-form-helper';
 
 export interface CreateEmployeeDialogData {
   testId: string;
@@ -15,7 +16,7 @@ export interface CreateEmployeeDialogData {
 
 @Component({
   selector: 'tafel-create-employee-dialog',
-  imports: [TafelDialogComponent, MatButtonModule, ReactiveFormsModule, CommonModule],
+  imports: [TafelDialogComponent, MatButtonModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule, CommonModule],
   templateUrl: 'create-employee-dialog.component.html',
 })
 export class CreateEmployeeDialogComponent {
@@ -59,6 +60,4 @@ export class CreateEmployeeDialogComponent {
   get lastname() {
     return this.createEmployeeForm.get('lastname')!;
   }
-
-  protected readonly controlStateClasses = controlStateClasses;
 }

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
@@ -3,7 +3,7 @@
     <div class="md:col-span-5">
       <div class="flex items-center gap-2">
         <mat-form-field class="w-full">
-          <mat-label>KFZ *</mat-label>
+          <mat-label>KFZ</mat-label>
           <mat-select testid="carInput" formControlName="car" [compareWith]="compareCar">
             @for (car of carList().cars; track car.id) {
               <mat-option [value]="car" [attr.testid]="'carInput-option-' + car.id">
@@ -21,7 +21,7 @@
     <div class="md:col-span-3 mt-4 md:mt-0">
       <div class="flex items-center gap-2">
         <mat-form-field class="w-full">
-          <mat-label>KM Start *</mat-label>
+          <mat-label>KM Start</mat-label>
           <input matInput testid="kmStartInput" type="number" formControlName="kmStart">
           @if (kmStart.errors?.required && kmStart.touched) {
             <mat-error>Pflichtfeld</mat-error>
@@ -36,7 +36,7 @@
     <div class="md:col-span-3 mt-4 md:mt-0">
       <div class="flex items-center gap-2">
         <mat-form-field class="w-full">
-          <mat-label>KM Ende *</mat-label>
+          <mat-label>KM Ende</mat-label>
           <input matInput testid="kmEndInput" type="number" formControlName="kmEnd">
           @if (kmEnd.errors?.required && kmEnd.touched) {
             <mat-error>Pflichtfeld</mat-error>
@@ -57,7 +57,7 @@
       @if (!selectedDriver()) {
         <div class="flex items-center gap-2">
           <mat-form-field class="w-full">
-            <mat-label>Fahrer *</mat-label>
+            <mat-label>Fahrer</mat-label>
             <input matInput testid="driverSearchInput" type="text" formControlName="driverSearchInput"
                    placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchDriver()">
             @if (driverSearchInput.errors?.required && driverSearchInput.touched) {
@@ -91,7 +91,7 @@
       @if (!selectedCoDriver()) {
         <div class="flex items-center gap-2">
           <mat-form-field class="w-full">
-            <mat-label>Beifahrer *</mat-label>
+            <mat-label>Beifahrer</mat-label>
             <input matInput testid="coDriverSearchInput" type="text" formControlName="coDriverSearchInput"
                    placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchCoDriver()">
             @if (coDriverSearchInput.errors?.required && coDriverSearchInput.touched) {

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.html
@@ -1,94 +1,83 @@
 <form [formGroup]="form" autocomplete="off">
   <div class="grid grid-cols-1 md:grid-cols-12 gap-6">
     <div class="md:col-span-5">
-      <label class="form-label">KFZ *</label>
       <div class="flex items-center gap-2">
-        <select testid="carInput" class="form-control" formControlName="car">
-          @for (car of carList().cars; track car.id) {
-            <option [ngValue]="car">
-              {{ car.licensePlate }} ({{ car.name }})
-            </option>
+        <mat-form-field class="w-full">
+          <mat-label>KFZ *</mat-label>
+          <mat-select testid="carInput" formControlName="car" [compareWith]="compareCar">
+            @for (car of carList().cars; track car.id) {
+              <mat-option [value]="car" [attr.testid]="'carInput-option-' + car.id">
+                {{ car.licensePlate }} ({{ car.name }})
+              </mat-option>
+            }
+          </mat-select>
+          @if (car.errors?.required && car.touched) {
+            <mat-error>Pflichtfeld</mat-error>
           }
-        </select>
+        </mat-form-field>
         <fa-icon [icon]="faTruck"></fa-icon>
       </div>
-      @if (car.errors?.required && car.touched) {
-        <div class="invalid-feedback">
-          Pflichtfeld
-        </div>
-      }
     </div>
     <div class="md:col-span-3 mt-4 md:mt-0">
-      <label class="form-label">KM Start *</label>
       <div class="flex items-center gap-2">
-        <input testid="kmStartInput" type="number" formControlName="kmStart" class="form-control"
-               [ngClass]="controlStateClasses(kmStart)">
+        <mat-form-field class="w-full">
+          <mat-label>KM Start *</mat-label>
+          <input matInput testid="kmStartInput" type="number" formControlName="kmStart">
+          @if (kmStart.errors?.required && kmStart.touched) {
+            <mat-error>Pflichtfeld</mat-error>
+          }
+          @if (kmStart.errors?.min && kmStart.touched) {
+            <mat-error>Muss mindestens 1 sein</mat-error>
+          }
+        </mat-form-field>
         <fa-icon [icon]="faGauge"></fa-icon>
       </div>
-      @if (kmStart.errors?.required && kmStart.touched) {
-        <div class="invalid-feedback">
-          Pflichtfeld
-        </div>
-      }
-      @if (kmStart.errors?.min && kmStart.touched) {
-        <div class="invalid-feedback">
-          Muss mindestens 1 sein
-        </div>
-      }
     </div>
     <div class="md:col-span-3 mt-4 md:mt-0">
-      <label class="form-label">KM Ende *</label>
       <div class="flex items-center gap-2">
-        <input testid="kmEndInput" type="number" formControlName="kmEnd" class="form-control"
-               [ngClass]="controlStateClasses(kmEnd)">
+        <mat-form-field class="w-full">
+          <mat-label>KM Ende *</mat-label>
+          <input matInput testid="kmEndInput" type="number" formControlName="kmEnd">
+          @if (kmEnd.errors?.required && kmEnd.touched) {
+            <mat-error>Pflichtfeld</mat-error>
+          }
+          @if (kmEnd.errors?.min && kmEnd.touched) {
+            <mat-error>Muss mindestens 1 sein</mat-error>
+          }
+          @if (kmEnd.errors?.kmValidation && kmEnd.touched) {
+            <mat-error>KM Ende muss größer als KM Start sein</mat-error>
+          }
+        </mat-form-field>
         <fa-icon [icon]="faGauge"></fa-icon>
       </div>
-      @if (kmEnd.errors?.required && kmEnd.touched) {
-        <div class="invalid-feedback">
-          Pflichtfeld
-        </div>
-      }
-      @if (kmEnd.errors?.min && kmEnd.touched) {
-        <div class="invalid-feedback">
-          Muss mindestens 1 sein
-        </div>
-      }
-      @if (kmEnd.errors?.kmValidation && kmEnd.touched) {
-        <div class="invalid-feedback">
-          KM Ende muss größer als KM Start sein
-        </div>
-      }
     </div>
   </div>
   <div class="grid grid-cols-1 md:grid-cols-12 gap-6 mt-4">
     <div class="md:col-span-5">
       @if (!selectedDriver()) {
-        <label class="form-label">Fahrer *</label>
         <div class="flex items-center gap-2">
-          <input testid="driverSearchInput" type="text" formControlName="driverSearchInput" class="form-control"
-                 placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchDriver()"
-                 [ngClass]="controlStateClasses(driverSearchInput)">
+          <mat-form-field class="w-full">
+            <mat-label>Fahrer *</mat-label>
+            <input matInput testid="driverSearchInput" type="text" formControlName="driverSearchInput"
+                   placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchDriver()">
+            @if (driverSearchInput.errors?.required && driverSearchInput.touched) {
+              <mat-error>Pflichtfeld</mat-error>
+            }
+            @if (driverSearchInput.errors?.maxlength && driverSearchInput.touched) {
+              <mat-error>
+                Fahrer zu lang (Limit: {{ driverSearchInput.errors?.maxlength.requiredLength }})
+              </mat-error>
+            }
+            @if (driverSearchInput.errors?.hasValue && driverSearchInput.touched) {
+              <mat-error>{{ driverSearchInput.errors?.hasValue.message }}</mat-error>
+            }
+          </mat-form-field>
           <tafel-employee-search-create #driverEmployeeSearchCreate [testIdPrefix]="'driver'"
                                         [searchInput]="driverSearchInput.value ?? ''"
                                         (selectedEmployee)="setSelectedDriver($event)"/>
         </div>
-        @if (driverSearchInput.errors?.required && driverSearchInput.touched) {
-          <div class="invalid-feedback">
-            Pflichtfeld
-          </div>
-        }
-        @if (driverSearchInput.errors?.maxlength && driverSearchInput.touched) {
-          <div class="invalid-feedback">
-            Fahrer zu lang (Limit: {{ driverSearchInput.errors?.maxlength.requiredLength }})
-          </div>
-        }
-        @if (driverSearchInput.errors?.hasValue && driverSearchInput.touched) {
-          <div class="invalid-feedback">
-            {{ driverSearchInput.errors?.hasValue.message }}
-          </div>
-        }
       } @else {
-        <label class="form-label">Fahrer *</label>
+        <div class="mb-2 font-medium">Fahrer *</div>
         <div class="flex items-center justify-between gap-2">
           <div testid="selectedDriverDescription">{{ selectedDriver()!.personnelNumber }} {{ selectedDriver()!.firstname }} {{ selectedDriver()!.lastname }}</div>
           <button type="button" matButton="filled" testid="selectedDriverRemoveButton" class="button-danger"
@@ -100,32 +89,29 @@
     </div>
     <div class="md:col-span-5 mt-4 md:mt-0">
       @if (!selectedCoDriver()) {
-        <label class="form-label">Beifahrer *</label>
         <div class="flex items-center gap-2">
-          <input testid="coDriverSearchInput" type="text" formControlName="coDriverSearchInput" class="form-control"
-                 placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchCoDriver()"
-                 [ngClass]="controlStateClasses(coDriverSearchInput)">
+          <mat-form-field class="w-full">
+            <mat-label>Beifahrer *</mat-label>
+            <input matInput testid="coDriverSearchInput" type="text" formControlName="coDriverSearchInput"
+                   placeholder="Personalnummer / Name" (keyup.enter)="triggerSearchCoDriver()">
+            @if (coDriverSearchInput.errors?.required && coDriverSearchInput.touched) {
+              <mat-error>Pflichtfeld</mat-error>
+            }
+            @if (coDriverSearchInput.errors?.maxlength && coDriverSearchInput.touched) {
+              <mat-error>
+                Beifahrer zu lang (Limit: {{ coDriverSearchInput.errors?.maxlength.requiredLength }})
+              </mat-error>
+            }
+            @if (coDriverSearchInput.errors?.hasValue && coDriverSearchInput.touched) {
+              <mat-error>{{ coDriverSearchInput.errors?.hasValue.message }}</mat-error>
+            }
+          </mat-form-field>
           <tafel-employee-search-create #coDriverEmployeeSearchCreate [testIdPrefix]="'codriver'"
                                         [searchInput]="coDriverSearchInput.value ?? ''"
                                         (selectedEmployee)="setSelectedCoDriver($event)"/>
         </div>
-        @if (coDriverSearchInput.errors?.required && coDriverSearchInput.touched) {
-          <div class="invalid-feedback">
-            Pflichtfeld
-          </div>
-        }
-        @if (coDriverSearchInput.errors?.maxlength && coDriverSearchInput.touched) {
-          <div class="invalid-feedback">
-            Beifahrer zu lang (Limit: {{ coDriverSearchInput.errors?.maxlength.requiredLength }})
-          </div>
-        }
-        @if (coDriverSearchInput.errors?.hasValue && coDriverSearchInput.touched) {
-          <div class="invalid-feedback">
-            {{ coDriverSearchInput.errors?.hasValue.message }}
-          </div>
-        }
       } @else {
-        <label class="form-label">Beifahrer *</label>
+        <div class="mb-2 font-medium">Beifahrer *</div>
         <div class="flex items-center justify-between gap-2">
           <div testid="selectedCoDriverDescription">{{ selectedCoDriver()!.personnelNumber }} {{ selectedCoDriver()!.firstname }} {{ selectedCoDriver()!.lastname }}</div>
           <button type="button" matButton="filled" testid="selectedCoDriverRemoveButton" class="button-danger"

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-basedata/food-collection-recording-basedata.component.ts
@@ -1,6 +1,9 @@
 import {Component, effect, inject, input, model, signal, viewChild} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {MatDialog} from '@angular/material/dialog';
 import {KmDiffDialogComponent} from './dialogs/km-diff-dialog.component';
 import {FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
@@ -16,7 +19,6 @@ import {
 import {CarData, CarList} from '../../../../api/car-api.service';
 import {SelectedRouteData} from '../food-collection-recording/food-collection-recording.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
-import {controlStateClasses} from '../../../../common/util/reactive-form-helper';
 
 @Component({
     selector: 'tafel-food-collection-recording-basedata',
@@ -26,6 +28,9 @@ import {controlStateClasses} from '../../../../common/util/reactive-form-helper'
         ReactiveFormsModule,
         FormsModule,
         MatButtonModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
         FaIconComponent,
         TafelEmployeeSearchCreateComponent
     ]
@@ -215,8 +220,11 @@ export class FoodCollectionRecordingBasedataComponent {
     return this.form.get('kmEnd')!;
   }
 
+  compareCar(a: CarData | null, b: CarData | null): boolean {
+    return a?.id === b?.id;
+  }
+
   protected readonly faTruck = faTruck;
   protected readonly faGauge = faGauge;
   protected readonly faRemove = faRemove;
-  protected readonly controlStateClasses = controlStateClasses;
 }

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-items-desktop/food-collection-recording-items-desktop.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-items-desktop/food-collection-recording-items-desktop.component.html
@@ -18,10 +18,11 @@
               <ng-container formArrayName="shops">
                 @for (shop of getShops(categoryIndex).controls; let shopIndex = $index; track shop) {
                   <td [formGroupName]="shopIndex">
-                    <input type="number" class="form-control" min="0"
-                           [attr.testid]="'category-' + foodCategories()?.[categoryIndex]?.id + '-shop-' + selectedRouteData()?.shops?.[shopIndex]?.id + '-input'"
-                           formControlName="amount"
-                           style="min-width: 3.6em; max-width: 5em;">
+                    <mat-form-field subscriptSizing="dynamic" style="min-width: 3.6em; max-width: 5em;">
+                      <input matInput type="number" min="0"
+                             [attr.testid]="'category-' + foodCategories()?.[categoryIndex]?.id + '-shop-' + selectedRouteData()?.shops?.[shopIndex]?.id + '-input'"
+                             formControlName="amount">
+                    </mat-form-field>
                   </td>
                 }
               </ng-container>

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-items-desktop/food-collection-recording-items-desktop.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording-items-desktop/food-collection-recording-items-desktop.component.ts
@@ -3,6 +3,8 @@ import {NgClass} from '@angular/common';
 import {Shop} from '../../../../api/route-api.service';
 
 import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
 import {FoodCategory} from '../../../../api/food-categories-api.service';
 import {FormArray, FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {
@@ -21,6 +23,8 @@ import {isControlInvalid, isControlValid} from '../../../../common/util/reactive
     ReactiveFormsModule,
     FormsModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
     NgClass
   ]
 })

--- a/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
@@ -5,86 +5,76 @@
     </mat-card-header>
     <mat-card-content>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        <div>
-          <label class="form-label">Benutzername *</label>
-          <input [formField]="userForm.username" testid="usernameInput" type="text" class="form-control" tafelAutofocus
-                 [ngClass]="fieldStateClasses(userForm.username())">
+        <mat-form-field>
+          <mat-label>Benutzername *</mat-label>
+          <input matInput [formField]="userForm.username" testid="usernameInput" type="text" tafelAutofocus>
           @for (errorMessage of visibleErrorMessages(userForm.username()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
-        <div>
-          <label class="form-label">Personalnummer *</label>
-          <input testid="personnelNumberInput" type="text" [formField]="userForm.personnelNumber" class="form-control"
-                 [ngClass]="fieldStateClasses(userForm.personnelNumber())">
+        </mat-form-field>
+        <mat-form-field>
+          <mat-label>Personalnummer *</mat-label>
+          <input matInput testid="personnelNumberInput" type="text" [formField]="userForm.personnelNumber">
           @for (errorMessage of visibleErrorMessages(userForm.personnelNumber()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
+        </mat-form-field>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-2">
-        <div>
-          <label class="form-label">Nachname *</label>
-          <input testid="lastnameInput" type="text" [formField]="userForm.lastname" class="form-control"
-                 [ngClass]="fieldStateClasses(userForm.lastname())">
+        <mat-form-field>
+          <mat-label>Nachname *</mat-label>
+          <input matInput testid="lastnameInput" type="text" [formField]="userForm.lastname">
           @for (errorMessage of visibleErrorMessages(userForm.lastname()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
-        <div>
-          <label class="form-label">Vorname *</label>
-          <input testid="firstnameInput" type="text" [formField]="userForm.firstname" class="form-control"
-                 autocomplete="new-password"
-                 [ngClass]="fieldStateClasses(userForm.firstname())">
+        </mat-form-field>
+        <mat-form-field>
+          <mat-label>Vorname *</mat-label>
+          <input matInput testid="firstnameInput" type="text" [formField]="userForm.firstname"
+                 autocomplete="new-password">
           @for (errorMessage of visibleErrorMessages(userForm.firstname()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
+        </mat-form-field>
       </div>
       <hr>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        <div>
-          <label class="form-label">Passwort</label>
-          <div class="flex items-center gap-2">
-            <input testid="passwordInput"
-                   autocomplete="new-password"
-                   [type]="passwordTextVisible() ? 'text' : 'password'"
-                   [formField]="userForm.password" class="form-control"
-                   [ngClass]="fieldStateClasses(userForm.password())">
-            <span (click)="togglePasswordVisibility()" class="cursor-pointer">
-                  @if (!passwordTextVisible()) {
-                    <fa-icon [icon]="faEyeSlash"></fa-icon>
-                  }
-                  @if (passwordTextVisible()) {
-                    <fa-icon [icon]="faEye"></fa-icon>
-                  }
-            </span>
-          </div>
+        <mat-form-field>
+          <mat-label>Passwort</mat-label>
+          <input matInput testid="passwordInput"
+                 autocomplete="new-password"
+                 [type]="passwordTextVisible() ? 'text' : 'password'"
+                 [formField]="userForm.password">
+          <button type="button" mat-icon-button matSuffix (click)="togglePasswordVisibility()">
+            @if (!passwordTextVisible()) {
+              <fa-icon [icon]="faEyeSlash"></fa-icon>
+            }
+            @if (passwordTextVisible()) {
+              <fa-icon [icon]="faEye"></fa-icon>
+            }
+          </button>
           @for (errorMessage of visibleErrorMessages(userForm.password()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
-        <div>
-          <label class="form-label">Passwort (Wiederholung)</label>
-          <div class="flex items-center gap-2">
-            <input testid="passwordRepeatInput"
-                   autocomplete="new-password"
-                   [type]="passwordRepeatTextVisible() ? 'text' : 'password'"
-                   [formField]="userForm.passwordRepeat" class="form-control"
-                   [ngClass]="fieldStateClasses(userForm.passwordRepeat())">
-            <span (click)="togglePasswordRepeatVisibility()" class="cursor-pointer">
-                  @if (!passwordRepeatTextVisible()) {
-                    <fa-icon [icon]="faEyeSlash"></fa-icon>
-                  }
-                  @if (passwordRepeatTextVisible()) {
-                    <fa-icon [icon]="faEye"></fa-icon>
-                  }
-            </span>
-          </div>
+        </mat-form-field>
+        <mat-form-field>
+          <mat-label>Passwort (Wiederholung)</mat-label>
+          <input matInput testid="passwordRepeatInput"
+                 autocomplete="new-password"
+                 [type]="passwordRepeatTextVisible() ? 'text' : 'password'"
+                 [formField]="userForm.passwordRepeat">
+          <button type="button" mat-icon-button matSuffix (click)="togglePasswordRepeatVisibility()">
+            @if (!passwordRepeatTextVisible()) {
+              <fa-icon [icon]="faEyeSlash"></fa-icon>
+            }
+            @if (passwordRepeatTextVisible()) {
+              <fa-icon [icon]="faEye"></fa-icon>
+            }
+          </button>
           @for (errorMessage of visibleErrorMessages(userForm.passwordRepeat()); track errorMessage) {
-            <div class="invalid-feedback">{{errorMessage}}</div>
+            <mat-error>{{errorMessage}}</mat-error>
           }
-        </div>
+        </mat-form-field>
       </div>
       <div class="mt-4">
         <button type="button" testid="generate-password-button" matButton="filled"
@@ -94,17 +84,12 @@
       <hr>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div>
-          <label class="form-label">Benutzer aktiv</label>
-          <div>
-            <input testid="enabledInput" type="checkbox" [formField]="userForm.enabled" class="form-check-input">
-          </div>
+          <mat-checkbox [formField]="userForm.enabled" testid="enabledInput">Benutzer aktiv</mat-checkbox>
         </div>
         <div class="mt-4 sm:mt-0">
-          <label class="form-label">Passwort-Änderung beim nächsten Login erforderlich</label>
-          <div>
-            <input testid="passwordChangeRequiredInput" type="checkbox" [formField]="userForm.passwordChangeRequired"
-                   class="form-check-input">
-          </div>
+          <mat-checkbox [formField]="userForm.passwordChangeRequired" testid="passwordChangeRequiredInput">
+            Passwort-Änderung beim nächsten Login erforderlich
+          </mat-checkbox>
         </div>
       </div>
       <hr>
@@ -114,10 +99,9 @@
       <div class="grid grid-cols-1 md:grid-cols-5 gap-2 mt-2">
         @for (permission of permissions(); track trackBy($index, permission); let i = $index) {
           <div [attr.testid]="'permission-' + i">
-            <label [attr.for]="'permission-checkbox-' + i">{{permission.title}}</label>
-            <div>
-              <input type="checkbox" [checked]="permission.enabled" (change)="togglePermission(i)" [attr.id]="'permission-checkbox-' + i" [attr.testid]="'permission-checkbox-' + i">
-            </div>
+            <mat-checkbox [checked]="permission.enabled" (change)="togglePermission(i)" [attr.testid]="'permission-checkbox-' + i">
+              {{permission.title}}
+            </mat-checkbox>
           </div>
         }
       </div>

--- a/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
@@ -6,14 +6,14 @@
     <mat-card-content>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <mat-form-field>
-          <mat-label>Benutzername *</mat-label>
+          <mat-label>Benutzername</mat-label>
           <input matInput [formField]="userForm.username" testid="usernameInput" type="text" tafelAutofocus>
           @for (errorMessage of visibleErrorMessages(userForm.username()); track errorMessage) {
             <mat-error>{{errorMessage}}</mat-error>
           }
         </mat-form-field>
         <mat-form-field>
-          <mat-label>Personalnummer *</mat-label>
+          <mat-label>Personalnummer</mat-label>
           <input matInput testid="personnelNumberInput" type="text" [formField]="userForm.personnelNumber">
           @for (errorMessage of visibleErrorMessages(userForm.personnelNumber()); track errorMessage) {
             <mat-error>{{errorMessage}}</mat-error>
@@ -22,14 +22,14 @@
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-2">
         <mat-form-field>
-          <mat-label>Nachname *</mat-label>
+          <mat-label>Nachname</mat-label>
           <input matInput testid="lastnameInput" type="text" [formField]="userForm.lastname">
           @for (errorMessage of visibleErrorMessages(userForm.lastname()); track errorMessage) {
             <mat-error>{{errorMessage}}</mat-error>
           }
         </mat-form-field>
         <mat-form-field>
-          <mat-label>Vorname *</mat-label>
+          <mat-label>Vorname</mat-label>
           <input matInput testid="firstnameInput" type="text" [formField]="userForm.firstname"
                  autocomplete="new-password">
           @for (errorMessage of visibleErrorMessages(userForm.firstname()); track errorMessage) {

--- a/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.ts
@@ -1,13 +1,16 @@
 import {Component, computed, effect, inject, input, output, signal} from '@angular/core';
 import {form, FormField, maxLength, required, validate} from '@angular/forms/signals';
 import {GeneratedPasswordResponse, UserApiService, UserData, UserPermission} from '../../../../api/user-api.service';
-import {CommonModule, NgClass} from '@angular/common';
+import {CommonModule} from '@angular/common';
 import {MatCardModule} from '@angular/material/card';
 import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faEye, faEyeSlash} from '@fortawesome/free-solid-svg-icons';
 import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofocus.directive';
-import {fieldStateClasses, visibleErrorMessages} from '../../../../common/util/signal-form-helper';
+import {visibleErrorMessages} from '../../../../common/util/signal-form-helper';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 
 @Component({
@@ -15,10 +18,12 @@ import {TafelToastrService} from '../../../../common/components/tafel-toastr/taf
     templateUrl: 'user-form.component.html',
     imports: [
         FormField,
-        NgClass,
         CommonModule,
         MatCardModule,
         MatButtonModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatCheckboxModule,
         FaIconComponent,
         TafelAutofocusDirective
     ]
@@ -188,7 +193,6 @@ export class UserFormComponent {
 
   // Expose utility functions for template use
   protected readonly visibleErrorMessages = visibleErrorMessages;
-  protected readonly fieldStateClasses = fieldStateClasses;
 
   protected readonly faEyeSlash = faEyeSlash;
   protected readonly faEye = faEye;


### PR DESCRIPTION
## Summary
- Finishes the customer-search Material migration by converting every remaining create/edit form's hand-rolled Bootstrap-lookalike markup (`.form-control`/`.form-label`/`.invalid-feedback`, `[ngClass]="fieldStateClasses(...)"`) to real Angular Material (`mat-form-field`/`matInput`/`mat-select`/`mat-checkbox`/`mat-error`)
- Affects `customer-form`, `user-form`, `create-employee-dialog`, `food-collection-recording-basedata`, `food-collection-recording-items-desktop`, and `login`
- Native gender/country/car `<select>`s become `mat-select` (first usage of `mat-select` in the repo); country/car use `[compareWith]` since they're bound to objects rather than primitives
- Updates the Cypress specs that relied on native-element-only `.select()`/`.check()` commands to drive `mat-select`/`mat-checkbox` instead
- `tafel-form.scss` is left in place since five other files outside this issue's scope still use its classes

Closes #2831

## Test plan
- [x] `ng lint` — clean
- [x] `ng build` — clean, no template/type errors
- [x] `ng test` — all 586 unit tests pass
- [x] `tsc --noEmit -p cypress/tsconfig.json` — clean
- [x] Ran the 6 affected Cypress e2e specs (customer-create, customer-edit, food-collection-recording, user-create, user-edit, login) against a live backend — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)