### PR TITLE
ci: add scheduled cleanup of untagged container package versions

### DIFF
--- a/.github/workflows/cleanup_packages.yml
+++ b/.github/workflows/cleanup_packages.yml
@@ -1,0 +1,24 @@
+name: Cleanup untagged container images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 8 * * 1'
+
+jobs:
+  delete-untagged-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Untagged versions are orphaned image manifests left behind whenever a
+      # mutable tag (dev/test/latest) moved to a new digest, plus any digest
+      # no tag ever pointed to. Nothing references them, so they're safe to
+      # delete outright rather than time-boxing a retention window.
+      - name: Delete untagged versions of the admin container image
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: admin
+          package-type: container
+          delete-only-untagged-versions: true
+          min-versions-to-keep: 0


### PR DESCRIPTION
## Summary
- GHCR never garbage-collects old image manifests on its own. Years of pushes to mutable `dev`/`test`/`latest` tags left thousands of orphaned, unreferenced (untagged) versions of the `admin` package sitting in GitHub Packages
- Add `cleanup_packages.yml`, mirroring the existing `cleanup_workflows.yml` pattern (weekly cron + manual `workflow_dispatch`), that deletes all untagged versions of the `admin` container package
- Untagged versions are unreferenced by definition, so pruning them unconditionally (`min-versions-to-keep: 0`) is safe rather than needing a time-boxed retention window

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` once and confirm it only removes untagged versions, leaving `latest` and version-tagged releases intact
- [ ] Confirm the weekly schedule runs without needing further input

🤖 Generated with [Claude Code](https://claude.com/claude-code)