### PR TITLE
fix: raise commitlint length limits for dependabot bumps

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,8 +31,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # No leading uppercase, no trailing period, and a length cap that keeps the full
-          # "type(scope)!: description" header under commitlint's 100-char header-max-length
-          # even with a long type+scope prefix.
+          # "type(scope)!: description" header under 100 chars even with a long type+scope
+          # prefix. This is intentionally stricter than commitlint.config.js's 150-char
+          # header-max-length, which was raised only to stop Dependabot's longer
+          # auto-generated commit messages from failing that check; human-authored titles
+          # should stay concise regardless.
           subjectPattern: ^(?![A-Z]).{0,79}[^.]$
           subjectPatternError: |
             The description "{subject}" found in title "{title}" must start with a lowercase

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,11 @@
+// Dependabot's auto-generated commit messages routinely trip config-conventional's
+// defaults: headers grow past 100 chars once a directory path or dependency-group
+// name is included, and bodies quote third-party changelog text we don't control.
+// Relax both instead of fighting an ever-recurring CI failure on every bump PR.
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 150],
+    'body-max-line-length': [0, 'always'],
+  },
+};


### PR DESCRIPTION
## Summary
- The `commitlint` job (CI) fails on Dependabot bump PRs whose auto-generated commit message exceeds config-conventional's default `header-max-length`/`body-max-line-length` of 100 chars — e.g. PR #2837/#2840's jsdom bump (113-char header, a body line at 101 chars).
- The job's `if: github.actor != 'dependabot[bot]'` skip doesn't catch this reliably: when a human syncs/rebases the branch, the triggering actor becomes that human, not `dependabot[bot]`, so the check runs anyway.
- Adds `commitlint.config.js` extending `@commitlint/config-conventional`, raising `header-max-length` to 150 and disabling `body-max-line-length` (we don't control Dependabot's or upstream changelog text). Human-authored PR titles remain capped at 100 chars via `pr-title-lint`'s `subjectPattern`, unchanged.

## Test plan
- [x] Verified locally with `commitlint --config commitlint.config.js` that the failing jsdom bump commit message from run 30437174259 now passes
- [x] Verified a non-conventional commit message still fails as expected
- [ ] Confirm the next Dependabot PR/re-run passes `commitlint` in CI

🤖 Generated with Claude Code