### PR TITLE
refactor(api)!: migrate TafelException hierarchy to RFC 7807 problem details

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/TafelActiveDistributionRequiredInterceptor.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/TafelActiveDistributionRequiredInterceptor.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.common.api
 
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.getCurrentDistribution
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component
@@ -23,7 +23,7 @@ class TafelActiveDistributionRequiredInterceptor(
 
             // Check if the method/class requires an active distribution and none exists
             if ((methodAnnotation != null || classAnnotation != null) && distributionRepository.getCurrentDistribution() == null) {
-                throw TafelValidationException("Ausgabe nicht gestartet!")
+                throw BusinessRuleException("Ausgabe nicht gestartet!")
             }
         }
         return true

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
@@ -7,7 +7,9 @@ import at.wrk.tafel.admin.backend.common.auth.components.TafelPasswordGenerator
 import at.wrk.tafel.admin.backend.common.auth.components.TafelUserDetailsManager
 import at.wrk.tafel.admin.backend.common.auth.model.*
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
@@ -80,10 +82,7 @@ class UserController(
     @PreAuthorize("hasAuthority('USER_MANAGEMENT')")
     fun getUser(@PathVariable userId: Long): ResponseEntity<User> {
         val userDetails = userDetailsManager.loadUserById(userId)
-            ?: throw TafelValidationException(
-                message = "Benutzer (ID: $userId) nicht gefunden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            ?: throw NotFoundException("Benutzer (ID: $userId) nicht gefunden!")
         val user = mapToResponse(userDetails)
         return ResponseEntity.ok(user)
     }
@@ -92,10 +91,7 @@ class UserController(
     @PreAuthorize("hasAuthority('USER_MANAGEMENT')")
     fun getUserByPersonnelNumber(@PathVariable personnelNumber: String): ResponseEntity<User> {
         val userDetails = userDetailsManager.loadUserByPersonnelNumber(personnelNumber.trim())
-            ?: throw TafelValidationException(
-                message = "Benutzer (Personalnummer: $personnelNumber) nicht gefunden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            ?: throw NotFoundException("Benutzer (Personalnummer: $personnelNumber) nicht gefunden!")
         val user = mapToResponse(userDetails)
         return ResponseEntity.ok(user)
     }
@@ -143,13 +139,13 @@ class UserController(
     private fun validateIfUserExists(user: User) {
         try {
             userDetailsManager.loadUserByUsername(user.username)
-            throw TafelValidationException("Benutzer (Benutzername: ${user.username}) existiert bereits!")
+            throw ConflictException("Benutzer (Benutzername: ${user.username}) existiert bereits!")
         } catch (_: UsernameNotFoundException) {
             // ignore
         }
 
         userDetailsManager.loadUserByPersonnelNumber(user.personnelNumber)?.let {
-            throw TafelValidationException("Benutzer (Personalnummer: ${user.personnelNumber}) existiert bereits!")
+            throw ConflictException("Benutzer (Personalnummer: ${user.personnelNumber}) existiert bereits!")
         }
     }
 
@@ -161,16 +157,10 @@ class UserController(
         @Valid @RequestBody user: User,
     ): ResponseEntity<User> {
         userDetailsManager.loadUserById(userId)
-            ?: throw TafelValidationException(
-                message = "Benutzer (ID: $userId) nicht vorhanden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            ?: throw NotFoundException("Benutzer (ID: $userId) nicht vorhanden!")
 
         if (user.password != user.passwordRepeat) {
-            throw TafelValidationException(
-                message = "Passwörter stimmen nicht überein!",
-                status = HttpStatus.BAD_REQUEST,
-            )
+            throw BusinessRuleException("Passwörter stimmen nicht überein!")
         }
 
         try {
@@ -180,7 +170,7 @@ class UserController(
             val userResponse = mapToResponse(userDetailsManager.loadUserById(userId)!!)
             return ResponseEntity.ok(userResponse)
         } catch (e: PasswordChangeException) {
-            throw TafelValidationException(e.message)
+            throw BusinessRuleException(e.message)
         }
     }
 
@@ -191,10 +181,7 @@ class UserController(
         @PathVariable userId: Long,
     ): ResponseEntity<Unit> {
         val tafelUser = userDetailsManager.loadUserById(userId)
-            ?: throw TafelValidationException(
-                message = "Benutzer (ID: $userId) nicht vorhanden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            ?: throw NotFoundException("Benutzer (ID: $userId) nicht vorhanden!")
 
         userDetailsManager.deleteUser(tafelUser.username)
         return ResponseEntity.noContent().build()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/lock/README.md
@@ -56,13 +56,13 @@ fun createNewDistribution(): DistributionEntity {
     val acquired = advisoryLockService.tryWithLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
         val currentDistribution = distributionRepository.getCurrentDistribution()
         if (currentDistribution != null) {
-            throw TafelValidationException("Ausgabe bereits gestartet!")
+            throw ConflictException("Ausgabe bereits gestartet!")
         }
         result = /* ... create and save the distribution ... */
     }
 
     if (!acquired) {
-        throw TafelValidationException("Ausgabe wird bereits erstellt!")
+        throw ConflictException("Ausgabe wird bereits erstellt!")
     }
     return result!!
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
@@ -48,25 +48,35 @@ Entities backing this module are **not** colocated with it: they live under `dat
   needs this named interface.
 
 ### `exception` — `@NamedInterface("exception")`
-- [`TafelExceptions.kt`](exception/TafelExceptions.kt): two exception types,
-  `TafelException` and `TafelValidationException` (both `RuntimeException` with an optional
-  `HttpStatus`; when `status` is null the handler below defaults to 400 Bad Request). They are
-  functionally near-identical today — the distinction is intent/logging severity, not behavior.
-- [`GenericExceptionHandler`](exception/GenericExceptionHandler.kt): a `@ControllerAdvice` with
-  three handlers:
-  - `TafelException` → logged at `warn`.
-  - `TafelValidationException` → logged at `debug` (expected/user-facing validation failures
-    shouldn't spam the warn log).
-  - anything else (`Exception`) → logged at `error`, always answered as 500.
-  All three build a localized `TafelErrorResponse` (`http-error.<status>.title` message key looked
-  up via `MessageSource`) and special-case SSE requests: if the incoming request's `Accept` header
-  contains `text/event-stream`, the error is written as an `event: error` SSE frame instead of a
-  normal JSON error body, so error responses don't break an open EventSource connection.
+- [`TafelExceptions.kt`](exception/TafelExceptions.kt): RFC 7807 (`ProblemDetail`) based exceptions,
+  each extending `org.springframework.web.ErrorResponseException` and fixing its own `HttpStatusCode`
+  in its constructor, so - unlike the old `TafelException`/`TafelValidationException` pair - the
+  status can't be forgotten at a throw site:
+  - `NotFoundException` → 404, the addressed resource (usually looked up by an id from the request
+    path) doesn't exist.
+  - `ConflictException` → 409, the request conflicts with the current state of a resource
+    (duplicate/already exists, an in-progress operation on the same resource, ...).
+  - `BusinessRuleException` → 400 by default (an explicit status can be passed), for business-rule
+    violations not covered by the two above, e.g. an invalid reference inside a request body.
+- [`GenericExceptionHandler`](exception/GenericExceptionHandler.kt): a `@ControllerAdvice` extending
+  Spring's `ResponseEntityExceptionHandler`, which natively turns any `ErrorResponseException` (our
+  three types above) and Spring's own `ErrorResponse`-producing exceptions (e.g.
+  `MethodArgumentNotValidException`) into a `ProblemDetail` response.
+  - `handleExceptionInternal` is the shared hook all of those funnel through: it localizes the
+    `ProblemDetail`'s `title` (`http-error.<status>.title` message key looked up via `MessageSource`)
+    and logs at `debug` (expected/user-facing failures shouldn't spam the log).
+  - `handleMethodArgumentNotValid` additionally attaches a structured `errors: [{field, message}]`
+    extension property to the `ProblemDetail`, instead of joining field errors into one string.
+  - Anything else (`Exception`) is caught by a dedicated `@ExceptionHandler`, logged at `error`, and
+    always answered as 500.
+  - All of these render through the same SSE special-case: if the incoming request's `Accept` header
+    contains `text/event-stream`, the error is written as an `event: error` SSE frame instead of a
+    normal JSON error body, so error responses don't break an open EventSource connection.
 - **Widely used:** `household`, `logistics`, `distribution`, and `settings` all declare
-  `base::exception` in their `allowedDependencies` and throw `TafelValidationException` for
-  business-rule violations (e.g. "Kunde Nr. X bereits vorhanden!" in `HouseholdController`). This is
-  the module to reach for whenever a service needs to reject a request with a clear HTTP status and
-  a user-facing message.
+  `base::exception` in their `allowedDependencies` and throw these exceptions for business-rule
+  violations (e.g. `ConflictException("Kunde Nr. X bereits vorhanden!")` in `HouseholdController`).
+  This is the module to reach for whenever a service needs to reject a request with a clear HTTP
+  status and a user-facing message.
 
 ### `version` — `@NamedInterface("version")`
 - [`VersionController`](version/VersionController.kt): `GET /api/version`, requires only

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
@@ -5,7 +5,8 @@ import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
 import at.wrk.tafel.admin.backend.modules.base.employee.Employee
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -36,7 +37,7 @@ class EmployeeService(
     @Transactional
     fun saveEmployee(employeeCreateRequest: EmployeeCreateRequest): Employee {
         if (employeeRepository.existsByPersonnelNumber(employeeCreateRequest.personnelNumber)) {
-            throw TafelValidationException("Mitarbeiter ${employeeCreateRequest.personnelNumber} ist bereits vorhanden!")
+            throw ConflictException("Mitarbeiter ${employeeCreateRequest.personnelNumber} ist bereits vorhanden!")
         }
 
         val employeeEntity = EmployeeEntity().apply {
@@ -51,10 +52,10 @@ class EmployeeService(
     @Transactional
     fun updateEmployee(employeeId: Long, employeeUpdateRequest: EmployeeCreateRequest): Employee {
         val employeeEntity = employeeRepository.findByIdOrNull(employeeId)
-            ?: throw TafelValidationException("Employee with id $employeeId not found")
+            ?: throw NotFoundException("Employee with id $employeeId not found")
 
         if (employeeRepository.existsByPersonnelNumberAndIdNot(employeeUpdateRequest.personnelNumber, employeeId)) {
-            throw TafelValidationException("Mitarbeiter ${employeeUpdateRequest.personnelNumber} ist bereits vorhanden!")
+            throw ConflictException("Mitarbeiter ${employeeUpdateRequest.personnelNumber} ist bereits vorhanden!")
         }
 
         employeeEntity.personnelNumber = employeeUpdateRequest.personnelNumber.trim()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -3,145 +3,107 @@ package at.wrk.tafel.admin.backend.modules.base.exception
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import org.slf4j.LoggerFactory
 import org.springframework.context.MessageSource
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import tools.jackson.databind.json.JsonMapper
-import java.time.LocalDateTime
-import java.util.*
 
 @ControllerAdvice
 class GenericExceptionHandler(
     private val messageSource: MessageSource,
     private val jsonMapper: JsonMapper,
-) {
+) : ResponseEntityExceptionHandler() {
 
     companion object {
-        private val logger = LoggerFactory.getLogger(GenericExceptionHandler::class.java)
-    }
-
-    @ExceptionHandler(TafelException::class)
-    fun handleTafelException(
-        exception: TafelException,
-        request: WebRequest,
-        locale: Locale,
-    ): ResponseEntity<Any> {
-        logger.warn(exception.message, exception)
-
-        val status = exception.status ?: HttpStatus.BAD_REQUEST
-        return createErrorResponse(
-            exception = exception,
-            status = status,
-            request = request,
-            locale = locale,
-        )
-    }
-
-    @ExceptionHandler(TafelValidationException::class)
-    fun handleTafelValidationException(
-        exception: TafelValidationException,
-        request: WebRequest,
-        locale: Locale,
-    ): ResponseEntity<Any> {
-        logger.debug(exception.message, exception)
-
-        val status = exception.status ?: HttpStatus.BAD_REQUEST
-        return createErrorResponse(
-            exception = exception,
-            status = status,
-            request = request,
-            locale = locale,
-        )
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValidException(
-        exception: MethodArgumentNotValidException,
-        request: WebRequest,
-        locale: Locale,
-    ): ResponseEntity<Any> {
-        logger.debug(exception.message, exception)
-
-        val message = exception.bindingResult.fieldErrors.joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
-        return createErrorResponse(
-            exception = exception,
-            status = HttpStatus.BAD_REQUEST,
-            message = message,
-            request = request,
-            locale = locale,
-        )
-    }
-
-    @ExceptionHandler(Exception::class)
-    fun handleException(
-        exception: Exception,
-        request: WebRequest,
-        locale: Locale,
-    ): ResponseEntity<Any> {
-        logger.error(exception.message, exception)
-
-        return createErrorResponse(
-            exception = exception,
-            status = HttpStatus.INTERNAL_SERVER_ERROR,
-            request = request,
-            locale = locale,
-        )
+        private val log = LoggerFactory.getLogger(GenericExceptionHandler::class.java)
     }
 
     /**
-     * Builds the error response, special-casing SSE requests.
-     *
+     * Central hook every default handler in [ResponseEntityExceptionHandler] funnels through
+     * (bean-validation failures via [handleMethodArgumentNotValid], and [TafelApiException] and its
+     * subclasses via the inherited `handleErrorResponseException`). Localizes the [ProblemDetail]'s
+     * title and renders the response, special-casing SSE requests.
+     */
+    public override fun handleExceptionInternal(
+        ex: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        statusCode: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        log.debug(ex.message, ex)
+
+        val status = HttpStatus.valueOf(statusCode.value())
+        val problemDetail = (body as? ProblemDetail) ?: ProblemDetail.forStatusAndDetail(statusCode, ex.message)
+        problemDetail.title = localizedTitle(status, request)
+
+        return renderResponse(problemDetail, status, request)
+    }
+
+    public override fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        val problemDetail = createProblemDetail(ex, status, "Validierung fehlgeschlagen", null, null, request)
+        problemDetail.setProperty(
+            "errors",
+            ex.bindingResult.fieldErrors.map { FieldErrorItem(field = it.field, message = it.defaultMessage) },
+        )
+        return handleExceptionInternal(ex, problemDetail, headers, status, request)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleGenericException(
+        exception: Exception,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        log.error(exception.message, exception)
+
+        val status = HttpStatus.INTERNAL_SERVER_ERROR
+        val problemDetail = ProblemDetail.forStatusAndDetail(status, exception.message)
+        problemDetail.title = localizedTitle(status, request)
+
+        return renderResponse(problemDetail, status, request)
+    }
+
+    private fun localizedTitle(status: HttpStatus, request: WebRequest): String = messageSource.getMessage(
+        "http-error.${status.value()}.title",
+        arrayOf<Any>(),
+        request.locale,
+    )
+
+    /**
      * If the incoming request's `Accept` header contains `text/event-stream`, a normal JSON error
      * body would not be understood by the open `EventSource` - it's written instead as an
      * `event: error` SSE frame so an in-flight SSE connection doesn't just look like it silently
      * broke.
      */
-    private fun createErrorResponse(
-        exception: Exception,
-        status: HttpStatus,
-        request: WebRequest,
-        locale: Locale,
-        message: String? = exception.message,
-    ): ResponseEntity<Any> {
-        val localizedErrorTitle: String = messageSource.getMessage(
-            "http-error.${status.value()}.title",
-            arrayOf<Any>(),
-            locale,
-        )
-
-        val error = TafelErrorResponse(
-            timestamp = LocalDateTime.now(),
-            status = status.value(),
-            error = localizedErrorTitle,
-            message = message,
-            trace = exception.stackTraceToString(),
-            path = (request as ServletWebRequest).request.requestURI,
-        )
-
+    private fun renderResponse(problemDetail: ProblemDetail, status: HttpStatus, request: WebRequest): ResponseEntity<Any> {
         val isSseRequest = request.getHeader("Accept")?.contains("text/event-stream") == true
         return if (isSseRequest) {
-            val errorMessage = jsonMapper.writeValueAsString(error)
+            val errorMessage = jsonMapper.writeValueAsString(problemDetail)
             ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .contentType(MediaType.TEXT_EVENT_STREAM)
-                .body("event: error\ndata: $errorMessage\n\n")
+                .body<Any>("event: error\ndata: $errorMessage\n\n")
         } else {
-            ResponseEntity.status(status).body(error)
+            ResponseEntity.status(status).body<Any>(problemDetail)
         }
     }
 }
 
 @ExcludeFromTestCoverage
-data class TafelErrorResponse(
-    val timestamp: LocalDateTime,
-    val status: Int,
-    val error: String,
+data class FieldErrorItem(
+    val field: String,
     val message: String?,
-    val trace: String?,
-    val path: String?,
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/TafelExceptions.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/TafelExceptions.kt
@@ -2,30 +2,50 @@ package at.wrk.tafel.admin.backend.modules.base.exception
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ProblemDetail
+import org.springframework.web.ErrorResponseException
 
 /**
- * Signals an unexpected/internal failure (e.g. a downstream dependency misbehaving).
- *
- * Structurally identical to [TafelValidationException] - both carry an optional [status]
- * ([GenericExceptionHandler] defaults to [org.springframework.http.HttpStatus.BAD_REQUEST] when
- * null). The distinction is intent/log severity only: [GenericExceptionHandler] logs this one at
- * `warn`, not the expected-failure `debug` level used for [TafelValidationException].
+ * Base for all Tafel-specific API exceptions. Each subclass fixes its own [HttpStatusCode] in its
+ * constructor, so - unlike the old `TafelException`/`TafelValidationException` with an optional
+ * `status` defaulting to 400 - the correct status can no longer be forgotten at a throw site.
+ * [GenericExceptionHandler] renders the carried [ProblemDetail] as the response body (RFC 7807).
  */
 @ExcludeFromTestCoverage
-class TafelException(
-    override val message: String?,
-    override val cause: Throwable? = null,
-    val status: HttpStatus? = null,
-) : RuntimeException()
+open class TafelApiException(
+    status: HttpStatusCode,
+    detail: String,
+    cause: Throwable? = null,
+) : ErrorResponseException(status, ProblemDetail.forStatusAndDetail(status, detail), cause)
 
 /**
- * Signals an expected, user-facing business-rule violation (e.g. "Ticketnummer bereits
- * vergeben!"). See [TafelException] for how the two differ - only in the log level
- * [GenericExceptionHandler] uses for them.
+ * The addressed resource (typically looked up by an id from the request path) doesn't exist.
  */
 @ExcludeFromTestCoverage
-class TafelValidationException(
-    override val message: String?,
-    override val cause: Throwable? = null,
-    val status: HttpStatus? = null,
-) : RuntimeException()
+class NotFoundException(
+    detail: String,
+    cause: Throwable? = null,
+) : TafelApiException(HttpStatus.NOT_FOUND, detail, cause)
+
+/**
+ * The request conflicts with the current state of a resource (duplicate/already exists, an
+ * in-progress operation on the same resource, etc.).
+ */
+@ExcludeFromTestCoverage
+class ConflictException(
+    detail: String,
+    cause: Throwable? = null,
+) : TafelApiException(HttpStatus.CONFLICT, detail, cause)
+
+/**
+ * A business-rule violation not covered by [NotFoundException]/[ConflictException] - e.g. invalid
+ * references inside a request body, or a precondition failure. Defaults to 400, but callers can
+ * pass a different status (e.g. 422) when that fits better.
+ */
+@ExcludeFromTestCoverage
+class BusinessRuleException(
+    detail: String,
+    status: HttpStatusCode = HttpStatus.BAD_REQUEST,
+    cause: Throwable? = null,
+) : TafelApiException(status, detail, cause)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
@@ -143,7 +143,7 @@ override fun preHandle(request: ..., response: ..., handler: Any): Boolean {
         val methodAnnotation = handler.method.getAnnotation(TafelActiveDistributionRequired::class.java)
         val classAnnotation = handler.beanType.getAnnotation(TafelActiveDistributionRequired::class.java)
         if ((methodAnnotation != null || classAnnotation != null) && distributionRepository.getCurrentDistribution() == null) {
-            throw TafelValidationException("Ausgabe nicht gestartet!")
+            throw BusinessRuleException("Ausgabe nicht gestartet!")
         }
     }
     return true
@@ -161,7 +161,7 @@ methods (`getCurrentTicketNumber`, `reopenAndGetPreviousTicket`, `closeCurrentTi
 distribution is active. That assumption is only safe because every controller entry point into these
 methods is annotated with `@TafelActiveDistributionRequired`. If you add a new caller that bypasses the
 controller layer (another service, a `@Scheduled` job, a test calling the service directly without an
-active distribution), you'll get an `NPE`, not the friendly `TafelValidationException`.
+active distribution), you'll get an `NPE`, not the friendly `BusinessRuleException`.
 
 ## Advisory locks: `CREATE_DISTRIBUTION` / `CLOSE_DISTRIBUTION`
 
@@ -204,7 +204,7 @@ Contributors sometimes assume the backend computes/generates the next ticket num
 val existingTicket = distribution.households.firstOrNull { it.ticketNumber == ticketNumber }
 // Can't assign to another household if already assigned but ok if it's the same household
 if (existingTicket != null && existingHousehold?.household?.id != householdId) {
-    throw TafelValidationException("Ticketnummer $ticketNumber bereits vergeben!")
+    throw ConflictException("Ticketnummer $ticketNumber bereits vergeben!")
 }
 ```
 There is no server-side range check for the 1–999 range mentioned in top-level docs — that range is a

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
@@ -10,7 +10,9 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionCloseValidationResult
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
@@ -62,7 +64,7 @@ class DistributionService(
         val acquired = advisoryLockService.tryWithLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
             val currentDistribution = distributionRepository.getCurrentDistribution()
             if (currentDistribution != null) {
-                throw TafelValidationException("Ausgabe bereits gestartet!")
+                throw ConflictException("Ausgabe bereits gestartet!")
             }
 
             val authenticatedUser = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
@@ -80,7 +82,7 @@ class DistributionService(
         }
 
         if (!acquired) {
-            throw TafelValidationException("Eine neue Ausgabe wird gerade gestartet. Bitte kurz warten und im Anschluss die Seite neu laden.")
+            throw ConflictException("Eine neue Ausgabe wird gerade gestartet. Bitte kurz warten und im Anschluss die Seite neu laden.")
         }
 
         return result!!
@@ -103,14 +105,14 @@ class DistributionService(
         val distribution = getCurrentDistribution()!!
 
         val household = householdRepository.findByHouseholdId(householdId)
-            ?: throw TafelValidationException("Kunde Nr. $householdId nicht vorhanden!")
+            ?: throw NotFoundException("Kunde Nr. $householdId nicht vorhanden!")
         val existingHousehold = distribution.households.firstOrNull { it.household?.householdId == householdId }
 
         val existingTicket = distribution.households.firstOrNull { it.ticketNumber == ticketNumber }
 
         // Can't assign to another household if already assigned but ok if it's the same household (update costContributionPaid flag)
         if (existingTicket != null && existingHousehold?.household?.id != householdId) {
-            throw TafelValidationException("Ticketnummer $ticketNumber bereits vergeben!")
+            throw ConflictException("Ticketnummer $ticketNumber bereits vergeben!")
         }
 
         val entry = existingHousehold ?: DistributionHouseholdEntity()
@@ -296,7 +298,7 @@ class DistributionService(
         }
 
         if (!acquired) {
-            throw TafelValidationException("Die Ausgabe wird gerade geschlossen. Bitte kurz warten und im Anschluss die Seite neu laden.")
+            throw ConflictException("Die Ausgabe wird gerade geschlossen. Bitte kurz warten und im Anschluss die Seite neu laden.")
         }
 
         return result!!
@@ -353,7 +355,7 @@ class DistributionService(
 
         val currentStatistic = currentDistribution.statistic
         if (currentStatistic == null) {
-            throw TafelValidationException("Statistik-Daten nicht vorhanden!")
+            throw BusinessRuleException("Statistik-Daten nicht vorhanden!")
         } else {
             currentStatistic.employeeCount = employeeCount
 
@@ -391,7 +393,7 @@ class DistributionService(
     @Transactional(readOnly = true)
     fun sendMails(distributionId: Long) {
         distributionRepository.findByIdOrNull(distributionId)
-            ?: throw TafelValidationException("Ausgabe nicht gefunden!")
+            ?: throw NotFoundException("Ausgabe nicht gefunden!")
 
         try {
             eventPublisher.publishEvent(DistributionClosedEvent(distributionId))

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticService.kt
@@ -4,7 +4,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -38,7 +38,7 @@ class DistributionStatisticService(
     }
 
     private fun saveStatisticEntry(distribution: DistributionEntity): DistributionStatisticEntity {
-        val statistic = distribution.statistic ?: throw TafelValidationException("Statistik-Daten nicht vorhanden!")
+        val statistic = distribution.statistic ?: throw BusinessRuleException("Statistik-Daten nicht vorhanden!")
         val statisticStartTime = distribution.startedAt!!.toLocalDate().atStartOfDay()
         val statisticEndTime = distribution.endedAt!!
         statistic.distribution = distribution

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/MissingCostContributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/MissingCostContributionService.kt
@@ -6,7 +6,7 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueType
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -42,7 +42,7 @@ class MissingCostContributionService(
             LocalDate.now(),
         )
         if (costContributionValue == null) {
-            throw TafelValidationException("No cost contribution value found. Skipping missing cost contribution post processing.")
+            throw BusinessRuleException("No cost contribution value found. Skipping missing cost contribution post processing.")
         }
 
         val householdsMissingCostContribution = distribution.households

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketController.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.distribution.internal.ticket
 
 import at.wrk.tafel.admin.backend.common.api.TafelActiveDistributionRequired
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.TicketNumberResponse
 import org.slf4j.LoggerFactory
@@ -39,7 +39,7 @@ class DistributionTicketController(
     ): ResponseEntity<Unit> {
         val deleted = service.deleteCurrentTicket(householdId)
         if (!deleted) {
-            throw TafelValidationException("Löschen des Tickets von Kunde Nr. $householdId fehlgeschlagen!")
+            throw BusinessRuleException("Löschen des Tickets von Kunde Nr. $householdId fehlgeschlagen!")
         }
         return ResponseEntity.noContent().build()
     }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
@@ -2,7 +2,8 @@ package at.wrk.tafel.admin.backend.modules.household
 
 import at.wrk.tafel.admin.backend.common.api.PagedResponse
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.household.internal.HouseholdDuplicationService
 import at.wrk.tafel.admin.backend.modules.household.internal.HouseholdService
 import jakarta.validation.Valid
@@ -46,7 +47,7 @@ class HouseholdController(
 
         household.id?.let {
             if (householdService.existsByHouseholdId(it)) {
-                throw TafelValidationException("Kunde Nr. $it bereits vorhanden!")
+                throw ConflictException("Kunde Nr. $it bereits vorhanden!")
             }
         }
 
@@ -65,10 +66,7 @@ class HouseholdController(
         val isSupervisor = authenticatedUser.hasRole("SUPERVISOR")
 
         if (!householdService.existsByHouseholdId(householdId)) {
-            throw TafelValidationException(
-                message = "Kunde Nr. $householdId nicht vorhanden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            throw NotFoundException("Kunde Nr. $householdId nicht vorhanden!")
         }
 
         return householdService.updateHousehold(householdId, household, force, isSupervisor)
@@ -77,10 +75,7 @@ class HouseholdController(
     @GetMapping("/{householdId}")
     @PreAuthorize("hasAuthority('CUSTOMER')")
     fun getHousehold(@PathVariable householdId: Long): Household = householdService.findByHouseholdId(householdId)
-        ?: throw TafelValidationException(
-            message = "Kunde Nr. $householdId nicht gefunden!",
-            status = HttpStatus.NOT_FOUND,
-        )
+        ?: throw NotFoundException("Kunde Nr. $householdId nicht gefunden!")
 
     @GetMapping
     @PreAuthorize("hasAuthority('CUSTOMER')")
@@ -113,10 +108,7 @@ class HouseholdController(
     @PreAuthorize("hasAuthority('CUSTOMER')")
     fun deleteHousehold(@PathVariable householdId: Long): ResponseEntity<Unit> {
         if (!householdService.existsByHouseholdId(householdId)) {
-            throw TafelValidationException(
-                message = "Kunde Nr. $householdId nicht vorhanden!",
-                status = HttpStatus.NOT_FOUND,
-            )
+            throw NotFoundException("Kunde Nr. $householdId nicht vorhanden!")
         }
 
         householdService.deleteHouseholdByHouseholdId(householdId)
@@ -142,10 +134,7 @@ class HouseholdController(
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_PDF)
                 .body(InputStreamResource(ByteArrayInputStream(pdfResult.bytes)))
-        } ?: throw TafelValidationException(
-            message = "Kunde Nr. $householdId nicht vorhanden!",
-            status = HttpStatus.NOT_FOUND,
-        )
+        } ?: throw NotFoundException("Kunde Nr. $householdId nicht vorhanden!")
     }
 
     @GetMapping("/above-limit")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/README.md
@@ -166,7 +166,7 @@ client-computed result can't be trusted) go through it.
 differently depending on the caller's role:
 - Non-supervisor: the household is saved anyway, but forced `validUntil = yesterday` (i.e. saved as
   already-invalid), and an `errorMsg` is returned to inform the user.
-- Supervisor without `force=true`: rejected outright with `TafelValidationException` (409 Conflict) -
+- Supervisor without `force=true`: rejected outright with `ConflictException` (409 Conflict) -
   supervisors get a chance to review and confirm before overriding.
 - Supervisor with `force=true`: saved as-is (validity untouched), no error.
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -9,7 +9,7 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs.Companion.postProcessingNecessary
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs.Companion.validHousehold
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.household.Household
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAboveLimitItem
 import at.wrk.tafel.admin.backend.modules.household.HouseholdCreationResponse
@@ -24,7 +24,6 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.Specification.where
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -51,10 +50,7 @@ class HouseholdService(
         val valid = incomeValidatorService.validate(mapToValidationPersons(household)).valid
         if (!valid && isSupervisor) {
             if (!force) {
-                throw TafelValidationException(
-                    message = "Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)",
-                    status = HttpStatus.CONFLICT,
-                )
+                throw ConflictException("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
             } else {
                 val savedEntity = saveWithMainPerson(entity)
                 return HouseholdCreationResponse(
@@ -92,10 +88,7 @@ class HouseholdService(
         val valid = incomeValidatorService.validate(mapToValidationPersons(household)).valid
         if (!valid && isSupervisor) {
             if (!force) {
-                throw TafelValidationException(
-                    message = "Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)",
-                    status = HttpStatus.CONFLICT,
-                )
+                throw ConflictException("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
             } else {
                 val savedEntity = saveWithMainPerson(mappedEntity)
                 return HouseholdUpdateResponse(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/README.md
@@ -13,8 +13,8 @@ destinations), **shops** (pickup points), and **cars** (the vehicle fleet).
 )
 ```
 
-- `base::exception` — for `TafelValidationException`, thrown by every service here on
-  not-found/invalid-reference (see below).
+- `base::exception` — for `NotFoundException`/`BusinessRuleException`, thrown by every service here
+  on not-found/invalid-reference (see below).
 - `base::employee` — **not** for generic "created/updated by" change tracking (this module's
   entities don't have that; `BaseChangeTrackingEntity` only carries `createdAt`/`updatedAt`
   timestamps, no employee FK). It's needed because `FoodCollectionEntity` has two real,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarService.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.CarEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.CarRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Car
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -37,7 +37,7 @@ class CarService(
 
     fun updateCar(carId: Long, updatedCar: Car): Car {
         val carEntity = carRepository.findByIdOrNull(carId)
-            ?: throw TafelValidationException("Car with id $carId not found")
+            ?: throw NotFoundException("Car with id $carId not found")
 
         carEntity.licensePlate = updatedCar.licensePlate
         carEntity.name = updatedCar.name
@@ -52,7 +52,7 @@ class CarService(
     fun reorderCars(carIds: List<Long>) {
         carIds.forEachIndexed { index, carId ->
             val entity = carRepository.findByIdOrNull(carId)
-                ?: throw TafelValidationException("Car with id $carId not found")
+                ?: throw NotFoundException("Car with id $carId not found")
 
             entity.sortOrder = index + 1
             carRepository.save(entity)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryService.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
@@ -37,7 +37,7 @@ class FoodCategoryService(
 
     fun updateFoodCategory(foodCategoryId: Long, updatedCategory: FoodCategory): FoodCategory {
         val entity = foodCategoriesRepository.findByIdOrNull(foodCategoryId)
-            ?: throw TafelValidationException("FoodCategory with id $foodCategoryId not found")
+            ?: throw NotFoundException("FoodCategory with id $foodCategoryId not found")
 
         entity.name = updatedCategory.name
         entity.weightPerUnit = updatedCategory.weightPerUnit
@@ -53,7 +53,7 @@ class FoodCategoryService(
     fun reorderFoodCategories(categoryIds: List<Long>) {
         categoryIds.forEachIndexed { index, categoryId ->
             val entity = foodCategoriesRepository.findByIdOrNull(categoryId)
-                ?: throw TafelValidationException("FoodCategory with id $categoryId not found")
+                ?: throw NotFoundException("FoodCategory with id $categoryId not found")
 
             entity.sortOrder = index + 1
             foodCategoriesRepository.save(entity)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionService.kt
@@ -9,7 +9,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionReposi
 import at.wrk.tafel.admin.backend.database.model.distribution.getCurrentDistribution
 import at.wrk.tafel.admin.backend.database.model.logistics.*
 import at.wrk.tafel.admin.backend.modules.base.employee.Employee
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.*
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -150,9 +150,9 @@ class FoodCollectionService(
             items.add(
                 FoodCollectionItemEntity().apply {
                     category = foodCategoryRepository.findByIdOrNull(categoryId)
-                        ?: throw TafelValidationException("Kategorie ungültig!")
+                        ?: throw NotFoundException("Kategorie nicht gefunden!")
                     shop = shopRepository.findByIdOrNull(shopId)
-                        ?: throw TafelValidationException("Filiale ungültig!")
+                        ?: throw NotFoundException("Filiale nicht gefunden!")
                     amount = newAmount
                 },
             )
@@ -167,7 +167,7 @@ class FoodCollectionService(
     } ?: FoodCollectionEntity().apply {
         distribution = distributionEntity
         route = routeRepository.findByIdOrNull(routeId)
-            ?: throw TafelValidationException("Route $routeId nicht gefunden!")
+            ?: throw NotFoundException("Route $routeId nicht gefunden!")
     }
 
     private fun mapEmployee(employee: EmployeeEntity): Employee = Employee(
@@ -189,13 +189,13 @@ class FoodCollectionService(
         return entity.apply {
             distribution = distributionEntity
             route = routeRepository.findByIdOrNull(routeId)
-                ?: throw TafelValidationException("Route $routeId nicht gefunden!")
+                ?: throw NotFoundException("Route $routeId nicht gefunden!")
             car = carRepository.findByIdOrNull(data.carId)
-                ?: throw TafelValidationException("Ungültiges KFZ!")
+                ?: throw NotFoundException("KFZ nicht gefunden!")
             driver = employeeRepository.findByIdOrNull(data.driverId)
-                ?: throw TafelValidationException("Ungültiger Fahrer!")
+                ?: throw NotFoundException("Fahrer nicht gefunden!")
             coDriver = employeeRepository.findByIdOrNull(data.coDriverId)
-                ?: throw TafelValidationException("Ungültiger Beifahrer!")
+                ?: throw NotFoundException("Beifahrer nicht gefunden!")
             kmStart = data.kmStart
             kmEnd = data.kmEnd
         }
@@ -213,7 +213,7 @@ class FoodCollectionService(
         return entity.apply {
             distribution = distributionEntity
             route = routeRepository.findByIdOrNull(routeId)
-                ?: throw TafelValidationException("Route $routeId nicht gefunden!")
+                ?: throw NotFoundException("Route $routeId nicht gefunden!")
             items = mapItemsToEntity(data.items)
         }
     }
@@ -221,9 +221,9 @@ class FoodCollectionService(
     private fun mapItemsToEntity(items: List<FoodCollectionItem>): List<FoodCollectionItemEntity> = items.map {
         FoodCollectionItemEntity().apply {
             category = foodCategoryRepository.findByIdOrNull(it.categoryId)
-                ?: throw TafelValidationException("Kategorie ungültig!")
+                ?: throw NotFoundException("Kategorie nicht gefunden!")
             shop = shopRepository.findByIdOrNull(it.shopId)
-                ?: throw TafelValidationException("Filiale ungültig!")
+                ?: throw NotFoundException("Filiale nicht gefunden!")
             amount = it.amount
         }
     }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
@@ -3,7 +3,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterContactEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContact
 import org.springframework.data.repository.findByIdOrNull
@@ -78,7 +78,7 @@ class ShelterService(
 
     fun updateShelter(shelterId: Long, updatedShelter: Shelter): Shelter {
         val shelterEntity = shelterRepository.findByIdOrNull(shelterId)
-            ?: throw TafelValidationException("Shelter with id $shelterId not found")
+            ?: throw NotFoundException("Shelter with id $shelterId not found")
 
         shelterEntity.name = updatedShelter.name
         shelterEntity.addressStreet = updatedShelter.addressStreet
@@ -110,7 +110,7 @@ class ShelterService(
     fun reorderShelters(shelterIds: List<Long>) {
         shelterIds.forEachIndexed { index, shelterId ->
             val entity = shelterRepository.findByIdOrNull(shelterId)
-                ?: throw TafelValidationException("Shelter with id $shelterId not found")
+                ?: throw NotFoundException("Shelter with id $shelterId not found")
 
             entity.sortOrder = index + 1
             shelterRepository.save(entity)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopService.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shop
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -15,7 +15,7 @@ class ShopService(
     @Transactional(readOnly = true)
     fun getShopsForRouteId(routeId: Long): List<Shop> {
         val route =
-            routeRepository.findByIdOrNull(routeId) ?: throw TafelValidationException("Route $routeId nicht gefunden!")
+            routeRepository.findByIdOrNull(routeId) ?: throw NotFoundException("Route $routeId nicht gefunden!")
         return route.stops.sortedBy { it.time }
             .mapNotNull { it.shop }
             .map { shop ->

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
@@ -13,7 +13,7 @@ limits). Both are exposed under `/api/settings` behind `@PreAuthorize("hasAuthor
 ```
 
 Confirmed — the only declared cross-module dependency is `base::exception`
-(`TafelValidationException`, thrown by `updateStaticValue()` when the id doesn't exist).
+(`NotFoundException`, thrown by `updateStaticValue()` when the id doesn't exist).
 
 **Why nothing else needs to be declared:** the entities this module manages —
 `MailRecipientEntity`/`MailRecipientRepository`/`MailType`/`RecipientType` (in

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsService.kt
@@ -6,7 +6,7 @@ import at.wrk.tafel.admin.backend.database.model.base.MailType
 import at.wrk.tafel.admin.backend.database.model.base.RecipientType
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientAdresses
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientType
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
@@ -106,7 +106,7 @@ class SettingsService(
     )
     fun updateStaticValue(staticValueId: Long, item: StaticValueItem): StaticValueItem {
         val entity = staticValueRepository.findByIdOrNull(staticValueId)
-            ?: throw TafelValidationException("Statischer Wert mit ID $staticValueId nicht gefunden")
+            ?: throw NotFoundException("Statischer Wert mit ID $staticValueId nicht gefunden")
 
         val today = LocalDate.now()
 

--- a/backend/src/main/resources/i18n/messages.properties
+++ b/backend/src/main/resources/i18n/messages.properties
@@ -1,4 +1,5 @@
 http-error.400.title=Ungültige Aktion
 http-error.404.title=Nicht gefunden
+http-error.409.title=Konflikt
 http-error.422.title=Verarbeitungsfehler
 http-error.500.title=Interner Serverfehler

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/api/ActiveDistributionRequiredInterceptorTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/api/ActiveDistributionRequiredInterceptorTest.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.common.api
 
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionEntity
 import io.mockk.every
 import io.mockk.mockk
@@ -36,10 +36,10 @@ class ActiveDistributionRequiredInterceptorTest {
         every { handlerMethod.beanType } returns this::class.java
         every { distributionRepository.findFirstByOrderByIdDesc() } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<BusinessRuleException> {
             interceptor.preHandle(request, response, handlerMethod)
         }
-        assertThat(exception.message).isEqualTo("Ausgabe nicht gestartet!")
+        assertThat(exception.body.detail).isEqualTo("Ausgabe nicht gestartet!")
     }
 
     @Test
@@ -75,10 +75,10 @@ class ActiveDistributionRequiredInterceptorTest {
         every { handlerMethod.beanType } returns AnnotatedClass::class.java
         every { distributionRepository.findFirstByOrderByIdDesc() } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<BusinessRuleException> {
             interceptor.preHandle(request, response, handlerMethod)
         }
-        assertThat(exception.message).isEqualTo("Ausgabe nicht gestartet!")
+        assertThat(exception.body.detail).isEqualTo("Ausgabe nicht gestartet!")
     }
 
     @TafelActiveDistributionRequired

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/lock/AdvisoryLockServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/lock/AdvisoryLockServiceTest.kt
@@ -1,6 +1,5 @@
 package at.wrk.tafel.admin.backend.database.common.lock
 
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -45,9 +44,9 @@ class AdvisoryLockServiceTest {
 
     @Test
     fun `withLock should release lock even when block throws exception`() {
-        assertThrows<TafelValidationException> {
+        assertThrows<IllegalStateException> {
             service.withLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
-                throw TafelValidationException("test exception")
+                throw IllegalStateException("test exception")
             }
         }
 
@@ -89,9 +88,9 @@ class AdvisoryLockServiceTest {
     fun `tryWithLock should release lock even when block throws exception`() {
         every { repository.tryAcquireLock(AdvisoryLockKey.CREATE_DISTRIBUTION.lockId) } returns true
 
-        assertThrows<TafelValidationException> {
+        assertThrows<IllegalStateException> {
             service.tryWithLock(AdvisoryLockKey.CREATE_DISTRIBUTION) {
-                throw TafelValidationException("test exception")
+                throw IllegalStateException("test exception")
             }
         }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxServiceTest.kt
@@ -1,7 +1,6 @@
 package at.wrk.tafel.admin.backend.database.common.sseoutbox
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelException
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -354,7 +353,7 @@ class SseOutboxServiceTest {
         }
 
         // Trigger error
-        onErrorSlot.captured.accept(TafelException("test error"))
+        onErrorSlot.captured.accept(IllegalStateException("test error"))
 
         verify {
             sseOutboxListenerService.unregisterCallback(

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
@@ -5,7 +5,8 @@ import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
 import at.wrk.tafel.admin.backend.modules.base.employee.Employee
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -13,8 +14,8 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -165,14 +166,13 @@ class EmployeeServiceTest {
     fun `update employee throws exception when not found`() {
         every { employeeRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy {
+        val exception = assertThrows<NotFoundException> {
             employeeService.updateEmployee(
                 99L,
                 EmployeeCreateRequest(personnelNumber = "00001", firstname = "first", lastname = "last"),
             )
         }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Employee with id 99 not found")
+        assertThat(exception.body.detail).isEqualTo("Employee with id 99 not found")
     }
 
     @Test
@@ -187,13 +187,12 @@ class EmployeeServiceTest {
         every { employeeRepository.findByIdOrNull(employeeId) } returns existingEntity
         every { employeeRepository.existsByPersonnelNumberAndIdNot("00002", employeeId) } returns true
 
-        assertThatThrownBy {
+        val exception = assertThrows<ConflictException> {
             employeeService.updateEmployee(
                 employeeId,
                 EmployeeCreateRequest(personnelNumber = "00002", firstname = "first", lastname = "last"),
             )
         }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Mitarbeiter 00002 ist bereits vorhanden!")
+        assertThat(exception.body.detail).isEqualTo("Mitarbeiter 00002 ist bereits vorhanden!")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.MessageSource
 import org.springframework.core.MethodParameter
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -37,108 +39,77 @@ internal class GenericExceptionHandlerTest {
     @BeforeEach
     fun beforeEach() {
         every { request.request.requestURI } returns "/dummy-path"
+        every { request.locale } returns Locale.GERMAN
     }
 
     @Test
-    fun `handles Exception properly`() {
+    fun `handles NotFoundException properly`() {
         every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
+            messageSource.getMessage("http-error.${HttpStatus.NOT_FOUND.value()}.title", arrayOf<Any>(), Locale.GERMAN)
         } returns "localized-title"
-        val exception = IllegalArgumentException("test-msg")
+        val exception = NotFoundException("notfound-msg")
 
-        val response = exceptionHandler.handleException(exception, request, Locale.GERMAN)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
-        val errorBody = response.body as TafelErrorResponse
-        assertThat(errorBody.timestamp).isNotNull()
-        assertThat(errorBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
-        assertThat(errorBody.error).isEqualTo("localized-title")
-        assertThat(errorBody.message).isEqualTo("test-msg")
-        assertThat(errorBody.trace).startsWith("java.lang.IllegalArgumentException: test-msg")
-        assertThat(errorBody.path).isEqualTo("/dummy-path")
-    }
-
-    @Test
-    fun `handles TafelException properly`() {
-        every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.BAD_REQUEST.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
-        } returns "localized-title"
-        val exception = TafelException("tafelexception-msg")
-
-        val response = exceptionHandler.handleTafelException(exception, request, Locale.GERMAN)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-        val errorBody = response.body as TafelErrorResponse
-        assertThat(errorBody.timestamp).isNotNull()
-        assertThat(errorBody.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
-        assertThat(errorBody.error).isEqualTo("localized-title")
-        assertThat(errorBody.message).isEqualTo("tafelexception-msg")
-        assertThat(errorBody.trace).startsWith("at.wrk.tafel.admin.backend.modules.base.exception.TafelException: tafelexception-msg")
-        assertThat(errorBody.path).isEqualTo("/dummy-path")
-    }
-
-    @Test
-    fun `handles TafelException and status overrides defaultvalue`() {
-        every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.NOT_FOUND.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
-        } returns "localized-title"
-        val exception = TafelException(message = "tafelexception-msg", status = HttpStatus.NOT_FOUND)
-
-        val response = exceptionHandler.handleTafelException(exception, request, Locale.GERMAN)
+        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
-        val errorBody = response.body as TafelErrorResponse
-        assertThat(errorBody.timestamp).isNotNull()
+        val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.NOT_FOUND.value())
-        assertThat(errorBody.error).isEqualTo("localized-title")
-        assertThat(errorBody.message).isEqualTo("tafelexception-msg")
-        assertThat(errorBody.trace).startsWith("at.wrk.tafel.admin.backend.modules.base.exception.TafelException: tafelexception-msg")
-        assertThat(errorBody.path).isEqualTo("/dummy-path")
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("notfound-msg")
     }
 
     @Test
-    fun `handles TafelValidationException properly`() {
+    fun `handles ConflictException properly`() {
         every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.BAD_REQUEST.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
+            messageSource.getMessage("http-error.${HttpStatus.CONFLICT.value()}.title", arrayOf<Any>(), Locale.GERMAN)
         } returns "localized-title"
+        val exception = ConflictException("conflict-msg")
 
-        val exception = TafelValidationException("tafelvalidationexception-msg")
-        val response = exceptionHandler.handleTafelValidationException(exception, request, Locale.GERMAN)
+        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.status).isEqualTo(HttpStatus.CONFLICT.value())
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("conflict-msg")
+    }
+
+    @Test
+    fun `handles BusinessRuleException with default status`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val exception = BusinessRuleException("businessrule-msg")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-        val errorBody = response.body as TafelErrorResponse
-        assertThat(errorBody.timestamp).isNotNull()
+        val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
-        assertThat(errorBody.error).isEqualTo("localized-title")
-        assertThat(errorBody.message).isEqualTo("tafelvalidationexception-msg")
-        assertThat(errorBody.trace).startsWith("at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException: tafelvalidationexception-msg")
-        assertThat(errorBody.path).isEqualTo("/dummy-path")
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("businessrule-msg")
+    }
+
+    @Test
+    fun `handles BusinessRuleException with explicit status`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.UNPROCESSABLE_CONTENT.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val exception = BusinessRuleException("businessrule-msg", status = HttpStatus.UNPROCESSABLE_CONTENT)
+
+        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT)
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.status).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT.value())
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("businessrule-msg")
     }
 
     @Test
     fun `handles MethodArgumentNotValidException properly`() {
         every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.BAD_REQUEST.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
+            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
         } returns "localized-title"
 
         val bindingResult = BeanPropertyBindingResult("target", "targetObject")
@@ -146,31 +117,46 @@ internal class GenericExceptionHandlerTest {
         bindingResult.addError(FieldError("targetObject", "fieldTwo", "must be positive"))
         val exception = MethodArgumentNotValidException(mockk<MethodParameter>(relaxed = true), bindingResult)
 
-        val response = exceptionHandler.handleMethodArgumentNotValidException(exception, request, Locale.GERMAN)
+        val response = exceptionHandler.handleMethodArgumentNotValid(exception, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-        val errorBody = response.body as TafelErrorResponse
-        assertThat(errorBody.timestamp).isNotNull()
+        val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
-        assertThat(errorBody.error).isEqualTo("localized-title")
-        assertThat(errorBody.message).isEqualTo("fieldOne: must not be blank; fieldTwo: must be positive")
-        assertThat(errorBody.path).isEqualTo("/dummy-path")
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.properties?.get("errors")).isEqualTo(
+            listOf(
+                FieldErrorItem("fieldOne", "must not be blank"),
+                FieldErrorItem("fieldTwo", "must be positive"),
+            ),
+        )
+    }
+
+    @Test
+    fun `handles Exception properly`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val exception = IllegalArgumentException("test-msg")
+
+        val response = exceptionHandler.handleGenericException(exception, request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("test-msg")
     }
 
     @Test
     fun `handles exception in SSE properly`() {
         every { request.getHeader("Accept") } returns "text/event-stream"
         every {
-            messageSource.getMessage(
-                "http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title",
-                arrayOf<Any>(),
-                any(),
-            )
+            messageSource.getMessage("http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title", arrayOf<Any>(), Locale.GERMAN)
         } returns "localized-title"
         val exception = IllegalArgumentException("test-msg")
         every { jsonMapper.writeValueAsString(any()) } returns exception.message
 
-        val response = exceptionHandler.handleException(exception, request, Locale.GERMAN)
+        val response = exceptionHandler.handleGenericException(exception, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
         val errorBody = response.body as String

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
@@ -2,7 +2,6 @@ package at.wrk.tafel.admin.backend.modules.distribution
 
 import at.wrk.tafel.admin.backend.database.common.sseoutbox.SseOutboxService
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionController.Companion.DISTRIBUTION_UPDATE_NOTIFICATION_NAME
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.*
@@ -72,9 +71,9 @@ internal class DistributionControllerTest {
     @Test
     fun `create new distribution with existing ongoing distribution`() {
         val message = "MSG"
-        every { service.createNewDistributionItem() } throws TafelException(message)
+        every { service.createNewDistributionItem() } throws IllegalStateException(message)
 
-        val exception = assertThrows(TafelException::class.java) {
+        val exception = assertThrows(IllegalStateException::class.java) {
             controller.createNewDistribution()
         }
 
@@ -266,11 +265,11 @@ internal class DistributionControllerTest {
                 any(),
                 any(),
             )
-        } throws TafelException("dummy error")
+        } throws IllegalStateException("dummy error")
 
         val requestBody = AssignHouseholdRequest(householdId = 1, ticketNumber = 100)
 
-        val exception = assertThrows<TafelException> {
+        val exception = assertThrows<IllegalStateException> {
             controller.assignHouseholdToDistribution(requestBody)
         }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionEndedEventListenerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionEndedEventListenerTest.kt
@@ -3,7 +3,6 @@ package at.wrk.tafel.admin.backend.modules.distribution.internal
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent
 import at.wrk.tafel.admin.backend.modules.distribution.internal.statistic.DistributionStatisticService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.statistic.MissingCostContributionService
@@ -91,8 +90,8 @@ internal class DistributionEndedEventListenerTest {
         every { distributionStatisticService.saveStatistic(distribution) } returns distributionStatistic
         every { distributionRepository.findById(distributionId) } returns Optional.of(distribution)
         every { missingCostContributionService.addMissingCostContributions(distribution) } throws
-            TafelValidationException("transient failure") andThenThrows
-            TafelValidationException("transient failure") andThen Unit
+            IllegalStateException("transient failure") andThenThrows
+            IllegalStateException("transient failure") andThen Unit
 
         listener.onDistributionEnded(DistributionEndedEvent(distributionId))
 
@@ -104,7 +103,7 @@ internal class DistributionEndedEventListenerTest {
     @Test
     fun `rolls back, retries, and never publishes event when adding missing cost contributions keeps failing`() {
         every { missingCostContributionService.addMissingCostContributions(any()) } throws
-            TafelValidationException("Test exception")
+            IllegalStateException("Test exception")
 
         val distributionId = 123L
         val distribution = mockk<DistributionEntity>()
@@ -114,7 +113,7 @@ internal class DistributionEndedEventListenerTest {
         every { distributionStatisticService.saveStatistic(distribution) } returns distributionStatistic
         every { distributionRepository.findById(distributionId) } returns Optional.of(distribution)
 
-        assertThrows<TafelValidationException> {
+        assertThrows<IllegalStateException> {
             listener.onDistributionEnded(DistributionEndedEvent(distributionId))
         }
 
@@ -124,7 +123,7 @@ internal class DistributionEndedEventListenerTest {
 
     @Test
     fun `forwards the error when event publishing fails, without retrying it`() {
-        every { eventPublisher.publishEvent(any<DistributionClosedEvent>()) } throws TafelValidationException("Test exception")
+        every { eventPublisher.publishEvent(any<DistributionClosedEvent>()) } throws IllegalStateException("Test exception")
 
         val distributionId = 123L
         val distribution = mockk<DistributionEntity>()
@@ -134,7 +133,7 @@ internal class DistributionEndedEventListenerTest {
         every { distributionStatisticService.saveStatistic(distribution) } returns distributionStatistic
         every { distributionRepository.findById(distributionId) } returns Optional.of(distribution)
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<IllegalStateException> {
             listener.onDistributionEnded(DistributionEndedEvent(distributionId))
         }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
@@ -12,7 +12,9 @@ import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListItem
@@ -299,22 +301,22 @@ internal class DistributionServiceTest {
             true
         }
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.createNewDistribution()
         }
 
-        assertThat(exception.message).isEqualTo("Ausgabe bereits gestartet!")
+        assertThat(exception.body.detail).isEqualTo("Ausgabe bereits gestartet!")
     }
 
     @Test
     fun `create new distribution with existing lock`() {
         every { advisoryLockService.tryWithLock(any(), any()) } returns false
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.createNewDistribution()
         }
 
-        assertThat(exception.message).isEqualTo("Eine neue Ausgabe wird gerade gestartet. Bitte kurz warten und im Anschluss die Seite neu laden.")
+        assertThat(exception.body.detail).isEqualTo("Eine neue Ausgabe wird gerade gestartet. Bitte kurz warten und im Anschluss die Seite neu laden.")
     }
 
     @Test
@@ -426,9 +428,9 @@ internal class DistributionServiceTest {
             block.invoke()
             true
         }
-        every { eventPublisher.publishEvent(any<DistributionEndedEvent>()) } throws TafelValidationException("Test exception")
+        every { eventPublisher.publishEvent(any<DistributionEndedEvent>()) } throws IllegalStateException("Test exception")
 
-        val exception = assertThrows<TafelValidationException> { service.closeDistribution() }
+        val exception = assertThrows<IllegalStateException> { service.closeDistribution() }
         assertThat(exception.message).isEqualTo("Test exception")
     }
 
@@ -446,11 +448,11 @@ internal class DistributionServiceTest {
     fun `close distribution with existing lock`() {
         every { advisoryLockService.tryWithLock(any(), any()) } returns false
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.closeDistribution()
         }
 
-        assertThat(exception.message).isEqualTo("Die Ausgabe wird gerade geschlossen. Bitte kurz warten und im Anschluss die Seite neu laden.")
+        assertThat(exception.body.detail).isEqualTo("Die Ausgabe wird gerade geschlossen. Bitte kurz warten und im Anschluss die Seite neu laden.")
     }
 
     @Test
@@ -513,14 +515,14 @@ internal class DistributionServiceTest {
         every { distributionRepository.findFirstByOrderByIdDesc() } returns activeDistribution
         every { householdRepository.findByHouseholdId(householdId) } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<NotFoundException> {
             service.assignHouseholdToDistribution(
                 householdId = householdId,
                 ticketNumber = ticketNumber,
             )
         }
 
-        assertThat(exception.message).isEqualTo("Kunde Nr. $householdId nicht vorhanden!")
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. $householdId nicht vorhanden!")
     }
 
     @Test
@@ -596,13 +598,13 @@ internal class DistributionServiceTest {
         every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity
         every { householdRepository.findByHouseholdId(householdId) } returns testHouseholdEntity1
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.assignHouseholdToDistribution(
                 householdId = householdId,
                 ticketNumber = ticketNumber,
             )
         }
-        assertThat(exception.message).isEqualTo("Ticketnummer $ticketNumber bereits vergeben!")
+        assertThat(exception.body.detail).isEqualTo("Ticketnummer $ticketNumber bereits vergeben!")
     }
 
     @Test
@@ -1091,16 +1093,16 @@ internal class DistributionServiceTest {
     fun `send mails with invalid distribution`() {
         every { distributionRepository.findByIdOrNull(testDistributionEntity.id!!) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.sendMails(testDistributionEntity.id!!) }
-        assertThat(exception.message).isEqualTo("Ausgabe nicht gefunden!")
+        val exception = assertThrows<NotFoundException> { service.sendMails(testDistributionEntity.id!!) }
+        assertThat(exception.body.detail).isEqualTo("Ausgabe nicht gefunden!")
     }
 
     @Test
     fun `send mails forwards the error when publishing fails`() {
         every { distributionRepository.findByIdOrNull(testDistributionEntity.id!!) } returns testDistributionEntity
-        every { eventPublisher.publishEvent(any<DistributionClosedEvent>()) } throws TafelValidationException("Test exception")
+        every { eventPublisher.publishEvent(any<DistributionClosedEvent>()) } throws IllegalStateException("Test exception")
 
-        val exception = assertThrows<TafelValidationException> { service.sendMails(testDistributionEntity.id!!) }
+        val exception = assertThrows<IllegalStateException> { service.sendMails(testDistributionEntity.id!!) }
         assertThat(exception.message).isEqualTo("Test exception")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionServiceTest.kt
@@ -12,7 +12,6 @@ import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
-import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/DistributionStatisticServiceTest.kt
@@ -6,7 +6,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatis
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity2
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity3
@@ -209,7 +209,7 @@ internal class DistributionStatisticServiceTest {
             endedAt = LocalDateTime.now()
         }
 
-        val message = assertThrows<TafelValidationException> { service.saveStatistic(testDistributionEntity) }
-        assertThat(message.message).isEqualTo("Statistik-Daten nicht vorhanden!")
+        val message = assertThrows<BusinessRuleException> { service.saveStatistic(testDistributionEntity) }
+        assertThat(message.body.detail).isEqualTo("Statistik-Daten nicht vorhanden!")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/MissingCostContributionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/statistic/MissingCostContributionServiceTest.kt
@@ -6,7 +6,7 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueType
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity2
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity3
@@ -83,7 +83,7 @@ class MissingCostContributionServiceTest {
 
         val distribution = mockk<DistributionEntity>()
 
-        val exception = assertThrows<TafelValidationException> { service.addMissingCostContributions(distribution) }
-        assertThat(exception.message).isEqualTo("No cost contribution value found. Skipping missing cost contribution post processing.")
+        val exception = assertThrows<BusinessRuleException> { service.addMissingCostContributions(distribution) }
+        assertThat(exception.body.detail).isEqualTo("No cost contribution value found. Skipping missing cost contribution post processing.")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketControllerTest.kt
@@ -1,6 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.distribution.internal.ticket
 
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.TicketNumberResponse
 import io.mockk.every
@@ -64,8 +64,8 @@ internal class DistributionTicketControllerTest {
 
         val householdId = 123L
 
-        val exception = assertThrows<TafelValidationException> { controller.deleteCurrentTicketForHousehold(householdId) }
-        assertThat(exception.message).isEqualTo("Löschen des Tickets von Kunde Nr. 123 fehlgeschlagen!")
+        val exception = assertThrows<BusinessRuleException> { controller.deleteCurrentTicketForHousehold(householdId) }
+        assertThat(exception.body.detail).isEqualTo("Löschen des Tickets von Kunde Nr. 123 fehlgeschlagen!")
 
         verify { service.deleteCurrentTicket(householdId) }
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
@@ -1,7 +1,8 @@
 package at.wrk.tafel.admin.backend.modules.household
 
 import at.wrk.tafel.admin.backend.modules.base.country.Country
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.household.internal.*
 import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValidatorResult
 import at.wrk.tafel.admin.backend.security.testUserEntity
@@ -157,9 +158,9 @@ class HouseholdControllerTest {
     fun `create household - given id and exists already`() {
         every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
 
-        val exception = assertThrows<TafelValidationException> { controller.createHousehold(false, testHousehold) }
+        val exception = assertThrows<ConflictException> { controller.createHousehold(false, testHousehold) }
 
-        assertThat(exception.message).isEqualTo("Kunde Nr. 100 bereits vorhanden!")
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 bereits vorhanden!")
     }
 
     @Test
@@ -203,12 +204,12 @@ class HouseholdControllerTest {
         every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
 
         val exception =
-            assertThrows<TafelValidationException> {
+            assertThrows<NotFoundException> {
                 controller.updateHousehold(testHousehold.id!!, false, testHousehold)
             }
 
-        assertThat(exception.message).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
     }
 
     @Test
@@ -270,10 +271,10 @@ class HouseholdControllerTest {
         every { householdService.findByHouseholdId(testHousehold.id!!) } returns null
 
         val exception =
-            assertThrows<TafelValidationException> { controller.getHousehold(testHousehold.id!!) }
+            assertThrows<NotFoundException> { controller.getHousehold(testHousehold.id!!) }
 
-        assertThat(exception.message).isEqualTo("Kunde Nr. ${testHousehold.id} nicht gefunden!")
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. ${testHousehold.id} nicht gefunden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         verify { householdService.findByHouseholdId(testHousehold.id!!) }
     }
 
@@ -292,10 +293,10 @@ class HouseholdControllerTest {
         every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
 
         val exception =
-            assertThrows<TafelValidationException> { controller.deleteHousehold(testHousehold.id!!) }
+            assertThrows<NotFoundException> { controller.deleteHousehold(testHousehold.id!!) }
 
-        assertThat(exception.message).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         verify { householdService.existsByHouseholdId(testHousehold.id!!) }
     }
 
@@ -383,10 +384,10 @@ class HouseholdControllerTest {
     fun `generate pdf - no result`() {
         every { householdService.generatePdf(any(), any()) } returns null
 
-        val exception = assertThrows<TafelValidationException> { controller.generatePdf(123, HouseholdPdfType.COMBINED) }
+        val exception = assertThrows<NotFoundException> { controller.generatePdf(123, HouseholdPdfType.COMBINED) }
 
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
-        assertThat(exception.message).isEqualTo("Kunde Nr. 123 nicht vorhanden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. 123 nicht vorhanden!")
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
@@ -8,7 +8,7 @@ import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
 import at.wrk.tafel.admin.backend.modules.base.country.Country
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.household.Household
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAddress
 import at.wrk.tafel.admin.backend.modules.household.HouseholdCreationResponse
@@ -280,12 +280,12 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.createHousehold(testHousehold, false, true)
         }
 
-        assertThat(exception.message).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
-        assertThat(exception.status).isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
+        assertThat(exception.body.detail).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
+        assertThat(exception.statusCode).isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
         verify(exactly = 0) { householdRepository.saveAndFlush(any()) }
     }
 
@@ -406,12 +406,12 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<ConflictException> {
             service.updateHousehold(testHouseholdUpdate.id!!, testHouseholdUpdate, force = false, isSupervisor = true)
         }
 
-        assertThat(exception.message).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
-        assertThat(exception.status).isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
+        assertThat(exception.body.detail).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
+        assertThat(exception.statusCode).isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
         verify(exactly = 0) { householdRepository.saveAndFlush(any()) }
     }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarServiceTest.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.CarEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.CarRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Car
 import at.wrk.tafel.admin.backend.modules.logistics.testCar1
 import at.wrk.tafel.admin.backend.modules.logistics.testCar2
@@ -12,8 +12,8 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
 
@@ -91,14 +91,13 @@ class CarServiceTest {
     fun `update car throws exception when not found`() {
         every { carRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy {
+        val exception = assertThrows<NotFoundException> {
             service.updateCar(
                 99L,
                 Car(id = 99L, licensePlate = "X", name = "X", enabled = true, sortOrder = 1),
             )
         }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Car with id 99 not found")
+        assertThat(exception.body.detail).isEqualTo("Car with id 99 not found")
     }
 
     @Test
@@ -185,8 +184,7 @@ class CarServiceTest {
     fun `reorder cars throws exception when a car is not found`() {
         every { carRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy { service.reorderCars(listOf(99L)) }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Car with id 99 not found")
+        val exception = assertThrows<NotFoundException> { service.reorderCars(listOf(99L)) }
+        assertThat(exception.body.detail).isEqualTo("Car with id 99 not found")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryServiceTest.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory1
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory2
@@ -13,8 +13,8 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
 import java.math.BigDecimal
@@ -179,9 +179,8 @@ class FoodCategoryServiceTest {
             enabled = false,
         )
 
-        assertThatThrownBy { service.updateFoodCategory(99L, updated) }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("FoodCategory with id 99 not found")
+        val exception = assertThrows<NotFoundException> { service.updateFoodCategory(99L, updated) }
+        assertThat(exception.body.detail).isEqualTo("FoodCategory with id 99 not found")
     }
 
     @Test
@@ -216,8 +215,7 @@ class FoodCategoryServiceTest {
     fun `reorder categories throws exception when a category is not found`() {
         every { foodCategoryRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy { service.reorderFoodCategories(listOf(99L)) }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("FoodCategory with id 99 not found")
+        val exception = assertThrows<NotFoundException> { service.reorderFoodCategories(listOf(99L)) }
+        assertThat(exception.body.detail).isEqualTo("FoodCategory with id 99 not found")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionServiceTest.kt
@@ -9,7 +9,7 @@ import at.wrk.tafel.admin.backend.database.model.logistics.*
 import at.wrk.tafel.admin.backend.modules.base.employee.Employee
 import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee1
 import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee2
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionEntity
 import at.wrk.tafel.admin.backend.modules.logistics.*
 import at.wrk.tafel.admin.backend.modules.logistics.model.*
@@ -131,8 +131,8 @@ class FoodCollectionServiceTest {
         every { distributionRepository.findFirstByOrderByIdDesc() } returns activeDistribution
         every { routeRepository.findByIdOrNull(routeId) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.saveRouteData(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Route 123 nicht gefunden!")
+        val exception = assertThrows<NotFoundException> { service.saveRouteData(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Route 123 nicht gefunden!")
     }
 
     @Test
@@ -185,8 +185,8 @@ class FoodCollectionServiceTest {
         every { distributionRepository.findFirstByOrderByIdDesc() } returns activeDistribution
         every { routeRepository.findByIdOrNull(routeId) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.saveItems(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Route 123 nicht gefunden!")
+        val exception = assertThrows<NotFoundException> { service.saveItems(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Route 123 nicht gefunden!")
     }
 
     @Test
@@ -703,8 +703,8 @@ class FoodCollectionServiceTest {
         every { distributionRepository.findFirstByOrderByIdDesc() } returns activeDistribution
         every { routeRepository.findByIdOrNull(routeId) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.patchItem(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Route 123 nicht gefunden!")
+        val exception = assertThrows<NotFoundException> { service.patchItem(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Route 123 nicht gefunden!")
     }
 
     @Test
@@ -723,8 +723,8 @@ class FoodCollectionServiceTest {
         every { routeRepository.findByIdOrNull(routeId) } returns testRoute1
         every { foodCategoryRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.patchItem(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Kategorie ungültig!")
+        val exception = assertThrows<NotFoundException> { service.patchItem(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Kategorie nicht gefunden!")
     }
 
     @Test
@@ -744,8 +744,8 @@ class FoodCollectionServiceTest {
         every { foodCategoryRepository.findByIdOrNull(testFoodCategory1.id!!) } returns testFoodCategory1
         every { shopRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.patchItem(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Filiale ungültig!")
+        val exception = assertThrows<NotFoundException> { service.patchItem(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Filiale nicht gefunden!")
     }
 
     @Test
@@ -805,10 +805,10 @@ class FoodCollectionServiceTest {
         every { routeRepository.findByIdOrNull(routeId) } returns testRoute1
         every { carRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<NotFoundException> {
             service.saveRouteData(routeId = routeId, data = data)
         }
-        assertThat(exception.message).isEqualTo("Ungültiges KFZ!")
+        assertThat(exception.body.detail).isEqualTo("KFZ nicht gefunden!")
     }
 
     @Test
@@ -830,10 +830,10 @@ class FoodCollectionServiceTest {
         every { carRepository.findByIdOrNull(testCar1.id!!) } returns testCar1
         every { employeeRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<NotFoundException> {
             service.saveRouteData(routeId = routeId, data = data)
         }
-        assertThat(exception.message).isEqualTo("Ungültiger Fahrer!")
+        assertThat(exception.body.detail).isEqualTo("Fahrer nicht gefunden!")
     }
 
     @Test
@@ -856,10 +856,10 @@ class FoodCollectionServiceTest {
         every { employeeRepository.findByIdOrNull(testEmployee1.id!!) } returns testEmployee1
         every { employeeRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<NotFoundException> {
             service.saveRouteData(routeId = routeId, data = data)
         }
-        assertThat(exception.message).isEqualTo("Ungültiger Beifahrer!")
+        assertThat(exception.body.detail).isEqualTo("Beifahrer nicht gefunden!")
     }
 
     @Test
@@ -920,8 +920,8 @@ class FoodCollectionServiceTest {
         every { routeRepository.findByIdOrNull(routeId) } returns testRoute1
         every { foodCategoryRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.saveItems(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Kategorie ungültig!")
+        val exception = assertThrows<NotFoundException> { service.saveItems(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Kategorie nicht gefunden!")
     }
 
     @Test
@@ -945,7 +945,7 @@ class FoodCollectionServiceTest {
         every { foodCategoryRepository.findByIdOrNull(testFoodCategory1.id!!) } returns testFoodCategory1
         every { shopRepository.findByIdOrNull(999L) } returns null
 
-        val exception = assertThrows<TafelValidationException> { service.saveItems(routeId = routeId, data = data) }
-        assertThat(exception.message).isEqualTo("Filiale ungültig!")
+        val exception = assertThrows<NotFoundException> { service.saveItems(routeId = routeId, data = data) }
+        assertThat(exception.body.detail).isEqualTo("Filiale nicht gefunden!")
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContact
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter1
@@ -15,8 +15,8 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
 
@@ -259,9 +259,8 @@ class ShelterServiceTest {
     fun `update shelter throws exception when not found`() {
         every { shelterRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy { service.updateShelter(99L, testShelter3ShelterModel()) }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Shelter with id 99 not found")
+        val exception = assertThrows<NotFoundException> { service.updateShelter(99L, testShelter3ShelterModel()) }
+        assertThat(exception.body.detail).isEqualTo("Shelter with id 99 not found")
     }
 
     @Test
@@ -296,9 +295,8 @@ class ShelterServiceTest {
     fun `reorder shelters throws exception when a shelter is not found`() {
         every { shelterRepository.findByIdOrNull(99L) } returns null
 
-        assertThatThrownBy { service.reorderShelters(listOf(99L)) }
-            .isInstanceOf(TafelValidationException::class.java)
-            .hasMessage("Shelter with id 99 not found")
+        val exception = assertThrows<NotFoundException> { service.reorderShelters(listOf(99L)) }
+        assertThat(exception.body.detail).isEqualTo("Shelter with id 99 not found")
     }
 
     private fun testShelter3ShelterModel() = Shelter(

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopServiceTest.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.Shop
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute1
 import io.mockk.every
@@ -28,11 +28,11 @@ class ShopServiceTest {
         val routeId = testRoute1.id!!
         every { routeRepository.findByIdOrNull(routeId) } returns null
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<NotFoundException> {
             service.getShopsForRouteId(routeId)
         }
 
-        assertThat(exception.message).isEqualTo("Route $routeId nicht gefunden!")
+        assertThat(exception.body.detail).isEqualTo("Route $routeId nicht gefunden!")
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DistributionClosedEventListenerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/DistributionClosedEventListenerTest.kt
@@ -6,7 +6,6 @@ import at.wrk.tafel.admin.backend.database.model.base.MailType
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity2
@@ -226,8 +225,8 @@ class DistributionClosedEventListenerTest {
         val (distributionId, distribution, distributionStatistic) = setupDistribution()
 
         every { dailyReportService.generateDailyReportPdf(distributionStatistic) } throws
-            TafelValidationException("transient failure") andThenThrows
-            TafelValidationException("transient failure") andThen ByteArray(10)
+            IllegalStateException("transient failure") andThenThrows
+            IllegalStateException("transient failure") andThen ByteArray(10)
         every { statisticExportService.exportStatisticFiles(distributionStatistic) } returns emptyList()
 
         listener.onDistributionClosed(DistributionClosedEvent(distributionId))
@@ -243,12 +242,12 @@ class DistributionClosedEventListenerTest {
         val (distributionId, distribution, distributionStatistic) = setupDistribution()
 
         every { dailyReportService.generateDailyReportPdf(distributionStatistic) } throws
-            TafelValidationException("permanent failure")
+            IllegalStateException("permanent failure")
         every { statisticExportService.exportStatisticFiles(distributionStatistic) } returns listOf(
             StatisticExportFile("file1.csv", ByteArray(10)),
         )
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<IllegalStateException> {
             listener.onDistributionClosed(DistributionClosedEvent(distributionId))
         }
 
@@ -265,9 +264,9 @@ class DistributionClosedEventListenerTest {
 
         every { dailyReportService.generateDailyReportPdf(distributionStatistic) } returns ByteArray(10)
         every { statisticExportService.exportStatisticFiles(distributionStatistic) } throws
-            TafelValidationException("permanent failure")
+            IllegalStateException("permanent failure")
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<IllegalStateException> {
             listener.onDistributionClosed(DistributionClosedEvent(distributionId))
         }
 
@@ -284,9 +283,9 @@ class DistributionClosedEventListenerTest {
         every { dailyReportService.generateDailyReportPdf(distributionStatistic) } returns ByteArray(10)
         every { statisticExportService.exportStatisticFiles(distributionStatistic) } returns emptyList()
         every { mailSenderService.sendHtmlMail(MailType.RETURN_BOXES, any(), any(), any(), any()) } throws
-            TafelValidationException("permanent failure")
+            IllegalStateException("permanent failure")
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<IllegalStateException> {
             listener.onDistributionClosed(DistributionClosedEvent(distributionId))
         }
 
@@ -301,13 +300,13 @@ class DistributionClosedEventListenerTest {
         val (distributionId, distribution, distributionStatistic) = setupDistribution()
 
         every { dailyReportService.generateDailyReportPdf(distributionStatistic) } throws
-            TafelValidationException("daily report failure")
+            IllegalStateException("daily report failure")
         every { statisticExportService.exportStatisticFiles(distributionStatistic) } throws
-            TafelValidationException("statistic failure")
+            IllegalStateException("statistic failure")
         every { mailSenderService.sendHtmlMail(MailType.RETURN_BOXES, any(), any(), any(), any()) } throws
-            TafelValidationException("return boxes failure")
+            IllegalStateException("return boxes failure")
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<IllegalStateException> {
             listener.onDistributionClosed(DistributionClosedEvent(distributionId))
         }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceTest.kt
@@ -13,7 +13,7 @@ import at.wrk.tafel.admin.backend.database.model.base.testMailRecipient_DR_TO2
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueType
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientAdresses
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientType
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
@@ -346,6 +346,6 @@ class SettingsServiceTest {
         )
 
         assertThatThrownBy { service.updateStaticValue(99L, updated) }
-            .isInstanceOf(TafelValidationException::class.java)
+            .isInstanceOf(NotFoundException::class.java)
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
@@ -5,7 +5,9 @@ import at.wrk.tafel.admin.backend.common.auth.components.*
 import at.wrk.tafel.admin.backend.common.auth.model.*
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminServerProperties
-import at.wrk.tafel.admin.backend.modules.base.exception.TafelValidationException
+import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
+import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
+import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -138,9 +140,9 @@ class UserControllerTest {
     fun `get user not found`() {
         every { userDetailsManager.loadUserById(any()) } returns null
 
-        val exception = assertThrows<TafelValidationException> { controller.getUser(1) }
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
-        assertThat(exception.message).isEqualTo("Benutzer (ID: 1) nicht gefunden!")
+        val exception = assertThrows<NotFoundException> { controller.getUser(1) }
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Benutzer (ID: 1) nicht gefunden!")
     }
 
     @Test
@@ -170,9 +172,9 @@ class UserControllerTest {
         every { userDetailsManager.loadUserByPersonnelNumber(testUser.personnelNumber) } returns null
 
         val exception =
-            assertThrows<TafelValidationException> { controller.getUserByPersonnelNumber(testUser.personnelNumber) }
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
-        assertThat(exception.message).isEqualTo("Benutzer (Personalnummer: test-personnelnumber) nicht gefunden!")
+            assertThrows<NotFoundException> { controller.getUserByPersonnelNumber(testUser.personnelNumber) }
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Benutzer (Personalnummer: test-personnelnumber) nicht gefunden!")
     }
 
     @Test
@@ -243,8 +245,8 @@ class UserControllerTest {
     fun `create user exists by username`() {
         every { userDetailsManager.loadUserByUsername(any()) } returns testUser
 
-        val exception = assertThrows<TafelValidationException> { controller.createUser(user = testUserApiResponse) }
-        assertThat(exception.message).isEqualTo("Benutzer (Benutzername: test-username) existiert bereits!")
+        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserApiResponse) }
+        assertThat(exception.body.detail).isEqualTo("Benutzer (Benutzername: test-username) existiert bereits!")
     }
 
     @Test
@@ -252,8 +254,8 @@ class UserControllerTest {
         every { userDetailsManager.loadUserByUsername(any()) } throws UsernameNotFoundException("dummy")
         every { userDetailsManager.loadUserByPersonnelNumber(any()) } returns testUser
 
-        val exception = assertThrows<TafelValidationException> { controller.createUser(user = testUserApiResponse) }
-        assertThat(exception.message).isEqualTo("Benutzer (Personalnummer: test-personnelnumber) existiert bereits!")
+        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserApiResponse) }
+        assertThat(exception.body.detail).isEqualTo("Benutzer (Personalnummer: test-personnelnumber) existiert bereits!")
     }
 
     @Test
@@ -261,10 +263,10 @@ class UserControllerTest {
         every { userDetailsManager.loadUserById(any()) } returns null
 
         val exception =
-            assertThrows<TafelValidationException> { controller.updateUser(userId = 123, user = testUserApiResponse) }
+            assertThrows<NotFoundException> { controller.updateUser(userId = 123, user = testUserApiResponse) }
 
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
-        assertThat(exception.message).isEqualTo("Benutzer (ID: 123) nicht vorhanden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Benutzer (ID: 123) nicht vorhanden!")
     }
 
     @Test
@@ -326,15 +328,15 @@ class UserControllerTest {
     fun `update user with passwords not matching`() {
         every { userDetailsManager.loadUserById(any()) } returns testUser
 
-        val exception = assertThrows<TafelValidationException> {
+        val exception = assertThrows<BusinessRuleException> {
             controller.updateUser(
                 userId = 123,
                 user = testUserApiResponse.copy(password = "123", passwordRepeat = "456"),
             )
         }
 
-        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
-        assertThat(exception.message).isEqualTo("Passwörter stimmen nicht überein!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception.body.detail).isEqualTo("Passwörter stimmen nicht überein!")
     }
 
     @Test
@@ -342,10 +344,10 @@ class UserControllerTest {
         every { userDetailsManager.loadUserById(any()) } returns null
 
         val exception =
-            assertThrows<TafelValidationException> { controller.deleteUser(userId = 123) }
+            assertThrows<NotFoundException> { controller.deleteUser(userId = 123) }
 
-        assertThat(exception.status).isEqualTo(HttpStatus.NOT_FOUND)
-        assertThat(exception.message).isEqualTo("Benutzer (ID: 123) nicht vorhanden!")
+        assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(exception.body.detail).isEqualTo("Benutzer (ID: 123) nicht vorhanden!")
     }
 
     @Test

--- a/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
@@ -278,7 +278,7 @@ describe('Customer Detail', () => {
           if (req.method === 'PUT') {
             req.reply({
               statusCode: 409,
-              body: {message: 'Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)'}
+              body: {detail: 'Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)'}
             });
           }
         });

--- a/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
@@ -30,11 +30,11 @@ describe('User Create', () => {
   it('create new user which exists already', () => {
     cy.visit('/#/benutzer/erstellen');
 
-    // 1. Intercept the POST request that returns the 400 error
+    // 1. Intercept the POST request that returns the 409 error
     // Replace '/api/users' with the actual endpoint URL your app uses
     cy.intercept('POST', '/api/users').as('createUserRequest');
     // 1. Suppress uncaught exceptions just for this test
-    cy.once('uncaught:exception', (err) => !err.message.includes('400'));
+    cy.once('uncaught:exception', (err) => !err.message.includes('409'));
 
     cy.getAnyRandomNumber().then(() => {
       fillUserForm('e2etest', 'e2etest');
@@ -43,12 +43,12 @@ describe('User Create', () => {
       cy.byTestId('permission-checkbox-CHECKIN').click();
       cy.byTestId('permission-checkbox-USER_MANAGEMENT').click();
 
-      // 2. Click save - Cypress will no longer fail on the 400 error
+      // 2. Click save - Cypress will no longer fail on the 409 error
       // because we are managing the request via intercept
       cy.byTestId('save-button').click();
 
       // 3. Wait for the request and verify the status (optional but recommended)
-      cy.wait('@createUserRequest').its('response.statusCode').should('eq', 400);
+      cy.wait('@createUserRequest').its('response.statusCode').should('eq', 409);
 
       // 4. Assert the UI feedback
       cy.get('.toast-message')

--- a/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.spec.ts
@@ -147,7 +147,7 @@ describe('ErrorHandlerInterceptor', () => {
         };
 
         const errorBody: TafelErrorResponse = {
-            message: 'Custom message from body'
+            detail: 'Custom message from body'
         };
         mockReq.flush(errorBody, mockErrorResponse);
         httpTestingController.verify();

--- a/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
+++ b/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
@@ -56,7 +56,7 @@ export const errorHandlerInterceptor: HttpInterceptorFn = (
     if (ERROR_CODES_WHITELIST.indexOf(error.status) === -1) {
       if (error.error?.constructor === Object) {
         const errorBody: TafelErrorResponse = error.error;
-        toastr.error(errorBody.message, `HTTP ${error.status} - ${error.statusText}`);
+        toastr.error(errorBody.detail ?? error.message, `HTTP ${error.status} - ${error.statusText}`);
       } else {
         let message = error.message;
         if (error.status === 504) {
@@ -80,5 +80,10 @@ export const errorHandlerInterceptor: HttpInterceptorFn = (
 };
 
 export interface TafelErrorResponse {
-  message: string;
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+  errors?: { field: string; message: string }[];
 }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
@@ -800,7 +800,7 @@ describe('CustomerDetailComponent', () => {
     customerApiService.updateCustomer.mockReturnValue(throwError(() => ({
       status: 409,
       error: {
-        message: 'Conflict: customer was updated by another user',
+        detail: 'Conflict: customer was updated by another user',
         body: { data: mockCustomer, errorMsg: 'Conflict: customer was updated by another user' }
       }
     })));
@@ -824,7 +824,7 @@ describe('CustomerDetailComponent', () => {
 
     customerApiService.updateCustomer.mockReturnValue(throwError(() => ({
       status: 500,
-      error: { message: 'Internal server error' }
+      error: { detail: 'Internal server error' }
     })));
 
     const fixture = TestBed.createComponent(CustomerDetailComponent);

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
@@ -208,7 +208,7 @@ export class CustomerDetailComponent {
       },
       error: (error: any) => {
         if (error.status === 409) {
-          this.openConfirmUpdateCustomerDialog(updatedCustomerData, error.error.message);
+          this.openConfirmUpdateCustomerDialog(updatedCustomerData, error.error.detail);
         } else {
           this.toastr.error('Verlängerung fehlgeschlagen!');
         }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-existing-customer.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-existing-customer.component.spec.ts
@@ -249,7 +249,7 @@ describe('CustomerEditComponent - Editing an existing customer', () => {
 
     apiService.updateCustomer.mockReturnValue(throwError(() => ({
       status: 409,
-      error: {message: mockMessage}
+      error: {detail: mockMessage}
     })));
 
     const fixture = TestBed.createComponent(CustomerEditComponent);
@@ -281,7 +281,7 @@ describe('CustomerEditComponent - Editing an existing customer', () => {
 
     apiService.updateCustomer.mockReturnValue(throwError(() => ({
       status: 500,
-      error: {message: 'Internal server error'}
+      error: {detail: 'Internal server error'}
     })));
 
     const fixture = TestBed.createComponent(CustomerEditComponent);

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-new-customer.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-new-customer.component.spec.ts
@@ -277,7 +277,7 @@ describe('CustomerEditComponent - Creating a new customer', () => {
     };
     apiService.createCustomer.mockReturnValueOnce(throwError(() => ({
       status: 409,
-      error: {message: mockMessage}
+      error: {detail: mockMessage}
     }))).mockReturnValueOnce(of(mockResponse));
 
     const fixture = TestBed.createComponent(CustomerEditComponent);
@@ -308,7 +308,7 @@ describe('CustomerEditComponent - Creating a new customer', () => {
 
     apiService.createCustomer.mockReturnValue(throwError(() => ({
       status: 500,
-      error: {message: 'Internal server error'}
+      error: {detail: 'Internal server error'}
     })));
 
     const fixture = TestBed.createComponent(CustomerEditComponent);

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
@@ -90,7 +90,7 @@ export class CustomerEditComponent {
           this.router.navigate(['/kunden/detail', customer.id]);
         },
         error: (error: any) => {
-          const errorMessage = error.error.message;
+          const errorMessage = error.error.detail;
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
               this.customerApiService.createCustomer(this.customerUpdated(), true).subscribe({
@@ -118,7 +118,7 @@ export class CustomerEditComponent {
           this.router.navigate(['/kunden/detail', customer.id]);
         },
         error: (error: any) => {
-          const errorMessage = error.error.message;
+          const errorMessage = error.error.detail;
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
               this.customerApiService.updateCustomer(this.customerUpdated(), true).subscribe({

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
@@ -52,7 +52,7 @@ export class UserEditComponent {
         this.router.navigate(['/benutzer/detail', user.id]);
       },
       error: (error: any) => {
-        this.toastr.error(error.error.message || 'Fehler beim Speichern des Benutzers');
+        this.toastr.error(error.error.detail || 'Fehler beim Speichern des Benutzers');
       },
     };
 


### PR DESCRIPTION
## Summary
- Replace `TafelException`/`TafelValidationException` (one generic exception with an optional `HttpStatus` defaulting to 400) with `NotFoundException` (404), `ConflictException` (409), and `BusinessRuleException` (400 by default), each extending Spring's `ErrorResponseException` and fixing their own status so it can no longer be forgotten at a throw site.
- Fixes a real bug the old design caused: `CarService`, `ShelterService`, `FoodCategoryService`, `ShopService`, `SettingsService`, `EmployeeService` (and 7 sites in `FoodCollectionService` worded "ungültig") forgot to pass `status = NOT_FOUND` and silently returned `400` instead of `404`.
- `GenericExceptionHandler` now extends `ResponseEntityExceptionHandler` and renders RFC 7807 `ProblemDetail` responses (localized `title`, `detail`, structured `errors: [{field, message}]` for bean-validation failures instead of one joined string), preserving the existing SSE special-case.
- Frontend's `errorhandler-interceptor.service.ts` and every component reading the error body directly move from the old `{message}` shape to the RFC 7807 `{type, title, status, detail, instance, errors}` shape.

## Test plan
- [x] `./gradlew :backend:compileKotlin :backend:compileTestKotlin` — clean
- [x] `./gradlew :backend:test` — 582/582 passing
- [x] `ng test --watch=false` (frontend) — 598/598 passing
- [x] Manually reasoned through status classification for every migrated throw site (path-lookup-by-id → 404, duplicate/already-exists/in-progress-lock → 409, payload-level business rule → 400)

Closes #2882

🤖 Generated with [Claude Code](https://claude.com/claude-code)