### PR TITLE
ci: parameterize deployment with environment and version

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -10,6 +10,14 @@ jobs:
     uses: ./.github/workflows/subflow_build.yml
   test:
     uses: ./.github/workflows/subflow_test.yml
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Determine short commit SHA
+        id: version
+        run: echo "version=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
   sonar:
     uses: ./.github/workflows/subflow_sonar.yml
     needs: test
@@ -19,10 +27,10 @@ jobs:
     uses: ./.github/workflows/subflow_lint.yml
   build-push-image:
     uses: ./.github/workflows/subflow_docker_image.yml
-    needs: build
+    needs: [build, version]
     with:
-      imageTags: ${{ github.sha }}
-      version: ${{ github.sha }}
+      imageTags: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
   e2e-test:
@@ -33,10 +41,10 @@ jobs:
     # main is the "must be green" pipeline: unlike PRs, deployment requires
     # backend+frontend unit tests AND e2e to have passed, not just a
     # successful build
-    needs: [build-push-image, test, e2e-test]
+    needs: [build-push-image, test, e2e-test, version]
     with:
       environment: test
-      version: ${{ github.sha }}
+      version: ${{ needs.version.outputs.version }}
     concurrency:
       group: test-environment
     secrets:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/subflow_docker_image.yml
     needs: build
     with:
-      imageTags: test
+      imageTags: ${{ github.sha }}
       version: ${{ github.sha }}
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -34,9 +34,12 @@ jobs:
     # backend+frontend unit tests AND e2e to have passed, not just a
     # successful build
     needs: [build-push-image, test, e2e-test]
+    with:
+      environment: test
+      version: ${{ github.sha }}
     concurrency:
       group: test-environment
     secrets:
       sshKey: ${{ secrets.SSH_PRIVATE_KEY }}
       sshKnownHosts: ${{ secrets.SSH_KNOWN_HOSTS }}
-      sshDeployCommand: ${{ secrets.SSH_DEPLOY_TEST_COMMAND }}
+      sshDeployCommand: ${{ secrets.SSH_DEPLOY_COMMAND }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/subflow_docker_image.yml
     needs: build
     with:
-      imageTags: dev
+      imageTags: ${{ github.event.pull_request.head.sha }}
       version: ${{ github.event.pull_request.head.sha }}
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -66,10 +66,13 @@ jobs:
   deploy-dev:
     uses: ./.github/workflows/subflow_deploy.yml
     needs: build-push-image
+    with:
+      environment: dev
+      version: ${{ github.event.pull_request.head.sha }}
     concurrency:
       group: dev-environment
     secrets:
       sshKey: ${{ secrets.SSH_PRIVATE_KEY }}
       sshKnownHosts: ${{ secrets.SSH_KNOWN_HOSTS }}
-      sshDeployCommand: ${{ secrets.SSH_DEPLOY_DEV_COMMAND }}
+      sshDeployCommand: ${{ secrets.SSH_DEPLOY_COMMAND }}
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,6 +45,16 @@ jobs:
     uses: ./.github/workflows/subflow_build.yml
   test:
     uses: ./.github/workflows/subflow_test.yml
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Determine short commit SHA
+        id: version
+        env:
+          FULL_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "version=${FULL_SHA:0:7}" >> "$GITHUB_OUTPUT"
   sonar:
     uses: ./.github/workflows/subflow_sonar.yml
     needs: test
@@ -54,10 +64,10 @@ jobs:
     uses: ./.github/workflows/subflow_lint.yml
   build-push-image:
     uses: ./.github/workflows/subflow_docker_image.yml
-    needs: build
+    needs: [build, version]
     with:
-      imageTags: ${{ github.event.pull_request.head.sha }}
-      version: ${{ github.event.pull_request.head.sha }}
+      imageTags: ${{ needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.version }}
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
   e2e-test:
@@ -65,10 +75,10 @@ jobs:
     needs: build
   deploy-dev:
     uses: ./.github/workflows/subflow_deploy.yml
-    needs: build-push-image
+    needs: [build-push-image, version]
     with:
       environment: dev
-      version: ${{ github.event.pull_request.head.sha }}
+      version: ${{ needs.version.outputs.version }}
     concurrency:
       group: dev-environment
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
     needs: [build, test, e2e-test, version]
     with:
       imageTags: |
-        test
         latest
         ${{ needs.version.outputs.version }}
       version: ${{ needs.version.outputs.version }}
@@ -68,19 +67,25 @@ jobs:
             Also tagged `latest`. All tags: https://github.com/wrk-tafel/admin/pkgs/container/admin
   deploy-test:
     uses: ./.github/workflows/subflow_deploy.yml
-    needs: github-release
+    needs: [version, github-release]
+    with:
+      environment: test
+      version: ${{ needs.version.outputs.version }}
     concurrency:
       group: test-environment
     secrets:
       sshKey: ${{ secrets.SSH_PRIVATE_KEY }}
       sshKnownHosts: ${{ secrets.SSH_KNOWN_HOSTS }}
-      sshDeployCommand: ${{ secrets.SSH_DEPLOY_TEST_COMMAND }}
+      sshDeployCommand: ${{ secrets.SSH_DEPLOY_COMMAND }}
   deploy-prod:
     uses: ./.github/workflows/subflow_deploy.yml
-    needs: github-release
+    needs: [version, github-release]
+    with:
+      environment: prod
+      version: ${{ needs.version.outputs.version }}
     concurrency:
       group: prod-environment
     secrets:
       sshKey: ${{ secrets.SSH_PRIVATE_KEY }}
       sshKnownHosts: ${{ secrets.SSH_KNOWN_HOSTS }}
-      sshDeployCommand: ${{ secrets.SSH_DEPLOY_PROD_COMMAND }}
+      sshDeployCommand: ${{ secrets.SSH_DEPLOY_COMMAND }}

--- a/.github/workflows/subflow_deploy.yml
+++ b/.github/workflows/subflow_deploy.yml
@@ -2,6 +2,15 @@ name: Deploy to server
 
 on:
   workflow_call:
+    inputs:
+      environment:
+        description: 'Target environment folder on the server, e.g. "dev", "test", "prod"'
+        type: string
+        required: true
+      version:
+        description: 'Docker image tag to deploy, e.g. a commit SHA or release version'
+        type: string
+        required: true
     secrets:
       sshKey:
         required: true
@@ -26,4 +35,4 @@ jobs:
           SSH_KNOWN_HOSTS: ${{ secrets.sshKnownHosts }}
           SSH_KEY_PATH: ${{ github.workspace }}/../private.key
       - name: Deploy to server
-        run: ${{ secrets.sshDeployCommand }}
+        run: ${{ secrets.sshDeployCommand }} ${{ inputs.environment }} ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Pass `environment` and `version` explicitly into `subflow_deploy.yml` instead of relying on scripts/images with a fixed tag baked in per environment
- PR/main-push image tags switch from mutable `dev`/`test` tags to the commit SHA; `release.yml` drops the redundant `test` tag so the same built image (tagged `latest` + version) is promoted through `deploy-test` then `deploy-prod`
- Collapse `SSH_DEPLOY_DEV_COMMAND` / `SSH_DEPLOY_TEST_COMMAND` / `SSH_DEPLOY_PROD_COMMAND` into a single `SSH_DEPLOY_COMMAND` secret, since the remote deploy command is now identical across environments (`environment`/`version` are appended as trailing args by the workflow)

## Required manual steps (outside this repo)
- [x] Add repo secret `SSH_DEPLOY_COMMAND` (same ssh command previously used per environment, without a baked-in env/version) and delete `SSH_DEPLOY_DEV_COMMAND`/`SSH_DEPLOY_TEST_COMMAND`/`SSH_DEPLOY_PROD_COMMAND`
- [x] Replace the three server scripts (`deploy_admin_dev.sh`/`deploy_admin_test.sh`/`deploy_admin_prod.sh`) with a single `deploy_admin.sh` that takes `$1=environment`, `$2=version`, resolves `DC_FILE=/toet/docker/admin/$ENVIRONMENT/docker-compose.yml`, and exports `IMAGE_TAG=$VERSION` before `docker-compose ... pull/down/up -d`
- [x] Update each environment's `docker-compose.yml` to reference `image: ghcr.io/wrk-tafel/admin:${IMAGE_TAG}` instead of a hardcoded tag

## Test plan
- [ ] Run this branch's PR pipeline and confirm `deploy-dev` still succeeds once the server/secret changes above are applied
- [ ] Confirm `main` push pipeline deploys to `test` correctly
- [ ] Confirm a `release` branch push builds once, creates the GitHub release, then deploys the same version to `test` and `prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)