### PR TITLE
chore: remove dead fieldStateClasses/controlStateClasses helpers

### DIFF
--- a/frontend/src/main/webapp/src/app/common/util/reactive-form-helper.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/util/reactive-form-helper.spec.ts
@@ -1,4 +1,4 @@
-import {controlStateClasses, isControlInvalid, isControlValid} from './reactive-form-helper';
+import {isControlInvalid, isControlValid} from './reactive-form-helper';
 
 describe('Reactive Form Helper', () => {
 
@@ -45,47 +45,6 @@ describe('Reactive Form Helper', () => {
       const mockControl = {valid: false, dirty: true, touched: false} as any;
 
       expect(isControlValid(mockControl)).toBe(false);
-    });
-  });
-
-  describe('controlStateClasses', () => {
-    it('should mark an untouched invalid control as neither invalid nor valid', () => {
-      const mockControl = {
-        invalid: true,
-        valid: false,
-        dirty: false,
-        touched: false
-      } as any;
-
-      const result = controlStateClasses(mockControl);
-
-      expect(result).toEqual({'is-invalid': false, 'is-valid': false});
-    });
-
-    it('should mark a touched invalid control as is-invalid', () => {
-      const mockControl = {
-        invalid: true,
-        valid: false,
-        dirty: false,
-        touched: true
-      } as any;
-
-      const result = controlStateClasses(mockControl);
-
-      expect(result).toEqual({'is-invalid': true, 'is-valid': false});
-    });
-
-    it('should mark a dirty valid control as is-valid', () => {
-      const mockControl = {
-        invalid: false,
-        valid: true,
-        dirty: true,
-        touched: false
-      } as any;
-
-      const result = controlStateClasses(mockControl);
-
-      expect(result).toEqual({'is-invalid': false, 'is-valid': true});
     });
   });
 

--- a/frontend/src/main/webapp/src/app/common/util/reactive-form-helper.ts
+++ b/frontend/src/main/webapp/src/app/common/util/reactive-form-helper.ts
@@ -32,22 +32,3 @@ export function isControlInvalid(control: AbstractControl): boolean {
 export function isControlValid(control: AbstractControl): boolean {
   return control.valid && (control.dirty || control.touched);
 }
-
-/**
- * Get the `is-invalid`/`is-valid` CSS classes for a reactive form control, for use with `[ngClass]`.
- *
- * @param control The reactive form control
- * @returns An object suitable for binding to `[ngClass]`
- *
- * @example
- * ```html
- * <!-- In template -->
- * <input formControlName="lastname" [ngClass]="controlStateClasses(lastname)">
- * ```
- */
-export function controlStateClasses(control: AbstractControl): Record<string, boolean> {
-  return {
-    'is-invalid': isControlInvalid(control),
-    'is-valid': isControlValid(control)
-  };
-}

--- a/frontend/src/main/webapp/src/app/common/util/signal-form-helper.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/util/signal-form-helper.spec.ts
@@ -1,4 +1,4 @@
-import {fieldStateClasses, getErrorMessages, shouldShowErrors, visibleErrorMessages} from './signal-form-helper';
+import {getErrorMessages, shouldShowErrors, visibleErrorMessages} from './signal-form-helper';
 
 describe('Signal Form Helper', () => {
 
@@ -152,44 +152,6 @@ describe('Signal Form Helper', () => {
       const result = visibleErrorMessages(mockFieldState);
 
       expect(result).toEqual(['Pflichtfeld']);
-    });
-  });
-
-  describe('fieldStateClasses', () => {
-    it('should mark an untouched invalid field as neither invalid nor valid', () => {
-      const mockFieldState = {
-        valid: () => false,
-        dirty: () => false,
-        touched: () => false
-      } as any;
-
-      const result = fieldStateClasses(mockFieldState);
-
-      expect(result).toEqual({'is-invalid': false, 'is-valid': false});
-    });
-
-    it('should mark a touched invalid field as is-invalid', () => {
-      const mockFieldState = {
-        valid: () => false,
-        dirty: () => false,
-        touched: () => true
-      } as any;
-
-      const result = fieldStateClasses(mockFieldState);
-
-      expect(result).toEqual({'is-invalid': true, 'is-valid': false});
-    });
-
-    it('should mark a dirty valid field as is-valid', () => {
-      const mockFieldState = {
-        valid: () => true,
-        dirty: () => true,
-        touched: () => false
-      } as any;
-
-      const result = fieldStateClasses(mockFieldState);
-
-      expect(result).toEqual({'is-invalid': false, 'is-valid': true});
     });
   });
 

--- a/frontend/src/main/webapp/src/app/common/util/signal-form-helper.ts
+++ b/frontend/src/main/webapp/src/app/common/util/signal-form-helper.ts
@@ -80,22 +80,3 @@ export function shouldShowErrors(fieldState: FieldState<any>): boolean {
 export function visibleErrorMessages(fieldState: FieldState<any>): string[] {
   return shouldShowErrors(fieldState) ? getErrorMessages(fieldState) : [];
 }
-
-/**
- * Get the `is-invalid`/`is-valid` CSS classes for a field, for use with `[ngClass]`.
- *
- * @param fieldState The field state from a signal form
- * @returns An object suitable for binding to `[ngClass]`
- *
- * @example
- * ```html
- * <!-- In template -->
- * <input [ngClass]="fieldStateClasses(userForm.username())">
- * ```
- */
-export function fieldStateClasses(fieldState: FieldState<any>): Record<string, boolean> {
-  return {
-    'is-invalid': shouldShowErrors(fieldState),
-    'is-valid': fieldState.valid() && (fieldState.dirty() || fieldState.touched())
-  };
-}


### PR DESCRIPTION
## Summary
- Follow-up to #2831/#2833/#2834: both `fieldStateClasses` (`signal-form-helper.ts`) and `controlStateClasses` (`reactive-form-helper.ts`) computed `is-invalid`/`is-valid` CSS classes for the CoreUI-style form markup that was fully migrated to Angular Material across those PRs
- Verified zero remaining callers anywhere in the app before removing them (and their spec test cases)
- Sibling helpers used for other purposes (`visibleErrorMessages`, `isControlInvalid`/`isControlValid` — still driving `mat-error` and row-highlighting) are untouched

## Test plan
- [x] `ng lint` — clean
- [x] `ng build` — clean
- [x] `ng test` — 580/580 pass (down from 586, matching the 6 removed test cases for the deleted functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)