### PR TITLE
test: add desktop (1024x768) and responsive coverage to all cypress specs

### DIFF
--- a/frontend/src/main/webapp/cypress.config.ts
+++ b/frontend/src/main/webapp/cypress.config.ts
@@ -3,8 +3,12 @@ import * as path from 'path';
 
 export default defineConfig({
   builder: '@cypress/schematic:cypress',
-  viewportWidth: 1280,
-  viewportHeight: 1024,
+  // 1024x768 is the smallest desktop resolution still used in production
+  // (right at the app's mobile/desktop breakpoint), so it's the baseline for
+  // all specs. Individual specs additionally test PHONE_VIEWPORT/TABLET_VIEWPORT
+  // (see cypress/support/viewports.ts) for pages with responsive layouts.
+  viewportWidth: 1024,
+  viewportHeight: 768,
   videoCompression: false,
   video: true,
   allowCypressEnv: false,

--- a/frontend/src/main/webapp/cypress/e2e/checkin.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/checkin.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('CheckIn', () => {
 
   beforeEach(() => {
@@ -67,10 +69,52 @@ describe('CheckIn', () => {
     cy.byTestId('ticketNumberInput').should('have.value', '');
   });
 
+  it('customer added, counted on dashboard and deleted again on phone', () => {
+    // Below md: (768px) everything stacks into a single column (form rows, detail
+    // panel, address/ticket rows) - verify the full flow still works stacked.
+    cy.viewport(PHONE_VIEWPORT);
+
+    searchCustomer(100);
+    cy.byTestId('customerDetailPanel').should('be.visible');
+
+    assignTicket(10);
+    assertFormReset();
+
+    assertDashboardCustomerCount(1);
+
+    cy.visit('/#/anmeldung/annahme');
+    searchCustomer(100);
+
+    cy.byTestId('ticketNumberInput').should('have.value', '10');
+    cy.byTestId('deleteTicketButton').click();
+
+    cy.get('.toast-message').should('be.visible').should('contain.text', 'Ticket-Nummer gelöscht!');
+
+    assertDashboardCustomerCount(0);
+  });
+
+  it('customer accepted with desktop-style form grid at tablet breakpoint', () => {
+    // At 768px the sidenav is still in mobile ("over") mode, but the page's own md: content
+    // grid (form rows, detail panel columns, address rows) already switches to its desktop
+    // arrangement - verify that combination renders and one flow still works.
+    cy.viewport(TABLET_VIEWPORT);
+
+    searchCustomer(100);
+    cy.byTestId('customerDetailPanel').should('be.visible');
+
+    assignTicket(10);
+    assertFormReset();
+
+    assertDashboardCustomerCount(1);
+  });
+
 });
 
 function searchCustomer(customerId: number) {
   cy.byTestId('customerIdInput').clear();
+  // guard against a race where the form's async reset (after the previous search) overwrites
+  // the field right after clear() - retry until it's genuinely empty before typing into it
+  cy.byTestId('customerIdInput').should('have.value', '');
   cy.byTestId('customerIdInput').type(customerId.toString());
   cy.byTestId('showCustomerButton').click();
   cy.byTestId('customerDetailPanel').should('be.visible');

--- a/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Customer Above Limit', () => {
 
   beforeEach(() => {
@@ -12,6 +14,7 @@ describe('Customer Above Limit', () => {
 
       cy.contains('[testid^="abovelimit-id-"]', customer.id!.toString())
         .closest('tr')
+        .scrollIntoView()
         .within(() => {
           cy.get('[testid^="abovelimit-name-"]').should('contain.text', customer.lastname).and('contain.text', customer.firstname);
           cy.get('[testid^="abovelimit-address-"]').should('contain.text', customer.address.city);
@@ -22,7 +25,51 @@ describe('Customer Above Limit', () => {
             .invoke('text')
             .should('not.be.empty');
 
+          // the table row and the equivalent card (below md:) both render a button with this
+          // testid - .closest('tr') above already scopes this to the (visible) table row's copy
           cy.get('[testid^="abovelimit-showcustomer-button-"]').click();
+        });
+
+      cy.url().should('include', '/kunden/detail/' + customer.id);
+    });
+  });
+
+  it('renders the card list on phone and still links to the customer detail page', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    cy.createDummyCustomer(50000, true).then((response) => {
+      const customer = response.body.data;
+
+      cy.visit('/#/kunden/ueber-limit');
+
+      // below md: the table is hidden and the card list is shown instead
+      cy.get('[testid^="abovelimit-id-"]').should('exist').and('not.be.visible');
+
+      cy.contains('mat-card', customer.lastname)
+        .scrollIntoView()
+        .should('be.visible')
+        .within(() => {
+          // the table row and the card both render a button with this testid - filter to the
+          // one that's actually displayed in this (card) branch
+          cy.get('[testid^="abovelimit-showcustomer-button-"]').filterDisplayed().should('have.length', 1).click();
+        });
+
+      cy.url().should('include', '/kunden/detail/' + customer.id);
+    });
+  });
+
+  it('renders the desktop-style table at tablet breakpoint and still links to the customer detail page', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.createDummyCustomer(50000, true).then((response) => {
+      const customer = response.body.data;
+
+      cy.visit('/#/kunden/ueber-limit');
+
+      cy.contains('[testid^="abovelimit-id-"]', customer.id!.toString())
+        .closest('tr')
+        .within(() => {
+          cy.get('[testid^="abovelimit-showcustomer-button-"]').filterDisplayed().should('have.length', 1).click();
         });
 
       cy.url().should('include', '/kunden/detail/' + customer.id);

--- a/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
@@ -1,5 +1,6 @@
 import {CustomerAddPersonData, Gender} from '../support/commands';
 import dayjs from 'dayjs';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Customer Creation', () => {
 
@@ -43,6 +44,16 @@ describe('Customer Creation', () => {
       .should('contain.text', 'Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet');
 
     cy.url().should('include', '/kunden/detail');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.reload();
+
+      cy.byTestId('lastnameInput').should('be.visible').type('Mustermann');
+      cy.byTestId('save-button').should('exist');
+    });
   });
 
   describe('Supervisor', () => {

--- a/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 dayjs.extend(customParseFormat);
 
@@ -114,6 +115,59 @@ describe('Customer Detail', () => {
 
     cy.byTestId('latest-customer-note').should('not.exist');
     cy.byTestId('latest-customer-note-none').should('be.visible');
+  });
+
+  it('renders responsively on phone (content before actions) and still allows locking/unlocking', () => {
+    cy.viewport(PHONE_VIEWPORT);
+    cy.visit('/#/kunden/detail/101');
+
+    cy.byTestId('customerIdText').should('be.visible');
+    cy.byTestId('latest-customer-note').scrollIntoView().should('be.visible');
+    cy.byTestId('editCustomerButton').scrollIntoView().should('be.visible');
+
+    // below lg: the outer section reverses (flex-col-reverse), so the data tabs render
+    // above the action buttons instead of below them
+    cy.byTestId('customerIdText').then(($content) => {
+      const contentTop = $content[0].getBoundingClientRect().top;
+      cy.byTestId('editCustomerButton').then(($actionButton) => {
+        expect(contentTop).to.be.lessThan($actionButton[0].getBoundingClientRect().top);
+      });
+    });
+
+    cy.byTestId('lock-info-banner').should('not.exist');
+
+    openEditMenu();
+    cy.byTestId('lockCustomerButton').click();
+    cy.byTestId('lockreason-input-text').type('dummy lockreason');
+    cy.byTestId('lock-customer-dialog').within(() => {
+      cy.byTestId('okButton').click();
+    });
+
+    cy.byTestId('lock-info-banner').should('exist');
+
+    openEditMenu();
+    cy.byTestId('unlockCustomerButton').click();
+
+    cy.byTestId('lock-info-banner').should('not.exist');
+  });
+
+  it('renders correctly at tablet breakpoint and still allows prolonging', () => {
+    cy.viewport(TABLET_VIEWPORT);
+    cy.visit('/#/kunden/detail/100');
+
+    cy.byTestId('customerIdText').should('be.visible');
+    cy.byTestId('latest-customer-note-none').should('be.visible');
+
+    let validDateString;
+    cy.byTestId('validUntilText').then(($value) => {
+      validDateString = $value.text();
+      const expectedValidDate = dayjs(validDateString, 'DD.MM.YYYY').add(1, 'months').endOf('day').format('DD.MM.YYYY');
+
+      cy.byTestId('prolongButton').click();
+      cy.byTestId('prolongOneMonthButton').click();
+
+      cy.byTestId('validUntilText').should('have.text', expectedValidDate);
+    });
   });
 
   it('ticket section not visible when no distribution is active', () => {

--- a/frontend/src/main/webapp/cypress/e2e/customer-duplicates.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-duplicates.cy.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import {CustomerData, Gender} from '../support/commands';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Customer Duplicates', () => {
 
@@ -66,6 +67,59 @@ describe('Customer Duplicates', () => {
 
       cy.visit('/#/kunden/detail/' + customer1.id);
       cy.url().should('include', '/kunden/detail/' + customer1.id);
+    });
+  });
+
+  it('stacks a duplicate pair into a single column on phone and deletion still works', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    createDuplicateCustomerPair().then(({first, second}) => {
+      const customer1 = first.body.data;
+      const customer2 = second.body.data;
+
+      cy.visit('/#/kunden/duplikate');
+
+      cy.byTestId('duplicate-customer-' + customer1.id).scrollIntoView().should('be.visible');
+      cy.byTestId('duplicate-customer-' + customer2.id).scrollIntoView().should('be.visible');
+
+      // below md: the pair grid collapses to a single column, so the cards stack on separate rows
+      // instead of sitting side by side (API/render order between the two isn't guaranteed, so
+      // just assert they're not on the same row rather than assuming which one comes first)
+      cy.byTestId('duplicate-customer-' + customer1.id).then(($first) => {
+        const firstTop = $first[0].getBoundingClientRect().top;
+        cy.byTestId('duplicate-customer-' + customer2.id).then(($second) => {
+          expect($second[0].getBoundingClientRect().top).to.not.equal(firstTop);
+        });
+      });
+
+      cy.byTestId('duplicate-delete-button-' + customer2.id).click();
+
+      cy.get('.toast-message').should('be.visible').and('contain.text', 'Kunde wurde gelöscht!');
+      cy.byTestId('duplicate-customer-' + customer2.id).should('not.exist');
+    });
+  });
+
+  it('renders a duplicate pair side-by-side at tablet breakpoint and merge still works', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    createDuplicateCustomerPair().then(({first, second}) => {
+      const customer1 = first.body.data;
+      const customer2 = second.body.data;
+
+      cy.visit('/#/kunden/duplikate');
+
+      // at md: (768px) the pair grid becomes 2 columns, so both cards start at the same row position
+      cy.byTestId('duplicate-customer-' + customer1.id).then(($first) => {
+        const firstTop = $first[0].getBoundingClientRect().top;
+        cy.byTestId('duplicate-customer-' + customer2.id).then(($second) => {
+          expect($second[0].getBoundingClientRect().top).to.eq(firstTop);
+        });
+      });
+
+      cy.byTestId('duplicate-merge-button-' + customer1.id).click();
+
+      cy.get('.toast-message').should('be.visible').and('contain.text', 'Kunde(n) wurden gelöscht');
+      cy.byTestId('duplicate-customer-' + customer2.id).should('not.exist');
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Customer Edit', () => {
 
   beforeEach(() => {
@@ -88,6 +90,20 @@ describe('Customer Edit', () => {
         .should('contain.text', 'Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet');
 
       cy.url().should('contain', '/kunden/detail/' + customerId);
+    });
+  });
+
+  it('remains usable on mobile viewports', () => {
+    cy.createDummyCustomer().then((response) => {
+      const customerId = response.body.data.id;
+
+      [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+        cy.viewport(viewport);
+        cy.visit('/#/kunden/bearbeiten/' + customerId);
+
+        cy.byTestId('lastnameInput').should('be.visible');
+        cy.byTestId('save-button').should('be.enabled');
+      });
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Customer Search', () => {
 
   beforeEach(() => {
@@ -49,15 +51,46 @@ describe('Customer Search', () => {
     clickSearchAndOpenFirstResult(100);
   });
 
-  function clickSearchAndOpenFirstResult(expectedCustomerId: number) {
-    cy.byTestId('search-button').click();
+  it('search result renders as a card list on phone and search still works', () => {
+    cy.viewport(PHONE_VIEWPORT);
 
-    cy.byTestId('searchresult-table').should('be.visible');
+    cy.createDummyCustomer().then((response) => {
+      const customer = response.body.data;
+
+      cy.byTestId('lastnameText').type(customer.lastname);
+      cy.byTestId('search-button').click();
+
+      // below md: the table row is hidden and the card list is shown instead
+      cy.byTestId('searchresult-row').should('exist').and('not.be.visible');
+
+      clickSearchAndOpenFirstResult(customer.id!, true);
+    });
+  });
+
+  it('search result renders as a table at tablet breakpoint and search still works', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.createDummyCustomer().then((response) => {
+      const customer = response.body.data;
+
+      cy.byTestId('lastnameText').type(customer.lastname);
+      clickSearchAndOpenFirstResult(customer.id!);
+    });
+  });
+
+  function clickSearchAndOpenFirstResult(expectedCustomerId: number, alreadySearched = false) {
+    if (!alreadySearched) {
+      cy.byTestId('search-button').click();
+    }
+
+    cy.byTestId('searchresult-table').scrollIntoView().should('be.visible');
     cy.byTestId('searchresult-row').should('have.length', 1);
 
-    cy.byTestId('searchresult-showcustomer-button-0').first().should('be.visible');
+    // the table and card list both render a button with this testid (one per branch, only one
+    // of which is displayed per viewport - see 'hidden md:block' / 'block md:hidden' in the template)
+    cy.byTestId('searchresult-showcustomer-button-0').filterDisplayed().should('have.length', 1);
 
-    cy.byTestId('searchresult-showcustomer-button-0').first().click();
+    cy.byTestId('searchresult-showcustomer-button-0').filterDisplayed().click();
     cy.url().should('include', '/kunden/detail/' + expectedCustomerId);
   }
 

--- a/frontend/src/main/webapp/cypress/e2e/dashboard.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/dashboard.cy.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import dayjs from 'dayjs';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Dashboard', () => {
 
@@ -67,6 +68,54 @@ describe('Dashboard', () => {
       .should((buffer: string | any[]) => expect(buffer.length).to.be.gt(5000));
 
     // --> CLOSED
+    cy.closeDistribution();
+  });
+
+  it('dashboard content and actions usable on phone', () => {
+    // Both grids collapse to a single column below the lg: (1024px) breakpoint - same
+    // arrangement as tablet, but still worth verifying the mobile nav chrome doesn't break it.
+    cy.viewport(PHONE_VIEWPORT);
+
+    cy.byTestId('distribution-state-text').should('have.text', 'Geschlossen');
+
+    cy.byTestId('distribution-start-button').click();
+    cy.byTestId('distribution-state-text').should('have.text', 'Geöffnet');
+
+    cy.byTestId('distribution-statistics-employee-count-input').type('100');
+    cy.byTestId('distribution-statistics-save-button').click();
+
+    cy.byTestId('distribution-notes-textarea').type('Test note - everything went well!');
+    cy.byTestId('distribution-notes-save-button').click();
+
+    // check if data is filled after reload
+    cy.reload();
+    cy.byTestId('distribution-statistics-employee-count-input')
+      .find('input')
+      .should('have.value', '100');
+    cy.byTestId('distribution-notes-textarea').should('have.value', 'Test note - everything went well!');
+
+    cy.closeDistribution();
+  });
+
+  it('dashboard content renders and download works at tablet breakpoint', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.byTestId('distribution-state-text').should('have.text', 'Geschlossen');
+    cy.byTestId('download-customerlist-button').should('not.exist');
+
+    cy.createDistribution();
+
+    const downloadCustomerListButton = cy.byTestId('download-customerlist-button');
+    downloadCustomerListButton.should('be.visible');
+    downloadCustomerListButton.click();
+
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    const formattedDate = dayjs().format('DD.MM.YYYY');
+    const downloadedFilename = path.join(downloadsFolder, `kundenliste-ausgabe-${formattedDate}.pdf`);
+
+    cy.readFile(downloadedFilename, 'binary', {timeout: 15000})
+      .should((buffer: string | any[]) => expect(buffer.length).to.be.gt(5000));
+
     cy.closeDistribution();
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Food Collection Recording', () => {
   beforeEach(() => {
     cy.loginDefault();
@@ -10,7 +12,7 @@ describe('Food Collection Recording', () => {
   });
 
   it('food collection recorded properly on desktop', () => {
-    cy.viewport(1920, 1080);
+    // Uses the global 1024x768 desktop baseline from cypress.config.ts.
 
     cy.getAnyRandomNumber().then((randomNumber) => {
       enterRouteData();
@@ -45,7 +47,10 @@ describe('Food Collection Recording', () => {
   });
 
   it('food collection recorded properly on responsive layouts', () => {
-    cy.viewport('iphone-7');
+    cy.viewport(PHONE_VIEWPORT);
+    // give the layout a moment to settle after the resize before the first interaction -
+    // otherwise a resize-triggered re-render can detach routeInput mid-click under load
+    cy.byTestId('routeInput').should('be.visible');
 
     cy.getAnyRandomNumber().then((randomNumber) => {
       enterRouteData();
@@ -65,11 +70,18 @@ describe('Food Collection Recording', () => {
 
       cy.byTestId('select-items-tab').click();
 
+      // the item-patch queue sends autosave requests sequentially, one per value change - alias
+      // it so the reload below can wait for every queued patch to land instead of racing them
+      cy.intercept('PATCH', '**/food-collections/route/*/items').as('patchItem');
+
       cy.byTestId('category-1-input').type('12');
       cy.byTestId('category-2-increment-button').click();
       cy.byTestId('category-2-increment-button').click();
       cy.byTestId('category-2-increment-button').click();
       cy.byTestId('category-2-decrement-button').click();
+
+      // category-1's two keystrokes ('1' then '12') plus category-2's 3 increments + 1 decrement
+      cy.wait(new Array(6).fill('@patchItem'));
 
       // validate auto-save on input change
       cy.reload();
@@ -98,6 +110,34 @@ describe('Food Collection Recording', () => {
 
       cy.byTestId('previous-shop-button').click();
       cy.byTestId('shop-title').should('have.text', '20 - Lidl');
+    });
+  });
+
+  it('food collection recording shows the desktop-style item grid at tablet breakpoint', () => {
+    // At the tablet width the sidenav is already in mobile ("over") mode, but page content
+    // switches to the desktop item grid at the app's md: (768px) breakpoint - verify both hold.
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.getAnyRandomNumber().then((randomNumber) => {
+      enterRouteData();
+      selectDriver();
+      createAndSelectCoDriver(randomNumber);
+      selectExistingCoDriver();
+
+      cy.byTestId('save-routedata-button').click();
+
+      cy.byTestId('km-diff-dialog')
+        .should('be.visible')
+        .within(() => {
+          cy.byTestId('ok-button').click();
+        });
+
+      assertSavedToast();
+
+      cy.byTestId('select-items-tab').click();
+      cy.byTestId('category-1-shop-20-input').should('be.visible').clear().type('12');
+      cy.byTestId('save-items-button').click();
+      assertSavedToast();
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/general.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('General', () => {
 
   beforeEach(() => {
@@ -30,6 +32,16 @@ describe('General', () => {
     cy.byTestId('subtitle').should('have.text', 'Interner Server Fehler');
 
     cy.url().should('include', '/500');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.visit('/#/invalidpath');
+
+      cy.byTestId('status').should('be.visible').and('have.text', '404');
+      cy.byTestId('title').should('be.visible').and('have.text', 'Seite nicht gefunden');
+    });
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/login.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/login.cy.ts
@@ -1,4 +1,5 @@
 import {UserData} from '../support/commands';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Login', () => {
 
@@ -132,6 +133,28 @@ describe('Login', () => {
       cy.url().should('contain', '/login/fehlgeschlagen');
       cy.byTestId('errorMessage').should('exist').and('contain.text', 'Zugriff nicht erlaubt');
     });
+  });
+
+  it('remains usable on a phone viewport', () => {
+    cy.viewport(PHONE_VIEWPORT);
+    cy.visit('/#/login');
+
+    cy.byTestId('username').should('be.visible').type('e2etest');
+    cy.byTestId('password').should('be.visible').type('e2etest');
+    cy.byTestId('loginButton').should('be.enabled').click();
+
+    cy.url().should('contain', '/uebersicht');
+  });
+
+  it('remains usable on a tablet viewport', () => {
+    cy.viewport(TABLET_VIEWPORT);
+    cy.visit('/#/login');
+
+    cy.byTestId('username').should('be.visible').type('e2etest');
+    cy.byTestId('password').should('be.visible').type('e2etest');
+    cy.byTestId('loginButton').should('be.enabled').click();
+
+    cy.url().should('contain', '/uebersicht');
   });
 
   function createTestUser(permissions: { key: string; title: string }[] = []) {

--- a/frontend/src/main/webapp/cypress/e2e/logout.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/logout.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Logout', () => {
 
   beforeEach(() => {
@@ -6,6 +8,26 @@ describe('Logout', () => {
   });
 
   it('logout working as expected', () => {
+    cy.byTestId('usermenu').click();
+    cy.byTestId('usermenu-logout').click();
+
+    cy.url().should('include', '/login');
+  });
+
+  it('remains usable on a phone viewport', () => {
+    cy.viewport(PHONE_VIEWPORT);
+    cy.visit('/#');
+
+    cy.byTestId('usermenu').click();
+    cy.byTestId('usermenu-logout').click();
+
+    cy.url().should('include', '/login');
+  });
+
+  it('remains usable on a tablet viewport', () => {
+    cy.viewport(TABLET_VIEWPORT);
+    cy.visit('/#');
+
     cy.byTestId('usermenu').click();
     cy.byTestId('usermenu-logout').click();
 

--- a/frontend/src/main/webapp/cypress/e2e/passwordchange.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/passwordchange.cy.ts
@@ -1,5 +1,6 @@
 import {recurse} from 'cypress-recurse';
 import {UserData} from '../support/commands';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('PasswordChange', () => {
 
@@ -41,6 +42,21 @@ describe('PasswordChange', () => {
 
     // Verify the error message is gone
     cy.byTestId('newRepeatedPasswordText-error').should('not.exist');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.reload();
+
+      cy.byTestId('usermenu').click();
+      cy.byTestId('usermenu-changepassword').click();
+
+      cy.byTestId('currentPasswordText').should('be.visible');
+      cy.byTestId('newPasswordText').should('be.visible');
+      cy.byTestId('newRepeatedPasswordText').should('be.visible');
+      cy.byTestId('saveButton').should('exist');
+    });
   });
 
   it('change password', () => {

--- a/frontend/src/main/webapp/cypress/e2e/scanner.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/scanner.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Scanner', () => {
 
   beforeEach(() => {
@@ -32,6 +34,16 @@ describe('Scanner', () => {
     cy.byTestId('message', {timeout: 20000}).should('contain.text', 'Letzter Scan: 12345');
 
     cy.wait('@scanResult', {timeout: 20000}).its('request.url').should('include', 'scanResult=12345');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.visit('/#/anmeldung/scanner');
+
+      cy.byTestId('scanner-id').should('be.visible');
+      cy.byTestId('state-camera', {timeout: 20000}).should('have.text', 'Bereit');
+    });
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/settings-food-categories.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-food-categories.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Settings - Food Categories', () => {
 
   beforeEach(() => {
@@ -88,6 +90,16 @@ describe('Settings - Food Categories', () => {
     cy.byTestId('enableFoodCategoryButton').first().click();
     cy.get('.toast-message')
       .should('be.visible');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.reload();
+
+      cy.byTestId('food-categories-table').should('exist');
+      cy.byTestId('addFoodCategoryButton').should('be.visible');
+    });
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/settings-mail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-mail.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Dashboard', () => {
 
   beforeEach(() => {
@@ -37,5 +39,72 @@ describe('Dashboard', () => {
     cy.byTestId('remove-recipient-button-STATISTICS-CC-0').click();
     cy.byTestId('save-button').click();
   });
+
+  it('recipients stack in a single column with dividers and the add/save flow works on phone', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    cy.byTestId('mailtype-tab-DAILY_REPORT').click();
+
+    // below the md: breakpoint the recipient groups render in a single column with a divider between them
+    // (scoped to the active tab body - other tabs stay mounted off-screen for animation purposes)
+    cy.get('.mat-mdc-tab-body-active hr').should('be.visible');
+
+    cy.intercept('POST', '/api/settings/mail-recipients').as('saveRecipients');
+    cy.intercept('GET', '/api/settings/mail-recipients').as('loadRecipients');
+
+    addRecipientSaveAndAssertPersisted('DAILY_REPORT', 'CC', 'phone-cc@email.com');
+  });
+
+  it('recipients render in a multi-column grid without dividers at tablet width', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.byTestId('mailtype-tab-RETURN_BOXES').click();
+
+    // at/above the md: breakpoint recipients render in a 3-column grid, so no divider is needed
+    cy.get('.mat-mdc-tab-body-active hr').should('not.be.visible');
+
+    addAndRemoveRecipient('RETURN_BOXES', 'CC', 'tablet-cc@email.com');
+  });
+
+  // Recipient counts per mail type/recipient type are seeded/mutated data, not fixed indices, so
+  // resolve the index dynamically instead of assuming a fixed testid suffix like '-0'.
+  function addAndRemoveRecipient(mailType: string, recipientType: string, email: string) {
+    const inputSelector = `[testid^="email-input-${mailType}-${recipientType}-"]`;
+
+    cy.get('body').then($body => {
+      const countBefore = $body.find(inputSelector).length;
+
+      cy.byTestId(`add-recipient-button-${mailType}-${recipientType}`).click();
+      cy.get(inputSelector).should('have.length', countBefore + 1);
+      cy.get(inputSelector).eq(countBefore).clear().type(email);
+      cy.get(inputSelector).eq(countBefore).should('have.value', email);
+
+      cy.byTestId(`remove-recipient-button-${mailType}-${recipientType}-${countBefore}`).click();
+      cy.get(inputSelector).should('have.length', countBefore);
+    });
+  }
+
+  function addRecipientSaveAndAssertPersisted(mailType: string, recipientType: string, email: string) {
+    const inputSelector = `[testid^="email-input-${mailType}-${recipientType}-"]`;
+
+    cy.get('body').then($body => {
+      const countBefore = $body.find(inputSelector).length;
+
+      cy.byTestId(`add-recipient-button-${mailType}-${recipientType}`).click();
+      cy.get(inputSelector).eq(countBefore).clear().type(email);
+
+      cy.byTestId('save-button').click();
+      cy.wait('@saveRecipients').its('response.statusCode').should('eq', 200);
+
+      cy.reload();
+      cy.wait('@loadRecipients');
+      cy.byTestId(`mailtype-tab-${mailType}`).click();
+      cy.get(inputSelector).eq(countBefore).should('have.value', email);
+
+      // Reset
+      cy.byTestId(`remove-recipient-button-${mailType}-${recipientType}-${countBefore}`).click();
+      cy.byTestId('save-button').click();
+    });
+  }
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/settings-shelters.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-shelters.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Settings - Shelters', () => {
 
   beforeEach(() => {
@@ -69,6 +71,16 @@ describe('Settings - Shelters', () => {
     cy.contains('Speichern').click();
     // Ensure dialog still open (save did not close because of validation)
     cy.get('input[formControlName="name"]').should('have.class', 'ng-invalid');
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.reload();
+
+      cy.byTestId('shelters-table').should('exist');
+      cy.byTestId('addShelterButton').should('be.visible');
+    });
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/settings-static-values.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-static-values.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('Settings - Static Values', () => {
 
   beforeEach(() => {
@@ -61,6 +63,16 @@ describe('Settings - Static Values', () => {
       cy.byTestId('staticValueAmountInput-0').clear().type('999999{esc}');
 
       cy.byTestId('static-values-row-0').should('have.text', originalText);
+    });
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.reload();
+
+      cy.byTestId('static-values-table').should('exist');
+      cy.byTestId('editStaticValueButton-0').scrollIntoView().should('be.visible');
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/statistics-general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/statistics-general.cy.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import dayjs from 'dayjs';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Statistics General', () => {
 
@@ -17,8 +18,8 @@ describe('Statistics General', () => {
     cy.contains(`Zeitraum: ${from} - ${to}`).should('be.visible');
 
     cy.contains('Kunden und Personen').should('be.visible');
-    cy.contains('Notschlafstellen').should('be.visible');
-    cy.contains('Transport- / Logistik').should('be.visible');
+    cy.contains('Notschlafstellen').scrollIntoView().should('be.visible');
+    cy.contains('Transport- / Logistik').scrollIntoView().should('be.visible');
   });
 
   it('switches to current month mode and updates the shown range', () => {
@@ -71,6 +72,36 @@ describe('Statistics General', () => {
 
     cy.readFile(downloadedFilename, 'binary', {timeout: 15000})
       .should((buffer: string | any[]) => expect(buffer.length).to.be.gt(0));
+  });
+
+  it('switches to a custom date range and updates the shown range on phone', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    // below the sm: breakpoint the date range card and the "von"/"bis" label+input pairs stack in a single column
+    cy.byTestId('dateRangeModeInput').contains('Benutzerdefiniert').click();
+
+    cy.intercept('GET', '/api/statistics/data?fromDate=2024-01-01&toDate=2024-06-30').as('customRangeData');
+
+    cy.byTestId('dataRangeFromInput').should('be.visible').clear().type('2024-01-01');
+    cy.byTestId('dataRangeToInput').should('be.visible').clear().type('2024-06-30');
+
+    cy.wait('@customRangeData');
+    cy.contains('Zeitraum: 01.01.2024 - 30.06.2024').should('be.visible');
+
+    cy.contains('Kunden und Personen').should('be.visible');
+    cy.contains('Notschlafstellen').scrollIntoView().should('be.visible');
+    cy.contains('Transport- / Logistik').scrollIntoView().should('be.visible');
+  });
+
+  it('shows the statistic and export cards and the aggregated data at tablet width', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    // at the md: breakpoint the statistic card (col-span-3) and export card (col-span-1) sit side by side
+    const currentYear = dayjs().year();
+    cy.byTestId('yearInput').should('be.visible').and('contain.text', currentYear.toString());
+    cy.contains('CSV-Export').should('be.visible');
+
+    cy.contains('Kunden und Personen').should('be.visible');
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/statistics-school-starter-packages.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/statistics-school-starter-packages.cy.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import dayjs from 'dayjs';
 import {CustomerData, Gender} from '../support/commands';
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 
 describe('Statistics School Starter Packages', () => {
 
@@ -64,6 +65,35 @@ describe('Statistics School Starter Packages', () => {
 
     cy.readFile(downloadedFilename, 'binary', {timeout: 15000})
       .should((buffer: string | any[]) => expect(buffer.length).to.be.gt(0));
+  });
+
+  // This page has no page-specific responsive Tailwind classes - the only viewport-dependent
+  // behavior is the paginator centering below the 768px breakpoint (tafel-paginator-responsive,
+  // see mat-paginator.scss). Just confirm the page renders and the paginator stays usable.
+  it('page loads and the paginator is usable on phone', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    createCustomerWithChildAge(8).then(() => {
+      cy.visit('/#/statistiken/schulstartpakete');
+
+      cy.byTestId('schoolStarterPackageAgeMinInput').should('be.visible');
+      cy.byTestId('school-starter-package-table').should('be.visible');
+      cy.get('.tafel-paginator-responsive').should('have.length', 2);
+      cy.get('.tafel-paginator-responsive').first().should('be.visible');
+    });
+  });
+
+  it('page loads and the paginator is usable on tablet', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    createCustomerWithChildAge(8).then(() => {
+      cy.visit('/#/statistiken/schulstartpakete');
+
+      cy.byTestId('schoolStarterPackageAgeMinInput').should('be.visible');
+      cy.byTestId('school-starter-package-table').should('be.visible');
+      cy.get('.tafel-paginator-responsive').should('have.length', 2);
+      cy.get('.tafel-paginator-responsive').first().should('be.visible');
+    });
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/ticket-screen.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/ticket-screen.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('TicketScreen', () => {
 
   beforeEach(() => {
@@ -28,6 +30,17 @@ describe('TicketScreen', () => {
     cy.get('@open').should('be.called');
     cy.byTestId('title').should('have.text', 'Ticket');
     cy.url().should('eq', Cypress.config().baseUrl + '#/anmeldung/ticketmonitor');
+  });
+
+  it('fullscreen kiosk display still loads at phone and tablet sizes', () => {
+    // No responsive markup on this page - just a smoke check that it still renders at
+    // the smaller viewports rather than exercising its layout in detail.
+    for (const viewport of [PHONE_VIEWPORT, TABLET_VIEWPORT]) {
+      cy.viewport(viewport);
+      cy.visit('/#/anmeldung/ticketmonitor');
+      cy.byTestId('title').should('exist');
+      cy.byTestId('text').should('exist');
+    }
   });
 
   describe('with distribution and tickets', () => {
@@ -74,6 +87,35 @@ describe('TicketScreen', () => {
 
       cy.byTestId('costcontribution-paid-yes-button').click();
       cy.byTestId('costcontribution-paid-yes-button').click();
+      assertTicketText('3');
+    });
+
+    it('tickets switched successfully on phone', () => {
+      // Below lg: (1024px) the control form and live-view preview stack into a single
+      // column, and below sm: (640px) the paid/not-paid buttons stack too - verify the flow
+      // still works fully stacked.
+      cy.viewport(PHONE_VIEWPORT);
+
+      cy.byTestId('show-currentticket-button').click();
+      assertTicketText('1');
+
+      cy.byTestId('costcontribution-paid-yes-button').click();
+      assertTicketText('2');
+    });
+
+    it('tickets switched successfully at tablet breakpoint (sm: button row)', () => {
+      // At 768px the sidenav is still in mobile ("over") mode and the lg: grid is still
+      // single-column, but the sm: paid/not-paid button row is already side-by-side - verify
+      // that combination renders and the flow still works.
+      cy.viewport(TABLET_VIEWPORT);
+
+      cy.byTestId('show-currentticket-button').click();
+      assertTicketText('1');
+
+      cy.byTestId('costcontribution-paid-yes-button').click();
+      assertTicketText('2');
+
+      cy.byTestId('costcontribution-paid-no-button').click();
       assertTicketText('3');
     });
 

--- a/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('User Create', () => {
 
   beforeEach(() => {
@@ -52,6 +54,16 @@ describe('User Create', () => {
       cy.get('.toast-message')
         .should('be.visible')
         .should('contain.text', 'Benutzer (Benutzername: e2etest) existiert bereits!');
+    });
+  });
+
+  it('remains usable on mobile viewports', () => {
+    [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+      cy.viewport(viewport);
+      cy.visit('/#/benutzer/erstellen');
+
+      cy.byTestId('usernameInput').should('be.visible').type('mobile-test-user');
+      cy.byTestId('save-button').should('exist');
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/user-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-detail.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('User Detail', () => {
 
   beforeEach(() => {
@@ -48,6 +50,34 @@ describe('User Detail', () => {
       cy.visit('/#/benutzer/detail/' + userId);
       cy.url().should('include', '/benutzer/suchen');
     });
+  });
+
+  it('disable and re-enable user on phone', () => {
+    cy.viewport(PHONE_VIEWPORT);
+    cy.visit('/#/benutzer/detail/300');
+
+    // action buttons and the details card stack (flex-col, buttons on top) below the lg: breakpoint
+    cy.byTestId('editUserButton').should('be.visible');
+    cy.byTestId('enabledText').should('have.text', 'Ja');
+
+    cy.byTestId('changeUserStateButton').click();
+    cy.byTestId('disableUserButton').click();
+
+    cy.byTestId('enabledText').should('have.text', 'Nein');
+
+    cy.byTestId('changeUserStateButton').click();
+    cy.byTestId('enableUserButton').click();
+
+    cy.byTestId('enabledText').should('have.text', 'Ja');
+  });
+
+  it('shows the stacked action/details layout at tablet width', () => {
+    cy.viewport(TABLET_VIEWPORT);
+    cy.visit('/#/benutzer/detail/300');
+
+    cy.byTestId('usernameText').should('have.text', 'admin');
+    cy.byTestId('editUserButton').should('be.visible');
+    cy.byTestId('changeUserStateButton').should('be.visible');
   });
 
 });

--- a/frontend/src/main/webapp/cypress/e2e/user-edit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-edit.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('User Edit', () => {
 
   beforeEach(() => {
@@ -27,6 +29,20 @@ describe('User Edit', () => {
 
       cy.byTestId('permissionsText').should('contain.text', 'Anmeldung');
       cy.byTestId('nameText').should('contain.text', 'updated');
+    });
+  });
+
+  it('remains usable on mobile viewports', () => {
+    cy.createDummyUser().then((response) => {
+      const user = response.body;
+
+      [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
+        cy.viewport(viewport);
+        cy.visit('/#/benutzer/bearbeiten/' + user.id);
+
+        cy.byTestId('firstnameInput').should('be.visible').and('have.value', user.firstname);
+        cy.byTestId('save-button').should('exist');
+      });
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/user-search.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-search.cy.ts
@@ -1,3 +1,5 @@
+import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
+
 describe('User Search', () => {
 
   beforeEach(() => {
@@ -44,16 +46,57 @@ describe('User Search', () => {
     });
   });
 
-  function clickSearchAndOpenFirstResult(expectedUserId: number) {
+  it('search result renders as cards and the search flow works on phone', () => {
+    cy.viewport(PHONE_VIEWPORT);
+
+    cy.createDummyUser().then(response => {
+      const user = response.body;
+
+      cy.byTestId('lastnameText').type(user.lastname);
+      search();
+
+      // desktop table branch stays in the DOM but is hidden below the md: breakpoint
+      cy.byTestId('searchresult-table').should('not.be.visible');
+
+      openFirstResult(user.id!);
+    });
+  });
+
+  it('search result renders as a table and the search flow works on tablet', () => {
+    cy.viewport(TABLET_VIEWPORT);
+
+    cy.createDummyUser().then(response => {
+      const user = response.body;
+
+      cy.byTestId('lastnameText').type(user.lastname);
+      search();
+
+      cy.byTestId('searchresult-table').should('be.visible');
+      cy.byTestId('searchresult-row-0').should('be.visible');
+
+      openFirstResult(user.id!);
+    });
+  });
+
+  function search() {
     cy.byTestId('search-button').click();
+  }
+
+  // The show-user button testid is rendered once per responsive branch (table row + card),
+  // both always in the DOM - filter to the currently displayed one so this works at any viewport.
+  function openFirstResult(expectedUserId: number) {
+    cy.byTestId('searchresult-showuser-button-0').filterDisplayed().should('have.length', 1);
+    cy.byTestId('searchresult-showuser-button-0').filterDisplayed().click();
+    cy.url().should('include', '/benutzer/detail/' + expectedUserId);
+  }
+
+  function clickSearchAndOpenFirstResult(expectedUserId: number) {
+    search();
 
     cy.byTestId('searchresult-table').should('be.visible');
     cy.byTestId('searchresult-row-0').should('be.visible');
 
-    cy.byTestId('searchresult-showuser-button-0').first().should('be.visible');
-
-    cy.byTestId('searchresult-showuser-button-0').first().click();
-    cy.url().should('include', '/benutzer/detail/' + expectedUserId);
+    openFirstResult(expectedUserId);
   }
 
 });

--- a/frontend/src/main/webapp/cypress/support/commands.ts
+++ b/frontend/src/main/webapp/cypress/support/commands.ts
@@ -33,6 +33,17 @@ Cypress.Commands.add(
     cy.get(`[testid="${id}"]`, options)
 );
 
+// Some responsive pages render the same testid twice (once per Tailwind `hidden md:block` /
+// `block md:hidden` branch) so only one is ever CSS-displayed at a time. Cypress's `:visible`
+// filter isn't safe to disambiguate them with, because it also treats an element scrolled outside
+// a clipping ancestor (e.g. a horizontally-scrollable table on a narrow viewport) as "not visible" -
+// which would incorrectly filter out the real match before a click ever gets the chance to scroll it
+// into view. `offsetParent` is null only when the element (or an ancestor) is actually
+// `display: none`, regardless of scroll position, so it isolates the currently-active branch.
+Cypress.Commands.add('filterDisplayed', {prevSubject: true}, (subject) =>
+  cy.wrap((subject as JQuery).filter((_, el) => (el as HTMLElement).offsetParent !== null))
+);
+
 // The backend requires the X-XSRF-TOKEN header (mirroring the XSRF-TOKEN cookie) on every
 // mutating request. The Angular app handles this via its xsrfInterceptor - direct cy.request
 // calls need the header injected here.
@@ -154,10 +165,15 @@ Cypress.Commands.add('addCustomerToDistribution', (request: AddCustomerToDistrib
 });
 
 Cypress.Commands.add('closeDistribution', () => {
+  // Runs from afterEach, including after a failed test that may not have gotten far enough to
+  // leave the distribution in a state the statistics endpoint accepts. Tolerate that failure so
+  // the actual close call below still runs - otherwise the distribution is left stuck open and
+  // every later spec's createDistribution() fails with "Ausgabe bereits gestartet!".
   cy.request({
     method: 'POST',
     url: '/api/distributions/statistics',
-    body: {employeeCount: 100, selectedShelterIds: [1, 2]}
+    body: {employeeCount: 100, selectedShelterIds: [1, 2]},
+    failOnStatusCode: false
   });
 
   cy.request({

--- a/frontend/src/main/webapp/cypress/support/index.ts
+++ b/frontend/src/main/webapp/cypress/support/index.ts
@@ -49,6 +49,14 @@ declare global {
       ): Chainable<JQuery<HTMLElementTagNameMap[K]>>;
 
       /**
+       * Filters a previously-queried set down to elements that are currently CSS-displayed
+       * (offsetParent !== null), ignoring scroll-clipping - use to disambiguate a testid that
+       * appears in both a `hidden md:block` and a `block md:hidden` responsive branch.
+       * @example cy.byTestId('foo').filterDisplayed().click();
+       */
+      filterDisplayed(): Chainable<JQuery<HTMLElement>>;
+
+      /**
        * Custom command to create a distribution.
        * @example cy.createDistribution();
        */

--- a/frontend/src/main/webapp/cypress/support/viewports.ts
+++ b/frontend/src/main/webapp/cypress/support/viewports.ts
@@ -1,0 +1,9 @@
+// Shared viewport presets for responsive e2e coverage. The desktop baseline (1024x768) is
+// set globally in cypress.config.ts; these are for specs that additionally need to verify
+// behavior below the app's mobile breakpoint (max-width: 1023.98px, see MOBILE_BREAKPOINT
+// in default-layout.component.ts).
+export const PHONE_VIEWPORT: Cypress.ViewportPreset = 'iphone-7';
+
+// 768px wide - lands exactly on the app's Tailwind `md:` breakpoint used by several
+// pages' table/card layout switches, while still being below the 1024px desktop breakpoint.
+export const TABLET_VIEWPORT: Cypress.ViewportPreset = 'ipad-2';


### PR DESCRIPTION
## Summary
- Sets the shared cypress viewport baseline to **1024x768** (`cypress.config.ts`) — the smallest desktop resolution still used in production — applied automatically to every spec.
- Adds a shared `PHONE_VIEWPORT`/`TABLET_VIEWPORT` constant pair (`cypress/support/viewports.ts`, iphone-7 / ipad-2) for responsive coverage.
- 12 specs with genuine responsive markup (dashboard, checkin, ticket-screen, customer-detail/search/duplicates/above-limit, user-search/detail, settings-mail, statistics-general/school-starter-packages) get real phone+tablet tests that exercise the actual responsive layout differences (table↔card swaps, grid/flex reflow, breakpoint boundaries).
- 13 desktop-only specs get a lightweight mobile smoke check confirming they still work under the mobile nav chrome.
- New `cy.filterDisplayed()` custom command to correctly disambiguate a testid duplicated across a `hidden md:block` / `block md:hidden` responsive pair — Cypress's `:visible` filter turned out to be scroll-clipping-aware and gave false negatives for elements scrolled out of a horizontally-overflowing table.

### Bugs found & fixed while verifying end-to-end
Surfaced by the viewport shrink and heavier full-suite runs, not previously visible:
- Several existing assertions needed `.scrollIntoView()` since 1024x768 is shorter/narrower than the old 1280x1024 default.
- `closeDistribution()`'s afterEach could throw on a failed test and skip the actual close call, leaving a distribution stuck open and cascading failures into every later spec that creates one — now tolerant of that.
- A real autosave race in `food-collection-recording.cy.ts` (`cy.reload()` firing before all queued PATCH requests landed).
- A `.clear()` vs async form-reset race in `checkin.cy.ts`.

Closes #2839

## Test plan
- [x] `npx tsc --noEmit -p cypress/tsconfig.json` — clean
- [x] `npm run lint` — clean
- [x] Full suite run against a freshly-seeded `e2e` profile backend: **25/25 specs, 153/153 tests passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)