### PR TITLE
fix: dialog title contrast, category rename & sonar suppression

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DistributionClosedEventListener.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DistributionClosedEventListener.kt
@@ -203,7 +203,7 @@ class DistributionClosedEventListener(
                 val returnBoxes = uniqueReturnCategories.mapNotNull { category ->
                     val amount = distribution.foodCollections.flatMap { it.items ?: emptyList() }
                         .filter { it.shop!!.id == shop.id }
-                        .filter { it.category?.id == category.id }
+                        .filter { it.category?.id == category.id } // NOSONAR kotlin:S6619
                         .sumOf { it.amount ?: 0 }
 
                     if (amount > 0) "${amount}x ${category.name}" else null

--- a/frontend/src/main/webapp/src/app/common/views/default-layout/navigation-menuItems.ts
+++ b/frontend/src/main/webapp/src/app/common/views/default-layout/navigation-menuItems.ts
@@ -150,7 +150,7 @@ export const navigationMenuItems: ITafelNavData[] = [
         url: '/einstellungen/statische-werte'
       },
       {
-        name: 'Lebensmittelkategorien',
+        name: 'Waren-Kategorien',
         url: '/einstellungen/lebensmittelkategorien'
       },
     ],

--- a/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.html
@@ -2,7 +2,7 @@
   <mat-card-header class="mb-2">
     <mat-card-title>
       <div class="flex items-center gap-2">
-        <h5 class="mb-0 mt-1">Lebensmittelkategorien</h5>
+        <h5 class="mb-0 mt-1">Waren-Kategorien</h5>
         <button matButton="filled" class="button-success" testid="addFoodCategoryButton" (click)="addFoodCategory()">
           <fa-icon [icon]="faPlus"></fa-icon>
         </button>

--- a/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.ts
@@ -75,7 +75,7 @@ export class SettingsFoodCategoriesComponent {
   private loadFoodCategories() {
     this.foodCategoriesApiService.getAllFoodCategories().subscribe({
       next: data => this._foodCategories.set(data),
-      error: () => this.toastr.error('Fehler beim Laden der Lebensmittelkategorien', 'Fehler')
+      error: () => this.toastr.error('Fehler beim Laden der Waren-Kategorien', 'Fehler')
     });
   }
 

--- a/frontend/src/main/webapp/src/scss/components/mat-dialog.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-dialog.scss
@@ -29,6 +29,7 @@
 .mat-mdc-dialog-title {
   padding: 0 !important;
   padding-left: 0.3rem !important;
+  color: #fff !important;
 }
 
 .mat-mdc-dialog-content {


### PR DESCRIPTION
## Summary
- Force white text on colored `tafel-dialog` titles — Angular Material's default subhead color was overriding the `text-white` utility, leaving poor contrast on colored headers
- Rename "Lebensmittelkategorien" to "Waren-Kategorien" across nav menu, page heading, and error toast
- Suppress a Sonar false positive (`kotlin:S6619`) on `it.category?.id` in `DistributionClosedEventListener` — same pattern already suppressed elsewhere in the codebase

## Test plan
- [ ] Verify dialog titles render white on all colored (warning/info/danger/success) headers
- [ ] Verify "Waren-Kategorien" appears correctly in nav, settings page, and error toast
- [ ] Confirm Sonar no longer flags the suppressed line