### PR TITLE
chore: add release and cleanup-branches skills

### DIFF
--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -1,0 +1,68 @@
+name: cleanup-branches
+description: Deletes every local git branch except `main`, `release` (and safely handles the currently checked-out branch if it's one of them). Use when the user wants to clean up, prune, or remove old/stale local branches in this repo.
+---
+
+Goal: end up with only `main` and `release` as local branches — delete everything else — without
+ever losing work that isn't safely recoverable (either from `origin` or from a merged/squash-merged
+PR record).
+
+## 1. See what's there
+
+```bash
+git fetch origin --prune
+git branch -vv
+```
+
+Every local branch except `main` and `release` is a deletion candidate, including the branch
+currently checked out — this repo squash-merges PRs (see CONTRIBUTING.md), so a finished feature
+branch is expected to still exist locally even after its PR is merged.
+
+## 2. Classify each candidate — don't force-delete blind
+
+For every candidate branch:
+
+- **Merged into `main` via a normal (non-squash) merge**: shows up in `git branch --merged main` →
+  safe, plain `git branch -d <branch>` works and is proof enough on its own.
+- **Squash-merged (the common case here)**: `git branch --merged` won't show these — the squash
+  commit isn't an ancestor of the original branch tip. Check GitHub instead:
+  ```bash
+  gh pr list --head <branch> --state all --json number,state,title
+  ```
+  A `MERGED` PR means it's safe to delete even though `git branch -d` will refuse (it can't see
+  the squash relationship) — use `git branch -D <branch>` for these specifically, since the PR
+  record is what makes the force safe, not the other way around.
+- **Open PR**: leave it alone and report it — the user may still be working on it.
+- **No PR record at all** (never pushed, or pushed then closed unmerged): don't guess. List it
+  separately and ask the user whether to keep or force-delete it — never silently force-delete a
+  branch with no merged-PR backing it.
+
+## 3. Handle the currently checked-out branch
+
+If it's a deletion candidate, switch away first — but check `git status` before doing so, and
+stash (`git stash -u`) any uncommitted work rather than discarding it:
+
+```bash
+git status
+git checkout main
+```
+
+Then classify it like any other candidate from step 2 before deleting it.
+
+## 4. Delete
+
+- Confirmed safe (merged, or squash-merged with a `MERGED` PR record): delete directly, no
+  per-branch prompt needed — but keep a running list of what you delete.
+- Anything else (open PR, no PR record, ambiguous): do not delete — hold it for the report.
+
+## 5. Report
+
+One summary:
+- Deleted: `<branch>` — merged / squash-merged via PR #N
+- Kept: `<branch>` — open PR #N / no PR record, needs your call / was the current branch and had
+  unstashed changes
+
+**Never:**
+- delete `main` or `release`
+- force-delete (`-D`) a branch without either a `MERGED` PR record from `gh` or explicit user
+  confirmation for that specific branch
+- discard uncommitted work to switch off the current branch — stash it first

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,71 @@
+name: release
+description: Prepares and triggers a production release by merging `main` into the `release` branch, which drives release.yml (build, test, sonar, lint, e2e, Docker images tagged `test`+`latest`+semver, GitHub release, deploy to test and prod). Use when the user wants to release, deploy, ship, or cut a new version of wrk-tafel/admin.
+---
+
+Goal: get everything currently on `main` out to production, with the correct semantic-version bump
+landing on the `release` branch's squash commit — then hand off for the user to merge. Merging is
+what actually triggers the prod deploy, so never do that without an explicit go-ahead in this
+conversation.
+
+## 1. Sync and see what would actually ship
+
+```bash
+git fetch origin main release
+git log origin/release..origin/main --oneline
+```
+
+If this is empty, tell the user `release` is already up to date with `main` and stop — there is
+nothing to release.
+
+## 2. Determine the version bump from Conventional Commit types
+
+`release.yml`'s `version` job (`paulhatch/semantic-version`) derives the next tag from the commit
+type of **the single squash commit that lands on `release`** — which is this PR's title, per
+CONTRIBUTING.md. So the PR title's type must reflect the highest-impact change being shipped:
+
+- Any commit with `!` after the type/scope, or a `BREAKING CHANGE:` footer → major → title gets
+  `!`, e.g. `feat!: ...` / `fix!: ...`
+- Else any `feat:` commit in the list → minor → title starts with `feat:`
+- Else → patch → title starts with `fix:` (or `chore:` if nothing user-facing changed)
+
+Read through the commits from step 1 to classify them rather than grepping blindly — a `feat:`
+commit that only touches internal tooling still counts as `feat` for this rule (the
+semantic-version job doesn't discriminate on scope).
+
+## 3. Open the release PR — do not merge it yet
+
+```bash
+gh pr create --base release --head main \
+  --title "<type>: release recent changes" \
+  --body "<bulleted list of the commits from step 1, PR numbers where available>"
+```
+
+Follow the existing naming precedent (`gh pr list --base release --state merged --limit 10` shows
+things like `fix: release recent changes`) — keep the body short, this PR's job is to carry the
+right squash type, not to re-explain every change.
+
+## 4. Confirm before merging
+
+Merging this PR pushes to `release`, which immediately kicks off `release.yml`: full
+build+test+e2e, Docker images tagged `test`/`latest`/`<version>`, a GitHub release, and —
+critically — SSH deploys to **both the test and prod environments**. This is exactly the kind of
+hard-to-reverse, shared-impact action that needs an explicit go-ahead: report the PR link, the
+commits it carries, and the version bump it will produce, then stop and wait for the user to say
+to merge it. Do not merge automatically, even if everything else in this workflow ran cleanly.
+
+## 5. If the user confirms: merge and watch
+
+```bash
+gh pr merge <number> --squash --subject "<the confirmed title>"
+gh run watch --exit-status $(gh run list --workflow=release.yml --branch release --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Report the run URL and final conclusion (success/failure). If it fails, do not retry or force
+anything — surface the failing job/step and let the user decide next steps, since this pipeline
+touches prod.
+
+**Never:**
+- push directly to `release` (always go through a PR, so CI title-lints it and there's a review
+  point before prod is touched)
+- merge the release PR without the user's explicit go-ahead in this conversation
+- retry a failed release deploy automatically


### PR DESCRIPTION
## Summary
- Add `/release` skill: prepares the `main` → `release` PR (with the correct Conventional Commit version-bump type), then stops for explicit confirmation before merging, since merging triggers the prod deploy
- Add `/cleanup-branches` skill: deletes local branches other than `main`/`release`, cross-checking squash-merged PRs via `gh` before force-deleting, and leaves anything with an open PR or no PR record for manual review