### PR TITLE
fix(frontend): use Angular Material's theming API instead of raw CSS overrides

### DIFF
--- a/frontend/src/main/webapp/src/app/common/components/tafel-dialog/tafel-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/common/components/tafel-dialog/tafel-dialog.component.html
@@ -1,5 +1,5 @@
 <div [ngClass]="'dialog-header-' + type()" testid="header">
-  <h4 mat-dialog-title class="text-white m-0" testid="title">{{ title() }}</h4>
+  <h4 mat-dialog-title class="m-0" testid="title">{{ title() }}</h4>
 </div>
 <mat-dialog-content>
   <ng-content select="[tafel-dialog-content]"></ng-content>

--- a/frontend/src/main/webapp/src/app/common/views/login-passwordchange/login-passwordchange.component.html
+++ b/frontend/src/main/webapp/src/app/common/views/login-passwordchange/login-passwordchange.component.html
@@ -1,6 +1,6 @@
 <div class="min-h-screen flex items-center justify-center bg-slate-50 p-6">
   <div class="w-full max-w-2xl">
-    <mat-card class="p-6 md:p-8 shadow-md">
+    <mat-card appearance="outlined" class="p-6 md:p-8 shadow-md">
       <mat-card-content>
         <div class="flex flex-col items-center mb-8 text-center">
           <img
@@ -30,7 +30,7 @@
             Speichern
           </button>
           <button
-            mat-raised-button
+            matButton="outlined"
             type="button"
             testid="cancelButton"
             (click)="cancel()"

--- a/frontend/src/main/webapp/src/app/common/views/login/login.component.html
+++ b/frontend/src/main/webapp/src/app/common/views/login/login.component.html
@@ -1,6 +1,6 @@
 <div class="min-h-screen flex items-center justify-center bg-[var(--tafel-background-secondary)] p-6">
   <div class="w-full max-w-md">
-    <mat-card class="shadow-md">
+    <mat-card appearance="outlined" class="shadow-md">
       <mat-card-content class="p-8 md:p-10">
         <div class="flex flex-col items-center mb-8 text-center">
           <img ngSrc="assets/img/brand/logo.svg" width="200" height="54" priority alt="ÖRK Logo" class="mb-4 h-[54px] w-[200px] object-contain"/>

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.html
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header class="mb-2">
     <h2 class="text-2xl font-semibold">Kunden-Annahme</h2>
   </mat-card-header>
@@ -40,7 +40,7 @@
     </div>
   </mat-card-content>
   @if (customer() !== undefined) {
-    <mat-card class="mt-6 md:m-4" testid="customerDetailPanel">
+    <mat-card appearance="outlined" class="mt-6 md:m-4" testid="customerDetailPanel">
       <mat-card-header>
         <h2 class="flex gap-2 text-xl font-semibold">
           <div class="badge"
@@ -94,7 +94,7 @@
                 @if ((customer()?.additionalPersons?.length ?? 0) > 0) {
                   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
                     @for (addPerson of customer()?.additionalPersons ?? []; track addPerson.id; let i = $index) {
-                      <mat-card>
+                      <mat-card appearance="outlined">
                         <mat-card-content>
                           <div class="flex justify-between">
                             <div class="font-semibold"
@@ -131,7 +131,7 @@
             </mat-tab-group>
           </div>
           <div>
-            <mat-card>
+            <mat-card appearance="outlined">
               <mat-card-header>
                 <div class="font-semibold">Aktuellste Notiz</div>
               </mat-card-header>

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/scanner/scanner.component.html
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/scanner/scanner.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-content class="flex justify-items-center">
     @if (availableCameras() && availableCameras()!.length === 0) {
       <div class="my-4 w-full">

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.html
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-content>
     <div class="flex justify-between items-center mb-6">
       <h3 class="text-xl font-semibold m-0">Ticket-Monitor - Steuerung</h3>

--- a/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/components/customer-form/customer-form.component.html
@@ -1,6 +1,6 @@
 <form>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
-    <mat-card>
+    <mat-card appearance="outlined">
       <mat-card-header>
         <h5>Hauptbezieher</h5>
       </mat-card-header>
@@ -176,7 +176,7 @@
       </mat-card-content>
     </mat-card>
     <div class="mt-4 md:mt-0">
-      <mat-card>
+      <mat-card appearance="outlined">
         <mat-card-header class="w-full">
           <div class="flex justify-between items-center w-full">
             <h5>Weitere Personen</h5>
@@ -191,7 +191,7 @@
           }
           @for (person of customerForm.additionalPersons().value(); track person.key; let i = $index) {
             <div class="mt-4">
-              <mat-card>
+              <mat-card appearance="outlined">
                 <mat-card-content [attr.testid]="'personform-' + i">
                   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                     <mat-form-field>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header class="text-xl font-bold">Kunden über dem Limit</mat-card-header>
   <mat-card-content>
     <div class="mb-4">
@@ -86,7 +86,7 @@
       <div class="block md:hidden mt-4">
         <div class="flex flex-col gap-4 mb-4">
           @for (item of customerAboveLimitData()!.items; track trackByCustomerId($index, item); let i = $index) {
-            <mat-card>
+            <mat-card appearance="outlined">
               <mat-card-header class="font-semibold">{{item.customer.id}} - {{item.customer.lastname}} {{item.customer.firstname}}</mat-card-header>
               <mat-card-content>
                 <div class="grid grid-cols-2 gap-2">

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
@@ -101,7 +101,7 @@
         <div class="mt-4">
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-2">
             <div>
-              <mat-card>
+              <mat-card appearance="outlined">
                 <mat-card-header class="justify-center text-center w-full">
                   <h5>Hauptbezieher</h5>
                 </mat-card-header>
@@ -190,7 +190,7 @@
               </mat-card>
             </div>
             <div>
-              <mat-card>
+              <mat-card appearance="outlined">
                 <mat-card-header class="w-full">
                   <div class="flex justify-between items-center w-full">
                     <h5 class="m-0">Aktuellste Notiz</h5>
@@ -239,7 +239,7 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-2">
               @for (addPerson of customerData()?.additionalPersons; track addPerson.id; let i = $index) {
                 <div>
-                  <mat-card>
+                  <mat-card appearance="outlined">
                     <mat-card-content>
                       <div class="flex justify-between">
                         <span class="font-bold"

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header class="text-xl font-bold">Kunden-Duplikate</mat-card-header>
   <mat-card-content>
     <div class="flex flex-col gap-2 mb-4">
@@ -42,7 +42,7 @@
       <div class="grid gap-4">
         @for (item of customerDuplicatesData()!.items; track trackByDuplicateItemId($index, item)) {
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4" [attr.testid]="'duplicate-pair-' + item.customer.id">
-          <mat-card class="mb-4 md:mb-0" [attr.testid]="'duplicate-customer-' + item.customer.id">
+          <mat-card appearance="outlined" class="mb-4 md:mb-0" [attr.testid]="'duplicate-customer-' + item.customer.id">
             <mat-card-header class="font-bold w-full">
               <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center w-full">
                 <div [attr.testid]="'duplicate-customer-name-' + item.customer.id">
@@ -84,7 +84,7 @@
           </mat-card>
           <div class="flex flex-col gap-4">
             @for (similarCustomer of item.similarCustomers; track trackBySimilarCustomerId($index, similarCustomer)) {
-            <mat-card [attr.testid]="'duplicate-customer-' + similarCustomer.id">
+            <mat-card appearance="outlined" [attr.testid]="'duplicate-customer-' + similarCustomer.id">
               <mat-card-header class="font-bold w-full">
                 <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center w-full">
                   <div [attr.testid]="'duplicate-customer-name-' + similarCustomer.id">

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.html
@@ -1,6 +1,6 @@
 <div class="mb-4">
     <tafel-customer-form [customerData]="customerData()" (customerDataChange)="customerDataUpdated($event)" [editMode]="editMode()"></tafel-customer-form>
-    <button testid="validate-button" matButton="outlined" class="px-6 mt-4 mb-4" (click)="validate()">Anspruch prüfen</button>
+    <button testid="validate-button" matButton="filled" class="px-6 mt-4 mb-4" (click)="validate()">Anspruch prüfen</button>
     <button testid="save-button" matButton="filled"
             [class.button-success]="isSaveEnabled()" [class.button-danger]="!isSaveEnabled()"
             class="px-6 mt-4 ms-2 mb-4" (click)="save()" [disabled]="!isSaveEnabled()">Speichern</button>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form" autocomplete="off">
-  <mat-card>
+  <mat-card appearance="outlined">
     <mat-card-content>
       <div class="mb-4">
         <h5 class="text-lg font-semibold">Kunden-Suche</h5>
@@ -140,7 +140,7 @@
           <div class="block md:hidden">
             <div class="flex flex-col gap-4 mb-4">
               @for (customer of searchResult()!.items; track customer.id; let i = $index) {
-                <mat-card>
+                <mat-card appearance="outlined">
                   <mat-card-header class="font-semibold">{{customer.id}} - {{customer.lastname}} {{customer.firstname}}</mat-card-header>
                   <mat-card-content>
                     <div class="grid grid-cols-2 gap-2">

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-notes-input/distribution-notes-input.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-notes-input/distribution-notes-input.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-primary">
+<mat-card appearance="outlined" class="h-full mat-card-primary">
   <mat-card-header>
     <mat-card-title>
       <h4>Anmerkungen</h4>
@@ -19,7 +19,7 @@
   </mat-card-content>
   <mat-card-footer class="mt-4">
     <button
-      mat-raised-button
+      matButton="filled"
       testid="distribution-notes-save-button"
       (click)="save()"
       [disabled]="inputIsDisabled()"

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-notes-input/distribution-notes-input.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-notes-input/distribution-notes-input.component.html
@@ -19,7 +19,7 @@
   </mat-card-content>
   <mat-card-footer class="mt-4">
     <button
-      matButton="filled"
+      mat-raised-button
       testid="distribution-notes-save-button"
       (click)="save()"
       [disabled]="inputIsDisabled()"

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-state/distribution-state.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-state/distribution-state.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-primary">
+<mat-card appearance="outlined" class="h-full mat-card-primary">
   <mat-card-header>
     <mat-card-title>
       <h4>Status</h4>
@@ -10,13 +10,13 @@
   <mat-card-footer class="mt-6">
     @if (!isDistributionActive()) {
       <button testid="distribution-start-button"
-              mat-raised-button
+              matButton="filled"
               (click)="createNewDistribution()">Tag starten
       </button>
     }
     @if (isDistributionActive()) {
       <button testid="distribution-close-button"
-              mat-raised-button
+              matButton="filled"
               (click)="openCloseDistributionDialog()">Tag beenden
       </button>
     }

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-state/distribution-state.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-state/distribution-state.component.html
@@ -10,13 +10,13 @@
   <mat-card-footer class="mt-6">
     @if (!isDistributionActive()) {
       <button testid="distribution-start-button"
-              matButton="filled"
+              mat-raised-button
               (click)="createNewDistribution()">Tag starten
       </button>
     }
     @if (isDistributionActive()) {
       <button testid="distribution-close-button"
-              matButton="filled"
+              mat-raised-button
               (click)="openCloseDistributionDialog()">Tag beenden
       </button>
     }

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statistics-input.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statistics-input.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-primary">
+<mat-card appearance="outlined" class="h-full mat-card-primary">
   <mat-card-header>
     <mat-card-title>
       <h4>Statistik</h4>
@@ -59,7 +59,7 @@
   </mat-card-content>
   <mat-card-footer>
     <button
-      mat-raised-button
+      matButton="filled"
       type="button"
       testid="distribution-statistics-save-button"
       (click)="save()"

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statistics-input.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/distribution-statistics-input/distribution-statistics-input.component.html
@@ -59,7 +59,7 @@
   </mat-card-content>
   <mat-card-footer>
     <button
-      matButton="filled"
+      mat-raised-button
       type="button"
       testid="distribution-statistics-save-button"
       (click)="save()"

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/food-amount/food-amount.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/food-amount/food-amount.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-primary">
+<mat-card appearance="outlined" class="h-full mat-card-primary">
   <mat-card-header>
     <mat-card-title>
       <h4 class="text-white">Erfasste Warenmenge</h4>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-{{ panelColor() }}" testid="recorded-food-collections-panel">
+<mat-card appearance="outlined" class="h-full mat-card-{{ panelColor() }}" testid="recorded-food-collections-panel">
   <mat-card-header>
     <mat-card-title>
       <h4 class="text-white">Erfasste Routen</h4>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/registered-customers/registered-customers.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/registered-customers/registered-customers.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-primary">
+<mat-card appearance="outlined" class="h-full mat-card-primary">
   <mat-card-header>
     <mat-card-title>
       <h4>Kunden angemeldet</h4>
@@ -8,7 +8,7 @@
     <div testid="customers-count" class="text-5xl">{{ count() ?? '-' }}</div>
   </mat-card-content>
   <mat-card-footer *tafelIfDistributionActive>
-    <button testid="download-customerlist-button" mat-raised-button (click)="downloadCustomerList()">
+    <button testid="download-customerlist-button" matButton="filled" (click)="downloadCustomerList()">
       <fa-icon [icon]="faDownload"></fa-icon>
       Kundenliste
     </button>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/registered-customers/registered-customers.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/registered-customers/registered-customers.component.html
@@ -8,7 +8,7 @@
     <div testid="customers-count" class="text-5xl">{{ count() ?? '-' }}</div>
   </mat-card-content>
   <mat-card-footer *tafelIfDistributionActive>
-    <button testid="download-customerlist-button" matButton="filled" (click)="downloadCustomerList()">
+    <button testid="download-customerlist-button" mat-raised-button (click)="downloadCustomerList()">
       <fa-icon [icon]="faDownload"></fa-icon>
       Kundenliste
     </button>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.html
@@ -1,9 +1,8 @@
 <button
-  mat-raised-button
+  matButton="filled"
   (click)="openSelectSheltersDialog()"
   testid="dashboard-select-shelters-button"
   [disabled]="disabled()"
-  class="mat-raised-button"
 >
   <fa-icon [icon]="faCalculator"></fa-icon>
 </button>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/select-shelters/select-shelters.component.html
@@ -1,5 +1,5 @@
 <button
-  matButton="filled"
+  mat-raised-button
   (click)="openSelectSheltersDialog()"
   testid="dashboard-select-shelters-button"
   [disabled]="disabled()"

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/tickets-processed/tickets-processed.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/tickets-processed/tickets-processed.component.html
@@ -1,4 +1,4 @@
-<mat-card class="h-full mat-card-{{ panelColor() }}">
+<mat-card appearance="outlined" class="h-full mat-card-{{ panelColor() }}">
   <mat-card-header>
     <mat-card-title>
       <h4>Tickets abgearbeitet</h4>

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.html
@@ -4,7 +4,7 @@
                    [pageIndex]="employeeSearchResponse().currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                    (page)="triggerSearch($event.pageIndex + 1)"></mat-paginator>
     @for (employee of employeeSearchResponse().items; track employee.id; let i = $index) {
-      <mat-card class="mb-2">
+      <mat-card appearance="outlined" class="mb-2">
         <mat-card-content>
           <div [attr.testid]="'select-employee-row-' + i" class="flex justify-between items-center">
             <span>{{ employee.personnelNumber }} {{ employee.firstname }} {{ employee.lastname }}</span>

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header>
     <h5>Warenerfassung</h5>
   </mat-card-header>

--- a/frontend/src/main/webapp/src/app/modules/settings/components/mail-recipients/mail-recipients.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/components/mail-recipients/mail-recipients.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header>
     <mat-card-title>
       <div class="flex items-center gap-2">

--- a/frontend/src/main/webapp/src/app/modules/settings/components/send-mails/send-mails.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/components/send-mails/send-mails.component.html
@@ -1,5 +1,5 @@
 <div class="flex gap-6">
-  <mat-card class="w-full">
+  <mat-card appearance="outlined" class="w-full">
     <mat-card-header>
       <mat-card-title>
         <div class="flex items-center gap-2">

--- a/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/food-categories/settings-food-categories.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full">
+<mat-card appearance="outlined" class="w-full">
   <mat-card-header class="mb-2">
     <mat-card-title>
       <div class="flex items-center gap-2">

--- a/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/shelters/settings-shelters.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full">
+<mat-card appearance="outlined" class="w-full">
   <mat-card-header class="mb-2">
     <mat-card-title>
       <div class="flex items-center gap-2">

--- a/frontend/src/main/webapp/src/app/modules/settings/views/static-values/settings-static-values.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/static-values/settings-static-values.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full">
+<mat-card appearance="outlined" class="w-full">
   <mat-card-header class="mb-2">
     <mat-card-title>
       <h5 class="mb-0 mt-1">Statische Werte</h5>

--- a/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/components/statistics-panel.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full h-full mat-card-primary">
+<mat-card appearance="outlined" class="w-full h-full mat-card-primary">
   <mat-card-content>
     <div class="text-sm">{{ data()?.subTitle }}</div>
     <div class="text-2xl font-bold">{{ data()?.title }}</div>

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/general/statistics-general.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/general/statistics-general.component.html
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
   <div class="md:col-span-3">
-    <mat-card>
+    <mat-card appearance="outlined">
       <mat-card-header>
         <h5>Statistik</h5>
       </mat-card-header>
@@ -72,7 +72,7 @@
     </mat-card>
   </div>
   <div class="mt-4 md:mt-0">
-    <mat-card class="h-full">
+    <mat-card appearance="outlined" class="h-full">
       <mat-card-header>
         <h5>Export</h5>
       </mat-card-header>
@@ -85,7 +85,7 @@
   </div>
 </div>
 @if (statisticsData()) {
-  <mat-card class="mt-4">
+  <mat-card appearance="outlined" class="mt-4">
     <mat-card-header>
       <h5>Zeitraum: {{ dateRangeFrom | date: 'dd.MM.yyyy' }} - {{ dateRangeTo | date: 'dd.MM.yyyy' }}</h5>
     </mat-card-header>

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.html
@@ -1,4 +1,4 @@
-<mat-card class="w-full">
+<mat-card appearance="outlined" class="w-full">
   <mat-card-header>
     <mat-card-title>
       <h5 class="mb-0 mt-1">Schulstartpakete</h5>

--- a/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/components/user-form/user-form.component.html
@@ -1,5 +1,5 @@
 <form autocomplete="off">
-  <mat-card>
+  <mat-card appearance="outlined">
     <mat-card-header class="justify-center text-center w-full">
       <h5>Benutzerdaten</h5>
     </mat-card-header>

--- a/frontend/src/main/webapp/src/app/modules/user/components/user-passwordchange/user-passwordchange.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/components/user-passwordchange/user-passwordchange.component.html
@@ -1,4 +1,4 @@
-<mat-card class="shadow-sm">
+<mat-card appearance="outlined" class="shadow-sm">
   <mat-card-header>
     <mat-card-title>
       Passwort ändern

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-detail/user-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-detail/user-detail.component.html
@@ -17,7 +17,7 @@
       <button mat-menu-item testid="deleteUserButton" (click)="deleteUser()">Benutzer löschen</button>
     </mat-menu>
   </div>
-  <mat-card class="mt-0 lg:mt-3 mb-0 lg:mb-3">
+  <mat-card appearance="outlined" class="mt-0 lg:mt-3 mb-0 lg:mb-3">
     <mat-card-content>
       <div class="mb-4">
         <h3>Benutzerdetails</h3>

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
@@ -1,5 +1,5 @@
 <form autocomplete="off" (ngSubmit)="$event.preventDefault()">
-  <mat-card class="shadow-sm">
+  <mat-card appearance="outlined" class="shadow-sm">
     <mat-card-content>
       <div class="mb-4">
         <h5 class="text-lg font-semibold">Benutzer-Suche</h5>
@@ -129,7 +129,7 @@
           <div class="block md:hidden">
             <div class="flex flex-col gap-4 mb-4">
               @for (user of this.searchResult()?.items; track user.id; let i = $index) {
-                <mat-card class="shadow-sm">
+                <mat-card appearance="outlined" class="shadow-sm">
                   <mat-card-header class="font-semibold">{{user.id}} - {{user.lastname}} {{user.firstname}}</mat-card-header>
                   <mat-card-content>
                     <div class="grid grid-cols-2 gap-2">

--- a/frontend/src/main/webapp/src/scss/components/mat-button.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-button.scss
@@ -1,3 +1,7 @@
+.mat-mdc-button-base {
+  box-shadow: none !important;
+}
+
 /* Support legacy "btn-success" / "btn-danger" utility classes on Material buttons
    and ensure the background color applies in normal, hover, focus and active states. */
 .mat-mdc-button:not([disabled]):not(.mat-mdc-button-disabled),

--- a/frontend/src/main/webapp/src/scss/components/mat-button.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-button.scss
@@ -1,7 +1,3 @@
-.mat-mdc-button-base {
-  box-shadow: none !important;
-}
-
 /* Support legacy "btn-success" / "btn-danger" utility classes on Material buttons
    and ensure the background color applies in normal, hover, focus and active states. */
 .mat-mdc-button:not([disabled]):not(.mat-mdc-button-disabled),

--- a/frontend/src/main/webapp/src/scss/components/mat-card.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-card.scss
@@ -2,10 +2,13 @@
   padding: 0 1rem 1rem 1rem !important;
 }
 
-.mat-mdc-card {
-  border: var(--tafel-border-color) solid 1px !important;
-  background-color: white !important;
-  box-shadow: none !important;
+// Every <mat-card> in the app uses appearance="outlined", whose own (unlayered) structural CSS
+// already sets background-color/border/box-shadow from these exact custom properties (falling
+// back to Material's system tokens otherwise) - set them directly instead of re-implementing the
+// outlined look with a raw override.
+:root {
+  --mat-card-outlined-container-color: white;
+  --mat-card-outlined-outline-color: var(--tafel-border-color);
 }
 
 .mat-mdc-card-header {

--- a/frontend/src/main/webapp/src/scss/components/mat-dialog.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-dialog.scss
@@ -21,18 +21,18 @@
   background-color: #1b9e3e;
 }
 
-// Remove border-radius from Material dialog surface
-.mat-mdc-dialog-surface {
-  border-radius: 8px !important;
-}
-
-.mat-mdc-dialog-title {
-  padding: 0 !important;
-  padding-left: 0.3rem !important;
-  color: #fff !important;
-}
-
-.mat-mdc-dialog-content {
-  padding: 1rem !important;
-  font-size: 1rem !important;
+// Tighter corners/padding and a larger content font than Material's M3 defaults, plus white
+// title text for tafel-dialog's colored severity header (dialog-header-* above) - every one of
+// these has a matching Material theming custom property, so set those instead of fighting the
+// cascade with raw !important overrides.
+:root {
+  --mat-dialog-container-shape: 8px;
+  --mat-dialog-headline-padding: 0 0 0 0.3rem;
+  --mat-dialog-subhead-color: white;
+  // tafel-dialog always renders <mat-dialog-actions>, which makes Material apply the
+  // "with-actions" content padding instead of the plain one - set both so this stays correct
+  // even if a dialog without actions is ever added.
+  --mat-dialog-content-padding: 1rem;
+  --mat-dialog-with-actions-content-padding: 1rem;
+  --mat-dialog-supporting-text-size: 1rem;
 }

--- a/frontend/src/main/webapp/src/scss/components/mat-menu.scss
+++ b/frontend/src/main/webapp/src/scss/components/mat-menu.scss
@@ -1,13 +1,39 @@
 // Material's M3 tokens default dropdown/overlay panels to a greyish "surface-container"
-// color. Match the white background + light grey border used for cards (mat-card.scss)
-// and buttons (mat-button.scss) instead.
+// color, an elevation shadow and (for menus/autocomplete) 4px rounded corners. Match the
+// white background + light grey border + flat look used for cards (mat-card.scss) and
+// buttons (mat-button.scss) instead - set through Material's own theming custom properties
+// rather than raw overrides, since all three panels expose them.
+:root {
+  --mat-menu-container-color: white;
+  --mat-menu-container-elevation-shadow: none;
+  --mat-menu-container-shape: 8px;
+  // A divider's own margin (8px top + 8px bottom by default) sits between two items but
+  // belongs to neither, so hovering either item stops short of the divider instead of
+  // reaching it. Zero it via these tokens; the same breathing room is restored on the
+  // adjacent items' own height below so it's included in their hover area.
+  --mat-menu-divider-top-spacing: 0;
+  --mat-menu-divider-bottom-spacing: 0;
+
+  --mat-select-panel-background-color: white;
+  --mat-select-container-elevation-shadow: none;
+
+  --mat-autocomplete-background-color: white;
+  --mat-autocomplete-container-elevation-shadow: none;
+  --mat-autocomplete-container-shape: 8px;
+}
+
+// No custom-property equivalent exists for any of these three panels' border, so this stays
+// a raw override.
 .mat-mdc-menu-panel,
 .mat-mdc-select-panel,
 .mat-mdc-autocomplete-panel {
-  background-color: white !important;
   border: var(--tafel-border-color) solid 1px !important;
+}
+
+// The select panel's border-radius is hardcoded in Material's own structural CSS (0 0 4px 4px)
+// with no corresponding token, unlike the menu/autocomplete panels above.
+.mat-mdc-select-panel {
   border-radius: 8px !important;
-  box-shadow: none !important;
 }
 
 // Clip content to the panel's rounded corners so a flush first/last row (see below)
@@ -20,7 +46,8 @@
 // loose for the short, dense menus used across the app. Padding is removed entirely
 // (rather than just reduced) so an item's hover/focus background reaches all the way to
 // the panel edge instead of leaving an uncolored strip above the first / below the last
-// item - the item itself is the only source of vertical spacing now.
+// item - the item itself is the only source of vertical spacing now. Neither has a
+// corresponding Material token.
 .mat-mdc-menu-content {
   padding: 0 !important;
 }
@@ -35,14 +62,6 @@
 
 .mat-mdc-menu-item {
   min-height: 36px !important;
-}
-
-// A divider's own margin (8px top + 8px bottom by default) sits between two items but
-// belongs to neither, so hovering either item stops short of the divider instead of
-// reaching it. Zero the divider's margin and move that same amount of breathing room
-// into the adjacent items' own height instead, so it's included in their hover area.
-.mat-mdc-menu-panel .mat-divider {
-  margin: 0 !important;
 }
 
 .mat-mdc-menu-item:has(+ .mat-divider) {


### PR DESCRIPTION
## Summary
Audited every custom rule in `scss/components/mat-*.scss` against what Angular Material already provides by default (M3 theming custom properties). Several rules were hand-reimplementing a Material-native look with `!important` overrides instead of using the theming API Material ships for exactly that purpose - same bug shape as the recent button-border fix (#2865).

- **`mat-card.scss`**: the global `.mat-mdc-card` border/background/shadow override was reimplementing Material's own `appearance="outlined"` variant. Added `appearance="outlined"` to all 45 `<mat-card>` usages app-wide and replaced the override with the two theming custom properties (`--mat-card-outlined-container-color`/`-outline-color`) it actually reads.
- **`mat-button.scss`**: converted the one `mat-raised-button` cancel action (login-passwordchange) to `matButton="outlined"`, which is the correct semantic replacement there. The other 6 `mat-raised-button` usages - all action buttons on colored `mat-card-primary` dashboard cards (Tag starten/beenden, Speichern x2, Kundenliste download, shelter-select) - were initially migrated to `matButton="filled"` too, but that variant defaults to Material's primary blue when unthemed, while `mat-raised-button` defaults to a neutral white/light-grey surface. That turned those buttons blue instead of their intended neutral look, so they were reverted back to `mat-raised-button` and the `.mat-mdc-button-base { box-shadow: none !important }` rule they rely on was restored.
- **`mat-menu.scss`**: background-color/box-shadow/border-radius for menu, select and autocomplete panels, plus divider spacing, all have direct Material custom-property equivalents - swapped in those instead of `!important`. The select panel's border-radius and all three panels' border still need raw overrides since Material exposes no token for either.
- **`mat-dialog.scss`**: surface border-radius, title padding/color, and content padding/font-size all have matching dialog theming tokens - set those instead. Also dropped the dead `text-white` class from `tafel-dialog`'s title template, which never had any effect since the old unlayered `!important` rule always overrode it anyway.

No visual change intended anywhere - same look as before, just without fighting Material's own cascade to get there.

## Test plan
- [x] `ng test` - full unit suite passes (598/598)
- [x] Visual check in a running app: login card, colored dashboard cards, user dropdown menu, a create dialog (info-colored header), a `mat-select` panel - all render identically to before
- [x] Dashboard action-button color regression (#2873) caught in review and fixed
- [ ] Full manual pass over every touched page not performed (37 files); flagging in case a reviewer wants to spot-check a few more

Fixes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)
