### PR TITLE
ci: switch cleanup schedule back to daily

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,9 +3,7 @@ name: Cleanup old workflow runs and package versions
 on:
   workflow_dispatch:
   schedule:
-    # TEMPORARY: every 5 minutes to burn down the ~6k-version untagged backlog
-    # (100/run cap). Revert to daily ('00 8 * * *') once the backlog is clear.
-    - cron: '*/5 * * * *'
+    - cron: '00 8 * * *'
 
 jobs:
   delete-workflow-runs:


### PR DESCRIPTION
## Summary
- Follow-up to #2856: switches the temporary every-5-minutes cleanup schedule back to daily, once the untagged version backlog on the `admin` GHCR package is cleared

**Depends on #2856** - this branch is stacked on top of it, so this PR will show extra commits until that one merges; afterward it'll be a single one-line cron diff.

**Do not merge until the untagged backlog is confirmed clear** (check https://github.com/wrk-tafel/admin/pkgs/container/admin).

## Test plan
- [ ] Confirm untagged version count is at/near 0 before merging
- [ ] After merge, confirm `cleanup.yml` runs once daily instead of every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)