### PR TITLE
fix(frontend): replace HTTP error whitelist with per-request opt-out

### DIFF
--- a/frontend/src/main/webapp/src/app/api/customer-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient, HttpParams, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpContext, HttpParams, HttpResponse} from '@angular/common/http';
 import {inject, Service} from '@angular/core';
 import {map, Observable} from 'rxjs';
 import {CountryData} from './country-api.service';
@@ -22,8 +22,8 @@ export class CustomerApiService {
     return this.http.post<ValidateCustomerResponse>('/households/validate', mapCustomerToHousehold(data));
   }
 
-  createCustomer(data: CustomerData, force: boolean): Observable<CustomerCreationResponse> {
-    return this.http.post<HouseholdCreationResponse>('/households', mapCustomerToHousehold(data), {params: {force}})
+  createCustomer(data: CustomerData, force: boolean, context?: HttpContext): Observable<CustomerCreationResponse> {
+    return this.http.post<HouseholdCreationResponse>('/households', mapCustomerToHousehold(data), {params: {force}, context})
       .pipe(
         map(response => ({data: mapHouseholdToCustomer(response?.data), errorMsg: response?.errorMsg ?? null})),
         tap(response => {
@@ -35,8 +35,8 @@ export class CustomerApiService {
       );
   }
 
-  updateCustomer(data: CustomerData, force: boolean): Observable<CustomerUpdateResponse> {
-    return this.http.put<HouseholdUpdateResponse>(`/households/${data.id}`, mapCustomerToHousehold(data), {params: {force}})
+  updateCustomer(data: CustomerData, force: boolean, context?: HttpContext): Observable<CustomerUpdateResponse> {
+    return this.http.put<HouseholdUpdateResponse>(`/households/${data.id}`, mapCustomerToHousehold(data), {params: {force}, context})
       .pipe(
         map(response => ({data: mapHouseholdToCustomer(response?.data), errorMsg: response?.errorMsg ?? null})),
         tap(response => {
@@ -48,12 +48,12 @@ export class CustomerApiService {
       );
   }
 
-  deleteCustomer(customerId: number): Observable<void> {
-    return this.http.delete<void>(`/households/${customerId}`);
+  deleteCustomer(customerId: number, context?: HttpContext): Observable<void> {
+    return this.http.delete<void>(`/households/${customerId}`, {context});
   }
 
-  getCustomer(id: number): Observable<CustomerData> {
-    return this.http.get<HouseholdData>('/households/' + id).pipe(map(mapHouseholdToCustomer));
+  getCustomer(id: number, context?: HttpContext): Observable<CustomerData> {
+    return this.http.get<HouseholdData>('/households/' + id, {context}).pipe(map(mapHouseholdToCustomer));
   }
 
   generatePdf(id: number, type: PdfType): Observable<HttpResponse<Blob>> {

--- a/frontend/src/main/webapp/src/app/api/distribution-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/distribution-api.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient, HttpParams, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpContext, HttpParams, HttpResponse} from '@angular/common/http';
 import {inject, Service} from '@angular/core';
 import {Observable} from 'rxjs';
 
@@ -22,13 +22,13 @@ export class DistributionApiService {
     return this.http.post<DistributionCloseValidationResult>('/distributions/close', null, {params: queryParams});
   }
 
-  assignCustomer(customerId: number, ticketNumber: number): Observable<void> {
+  assignCustomer(customerId: number, ticketNumber: number, context?: HttpContext): Observable<void> {
     // the backend identifies the customer by its household id (same number as before)
     const body: AssignHouseholdRequest = {
       householdId: customerId,
       ticketNumber: ticketNumber,
     };
-    return this.http.post<void>('/distributions/households', body);
+    return this.http.post<void>('/distributions/households', body, {context});
   }
 
   saveStatistic(employeeCount: number, selectedShelterIds: number[]): Observable<void> {

--- a/frontend/src/main/webapp/src/app/api/distribution-ticket-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/distribution-ticket-api.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpContext} from '@angular/common/http';
 import {inject, Service} from '@angular/core';
 import {Observable} from 'rxjs';
 
@@ -10,8 +10,8 @@ export class DistributionTicketApiService {
     return this.http.get<TicketNumberResponse>(`/households/${customerId}/ticket`);
   }
 
-  deleteCurrentTicketOfCustomer(customerId: number): Observable<void> {
-    return this.http.delete<void>(`/households/${customerId}/ticket`);
+  deleteCurrentTicketOfCustomer(customerId: number, context?: HttpContext): Observable<void> {
+    return this.http.delete<void>(`/households/${customerId}/ticket`, {context});
   }
 
 }

--- a/frontend/src/main/webapp/src/app/api/user-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/user-api.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient, HttpParams} from '@angular/common/http';
+import {HttpClient, HttpContext, HttpParams} from '@angular/common/http';
 import {inject, Service} from '@angular/core';
 import {Observable} from 'rxjs';
 import {PagedResponse} from '../common/api/paged-response';
@@ -7,16 +7,16 @@ import {PagedResponse} from '../common/api/paged-response';
 export class UserApiService {
   private readonly http = inject(HttpClient);
 
-  changePassword(request: ChangePasswordRequest): Observable<ChangePasswordResponse> {
-    return this.http.post<ChangePasswordResponse>('/users/change-password', request);
+  changePassword(request: ChangePasswordRequest, context?: HttpContext): Observable<ChangePasswordResponse> {
+    return this.http.post<ChangePasswordResponse>('/users/change-password', request, {context});
   }
 
   getUserForId(userId: number): Observable<UserData> {
     return this.http.get<UserData>('/users/' + userId);
   }
 
-  getUserForPersonnelNumber(personnelNumber: string): Observable<UserData> {
-    return this.http.get<UserData>('/users/personnel-number/' + personnelNumber);
+  getUserForPersonnelNumber(personnelNumber: string, context?: HttpContext): Observable<UserData> {
+    return this.http.get<UserData>('/users/personnel-number/' + personnelNumber, {context});
   }
 
   searchUser(
@@ -45,16 +45,16 @@ export class UserApiService {
     return this.http.get<UserSearchResult>('/users', {params: queryParams});
   }
 
-  updateUser(data: UserData): Observable<UserData> {
-    return this.http.put<UserData>(`/users/${data.id}`, data);
+  updateUser(data: UserData, context?: HttpContext): Observable<UserData> {
+    return this.http.put<UserData>(`/users/${data.id}`, data, {context});
   }
 
   deleteUser(userId: number): Observable<void> {
     return this.http.delete<void>(`/users/${userId}`);
   }
 
-  createUser(data: UserData): Observable<UserData> {
-    return this.http.post<UserData>('/users', data);
+  createUser(data: UserData, context?: HttpContext): Observable<UserData> {
+    return this.http.post<UserData>('/users', data, {context});
   }
 
   generatePassword(): Observable<GeneratedPasswordResponse> {

--- a/frontend/src/main/webapp/src/app/common/api/problem-detail.ts
+++ b/frontend/src/main/webapp/src/app/common/api/problem-detail.ts
@@ -1,0 +1,45 @@
+import {HttpErrorResponse} from '@angular/common/http';
+
+/** Mirrors Spring's RFC 7807 `ProblemDetail` (see the backend's `GenericExceptionHandler`). */
+export interface ProblemDetail {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+  errors?: { field: string; message: string }[];
+}
+
+export function isProblemDetail(body: unknown): body is ProblemDetail {
+  return !!body && typeof body === 'object' && (body as object).constructor === Object;
+}
+
+const GENERIC_FALLBACK_MESSAGE = 'Es ist ein unerwarteter Fehler aufgetreten.';
+
+/**
+ * Statuses whose body typically carries no useful `detail`. Covers both statuses the backend
+ * writes itself without going through `GenericExceptionHandler` (security-filter-level responses
+ * like 403/423) and statuses that never reach the backend at all - `0` (no connection: offline,
+ * DNS failure, CORS rejection) and `502`/`503`/`504` (reverse proxy / gateway responses emitted
+ * when the backend process itself is unreachable, not something any controller ever sends).
+ */
+const STATUS_MESSAGE_OVERRIDES: Partial<Record<number, string>> = {
+  0: 'Keine Verbindung zum Server!',
+  403: 'Zugriff nicht erlaubt!',
+  423: 'Konto vorübergehend gesperrt!',
+  500: 'Interner Serverfehler!',
+  502: 'Server nicht verfügbar!',
+  503: 'Server nicht verfügbar!',
+  504: 'Server nicht verfügbar!',
+};
+
+/**
+ * User-safe message for an `HttpErrorResponse` - never returns Angular's raw technical
+ * `error.message` (e.g. "Http failure response for /x: 500 Internal Server Error").
+ */
+export function extractErrorMessage(error: HttpErrorResponse): string {
+  if (isProblemDetail(error.error) && error.error.detail) {
+    return error.error.detail;
+  }
+  return STATUS_MESSAGE_OVERRIDES[error.status] ?? GENERIC_FALLBACK_MESSAGE;
+}

--- a/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.spec.ts
@@ -1,8 +1,10 @@
 import type { MockedObject } from 'vitest';
-import { HttpClient, provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
+import { HttpClient, HttpContext, provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { errorHandlerInterceptor, TafelErrorResponse } from './errorhandler-interceptor.service';
+import { errorHandlerInterceptor } from './errorhandler-interceptor.service';
+import { SUPPRESS_ERROR_TOAST } from './suppress-error-toast.token';
+import { ProblemDetail } from '../api/problem-detail';
 import { AuthenticationService } from '../security/authentication.service';
 import {TafelToastrService} from '../components/tafel-toastr/tafel-toastr.service';
 
@@ -46,14 +48,33 @@ describe('ErrorHandlerInterceptor', () => {
         httpTestingController.verify();
     });
 
-    it('generic http error', () => {
+    it('generic http error with an unmapped status falls back to the generic message', () => {
         authServiceSpy.isAuthenticated.mockReturnValue(false);
 
         /* eslint-disable @typescript-eslint/no-unused-vars */
         const observer = {
             error: (error: any) => {
                 expect(toastrSpy.error).toHaveBeenCalledWith(
-                    'Http failure response for /test: 500 Internal Server Error',
+                    'Es ist ein unerwarteter Fehler aufgetreten.',
+                    'HTTP 418 - I\'m a teapot'
+                );
+            },
+        };
+        httpClient.get('/test').subscribe(observer);
+
+        const mockReq = httpTestingController.expectOne('/test');
+        const mockErrorResponse = { status: 418, statusText: 'I\'m a teapot' };
+        mockReq.flush(null, mockErrorResponse);
+        httpTestingController.verify();
+    });
+
+    it('http 500 error without a body (e.g. a raw servlet-container error page) shows a specific message', () => {
+        authServiceSpy.isAuthenticated.mockReturnValue(false);
+
+        const observer = {
+            error: (_: any) => {
+                expect(toastrSpy.error).toHaveBeenCalledWith(
+                    'Interner Serverfehler!',
                     'HTTP 500 - Internal Server Error'
                 );
             },
@@ -61,8 +82,67 @@ describe('ErrorHandlerInterceptor', () => {
         httpClient.get('/test').subscribe(observer);
 
         const mockReq = httpTestingController.expectOne('/test');
-        const mockErrorResponse = { status: 500, statusText: 'Internal Server Error' };
-        mockReq.flush(null, mockErrorResponse);
+        mockReq.flush(null, { status: 500, statusText: 'Internal Server Error' });
+        httpTestingController.verify();
+    });
+
+    it.each([502, 503])('http %i error (reverse proxy / gateway response) shows a server-unavailable message', (status) => {
+        authServiceSpy.isAuthenticated.mockReturnValue(false);
+
+        const observer = {
+            error: (_: any) => {
+                expect(toastrSpy.error).toHaveBeenCalledWith('Server nicht verfügbar!', `HTTP ${status} - Error`);
+            },
+        };
+        httpClient.get('/test').subscribe(observer);
+
+        const mockReq = httpTestingController.expectOne('/test');
+        mockReq.flush(null, { status, statusText: 'Error' });
+        httpTestingController.verify();
+    });
+
+    it('network-level error (no response reached the server) shows a connection message', () => {
+        authServiceSpy.isAuthenticated.mockReturnValue(false);
+
+        const observer = {
+            error: (_: any) => {
+                expect(toastrSpy.error).toHaveBeenCalledWith('Keine Verbindung zum Server!', 'HTTP 0 - Unknown Error');
+            },
+        };
+        httpClient.get('/test').subscribe(observer);
+
+        const mockReq = httpTestingController.expectOne('/test');
+        mockReq.error(new ProgressEvent('error'));
+        httpTestingController.verify();
+    });
+
+    it.each([400, 401, 404, 409])('shows a toast by default for status %i when not suppressed', (status) => {
+        authServiceSpy.isAuthenticated.mockReturnValue(false);
+
+        const observer = {
+            error: (_: any) => {
+                expect(toastrSpy.error).toHaveBeenCalled();
+            },
+        };
+        httpClient.get('/test').subscribe(observer);
+
+        const mockReq = httpTestingController.expectOne('/test');
+        mockReq.flush(null, { status, statusText: 'Error' });
+        httpTestingController.verify();
+    });
+
+    it('suppresses the toast when SUPPRESS_ERROR_TOAST context is set', () => {
+        authServiceSpy.isAuthenticated.mockReturnValue(false);
+
+        const observer = {
+            error: (_: any) => {
+                expect(toastrSpy.error).not.toHaveBeenCalled();
+            },
+        };
+        httpClient.get('/test', { context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true) }).subscribe(observer);
+
+        const mockReq = httpTestingController.expectOne('/test');
+        mockReq.flush(null, { status: 400, statusText: 'Bad Request' });
         httpTestingController.verify();
     });
 
@@ -146,7 +226,7 @@ describe('ErrorHandlerInterceptor', () => {
             statusText: 'Error Code'
         };
 
-        const errorBody: TafelErrorResponse = {
+        const errorBody: ProblemDetail = {
             detail: 'Custom message from body'
         };
         mockReq.flush(errorBody, mockErrorResponse);

--- a/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
+++ b/frontend/src/main/webapp/src/app/common/http/errorhandler-interceptor.service.ts
@@ -4,6 +4,8 @@ import {from, Observable, throwError} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {AuthenticationService} from '../security/authentication.service';
 import {TafelToastrService} from '../components/tafel-toastr/tafel-toastr.service';
+import {extractErrorMessage} from '../api/problem-detail';
+import {SUPPRESS_ERROR_TOAST} from './suppress-error-toast.token';
 
 /**
  * Central HTTP error handling, applied to every request. Three independent stages are chained
@@ -17,9 +19,9 @@ import {TafelToastrService} from '../components/tafel-toastr/tafel-toastr.servic
  *    'blob'` requests (PDF downloads), Angular still delivers a JSON error body as a `Blob`
  *    instead of parsing it, so this reads the blob as text and re-parses it into the same shape a
  *    non-blob request would have gotten.
- * 3. {@link handleErrorMessage} - shows a toast with the backend's error message, unless the
- *    status is in `ERROR_CODES_WHITELIST` (callers handling those themselves, e.g. inline form
- *    validation on `400`/`409`, or the login screen on `401`/`404`).
+ * 3. {@link handleErrorMessage} - shows a toast with the backend's error message by default,
+ *    unless the request opted out via the {@link SUPPRESS_ERROR_TOAST} context (callers that
+ *    fully own presenting the error themselves).
  */
 export const errorHandlerInterceptor: HttpInterceptorFn = (
   request: HttpRequest<unknown>,
@@ -27,7 +29,6 @@ export const errorHandlerInterceptor: HttpInterceptorFn = (
 ): Observable<HttpEvent<unknown>> => {
   const authenticationService = inject(AuthenticationService);
   const toastr = inject(TafelToastrService);
-  const ERROR_CODES_WHITELIST = [400, 401, 404, 409];
 
   const handleAuthError = (error: HttpErrorResponse): Observable<any> => {
     if (authenticationService.isAuthenticated() && error.status === 401) {
@@ -53,21 +54,8 @@ export const errorHandlerInterceptor: HttpInterceptorFn = (
   };
 
   const handleErrorMessage = (error: HttpErrorResponse): Observable<any> => {
-    if (ERROR_CODES_WHITELIST.indexOf(error.status) === -1) {
-      if (error.error?.constructor === Object) {
-        const errorBody: TafelErrorResponse = error.error;
-        toastr.error(errorBody.detail ?? error.message, `HTTP ${error.status} - ${error.statusText}`);
-      } else {
-        let message = error.message;
-        if (error.status === 504) {
-          message = 'Server nicht verfügbar!';
-        } else if (error.status === 403) {
-          message = 'Zugriff nicht erlaubt!';
-        } else if (error.status === 423) {
-          message = 'Konto vorübergehend gesperrt!';
-        }
-        toastr.error(message, `HTTP ${error.status} - ${error.statusText}`);
-      }
+    if (!request.context.get(SUPPRESS_ERROR_TOAST)) {
+      toastr.error(extractErrorMessage(error), `HTTP ${error.status} - ${error.statusText}`);
     }
     return throwError(() => error);
   };
@@ -78,12 +66,3 @@ export const errorHandlerInterceptor: HttpInterceptorFn = (
     .pipe(catchError((error: HttpErrorResponse) => remapErrorBodyOnByteArrayResponseType(request, error)))
     .pipe(catchError((error) => handleErrorMessage(error)));
 };
-
-export interface TafelErrorResponse {
-  type?: string;
-  title?: string;
-  status?: number;
-  detail?: string;
-  instance?: string;
-  errors?: { field: string; message: string }[];
-}

--- a/frontend/src/main/webapp/src/app/common/http/suppress-error-toast.token.ts
+++ b/frontend/src/main/webapp/src/app/common/http/suppress-error-toast.token.ts
@@ -1,0 +1,11 @@
+import {HttpContextToken} from '@angular/common/http';
+
+/**
+ * Per-request opt-out from the generic error toast in `errorHandlerInterceptor`. Set on a request
+ * when the caller fully owns presenting the error to the user (e.g. an inline form validation
+ * message, a custom confirm-dialog, or a deliberately-swallowed background request) - the
+ * interceptor still re-throws the error either way, this only silences its own toast.
+ *
+ * Does NOT affect the unconditional 401 "session expired" redirect - that remains cross-cutting.
+ */
+export const SUPPRESS_ERROR_TOAST = new HttpContextToken<boolean>(() => false);

--- a/frontend/src/main/webapp/src/app/common/http/suppress-error-toast.token.ts
+++ b/frontend/src/main/webapp/src/app/common/http/suppress-error-toast.token.ts
@@ -1,4 +1,4 @@
-import {HttpContextToken} from '@angular/common/http';
+import {HttpContext, HttpContextToken} from '@angular/common/http';
 
 /**
  * Per-request opt-out from the generic error toast in `errorHandlerInterceptor`. Set on a request
@@ -9,3 +9,13 @@ import {HttpContextToken} from '@angular/common/http';
  * Does NOT affect the unconditional 401 "session expired" redirect - that remains cross-cutting.
  */
 export const SUPPRESS_ERROR_TOAST = new HttpContextToken<boolean>(() => false);
+
+/**
+ * Ready-made context for the common case of opting a request out of the generic toast and nothing
+ * else - pass it straight as `{context: SUPPRESS_ERROR_TOAST_CONTEXT}` instead of building a new
+ * `HttpContext` per call site. Shared across all callers, so never call `.set()` on it: `HttpContext`
+ * mutates in place, and doing so would leak extra context into every other request using this
+ * constant. Build a request-local `HttpContext` instead if a call site ever needs to combine this
+ * opt-out with other context data.
+ */
+export const SUPPRESS_ERROR_TOAST_CONTEXT = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);

--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.spec.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 
 import { AuthenticationService } from './authentication.service';
 import { provideHttpClient, withXhr } from '@angular/common/http';
+import { SUPPRESS_ERROR_TOAST } from '../http/suppress-error-toast.token';
 
 describe('AuthenticationService', () => {
     let httpMock: HttpTestingController;
@@ -127,6 +128,26 @@ describe('AuthenticationService', () => {
         loginMockReq.flush(null, loginMockResponse);
 
         httpMock.expectNone('/users/info');
+
+        httpMock.verify();
+    });
+
+    it('login request suppresses the generic error toast', () => {
+        service.login('USER', 'PWD');
+
+        const mockLoginReq = httpMock.expectOne('/login');
+        expect(mockLoginReq.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(true);
+        mockLoginReq.flush(null, { status: 500, statusText: 'Internal Server Error' });
+
+        httpMock.verify();
+    });
+
+    it('loadUserInfo suppresses the generic error toast (so a logged-out visitor never sees an error toast on page load)', () => {
+        service.loadUserInfo();
+
+        const mockReq = httpMock.expectOne('/users/info');
+        expect(mockReq.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(true);
+        mockReq.flush(null, { status: 401, statusText: 'Unauthorized' });
 
         httpMock.verify();
     });

--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
@@ -1,8 +1,9 @@
-import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {HttpClient, HttpContext, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {inject, Service, signal} from '@angular/core';
 import {Router} from '@angular/router';
 import {firstValueFrom, Observable, of} from 'rxjs';
 import {catchError, map, tap} from 'rxjs/operators';
+import {SUPPRESS_ERROR_TOAST} from '../http/suppress-error-toast.token';
 
 @Service()
 export class AuthenticationService {
@@ -61,7 +62,8 @@ export class AuthenticationService {
   }
 
   public loadUserInfo(): Promise<UserInfo | null> {
-    return firstValueFrom(this.http.get<UserInfo>('/users/info')
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    return firstValueFrom(this.http.get<UserInfo>('/users/info', {context})
       .pipe(tap(userInfo => {
           this.userInfo.set(userInfo);
           return of(userInfo);
@@ -74,7 +76,8 @@ export class AuthenticationService {
   private executeLoginRequest(username: string, password: string): Observable<LoginResponse> {
     const encodedCredentials = btoa(username + ':' + password);
     const options = {
-      headers: new HttpHeaders().set('Authorization', 'Basic ' + encodedCredentials)
+      headers: new HttpHeaders().set('Authorization', 'Basic ' + encodedCredentials),
+      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true)
     };
     return this.http.post<LoginResponse>('/login', undefined, options);
   }

--- a/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authentication.service.ts
@@ -1,9 +1,9 @@
-import {HttpClient, HttpContext, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {inject, Service, signal} from '@angular/core';
 import {Router} from '@angular/router';
 import {firstValueFrom, Observable, of} from 'rxjs';
 import {catchError, map, tap} from 'rxjs/operators';
-import {SUPPRESS_ERROR_TOAST} from '../http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../http/suppress-error-toast.token';
 
 @Service()
 export class AuthenticationService {
@@ -62,8 +62,7 @@ export class AuthenticationService {
   }
 
   public loadUserInfo(): Promise<UserInfo | null> {
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    return firstValueFrom(this.http.get<UserInfo>('/users/info', {context})
+    return firstValueFrom(this.http.get<UserInfo>('/users/info', {context: SUPPRESS_ERROR_TOAST_CONTEXT})
       .pipe(tap(userInfo => {
           this.userInfo.set(userInfo);
           return of(userInfo);
@@ -77,7 +76,7 @@ export class AuthenticationService {
     const encodedCredentials = btoa(username + ':' + password);
     const options = {
       headers: new HttpHeaders().set('Authorization', 'Basic ' + encodedCredentials),
-      context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true)
+      context: SUPPRESS_ERROR_TOAST_CONTEXT
     };
     return this.http.post<LoginResponse>('/login', undefined, options);
   }

--- a/frontend/src/main/webapp/src/app/common/views/passwordchange-form/passwordchange-form.component.ts
+++ b/frontend/src/main/webapp/src/app/common/views/passwordchange-form/passwordchange-form.component.ts
@@ -3,7 +3,7 @@ import {form, FormField, maxLength, minLength, required, validate} from '@angula
 import {ChangePasswordRequest, ChangePasswordResponse, UserApiService} from '../../../api/user-api.service';
 import {catchError, map} from 'rxjs/operators';
 import {Observable, throwError} from 'rxjs';
-import {HttpErrorResponse} from '@angular/common/http';
+import {HttpContext, HttpErrorResponse} from '@angular/common/http';
 import {CommonModule} from '@angular/common';
 import {TafelAutofocusDirective} from '../../directive/tafel-autofocus.directive';
 import {faEye, faEyeSlash} from '@fortawesome/free-solid-svg-icons';
@@ -12,6 +12,7 @@ import {MatError, MatFormField, MatInput, MatLabel, MatSuffix} from '@angular/ma
 import {MatDivider} from '@angular/material/list';
 import {MatIcon} from '@angular/material/icon';
 import {visibleErrorMessages} from '../../util/signal-form-helper';
+import {SUPPRESS_ERROR_TOAST} from '../../http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-passwordchange-form',
@@ -102,7 +103,8 @@ export class PasswordChangeFormComponent {
 
     const passwordChangeRequest: ChangePasswordRequest = {passwordCurrent: currentPassword, passwordNew: newPassword};
 
-    return this.userApiService.changePassword(passwordChangeRequest).pipe(
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    return this.userApiService.changePassword(passwordChangeRequest, context).pipe(
       map(
         /* eslint-disable @typescript-eslint/no-unused-vars */
         (response: ChangePasswordResponse) => {

--- a/frontend/src/main/webapp/src/app/common/views/passwordchange-form/passwordchange-form.component.ts
+++ b/frontend/src/main/webapp/src/app/common/views/passwordchange-form/passwordchange-form.component.ts
@@ -3,7 +3,7 @@ import {form, FormField, maxLength, minLength, required, validate} from '@angula
 import {ChangePasswordRequest, ChangePasswordResponse, UserApiService} from '../../../api/user-api.service';
 import {catchError, map} from 'rxjs/operators';
 import {Observable, throwError} from 'rxjs';
-import {HttpContext, HttpErrorResponse} from '@angular/common/http';
+import {HttpErrorResponse} from '@angular/common/http';
 import {CommonModule} from '@angular/common';
 import {TafelAutofocusDirective} from '../../directive/tafel-autofocus.directive';
 import {faEye, faEyeSlash} from '@fortawesome/free-solid-svg-icons';
@@ -12,7 +12,7 @@ import {MatError, MatFormField, MatInput, MatLabel, MatSuffix} from '@angular/ma
 import {MatDivider} from '@angular/material/list';
 import {MatIcon} from '@angular/material/icon';
 import {visibleErrorMessages} from '../../util/signal-form-helper';
-import {SUPPRESS_ERROR_TOAST} from '../../http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-passwordchange-form',
@@ -103,8 +103,7 @@ export class PasswordChangeFormComponent {
 
     const passwordChangeRequest: ChangePasswordRequest = {passwordCurrent: currentPassword, passwordNew: newPassword};
 
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    return this.userApiService.changePassword(passwordChangeRequest, context).pipe(
+    return this.userApiService.changePassword(passwordChangeRequest, SUPPRESS_ERROR_TOAST_CONTEXT).pipe(
       map(
         /* eslint-disable @typescript-eslint/no-unused-vars */
         (response: ChangePasswordResponse) => {

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
@@ -320,7 +320,7 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(component.customer()).toEqual(mockCustomer);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
 
         expect(component.customerState()).toBe(CustomerState.VALID);
         expect(component.customerStateText()).toBe('GÜLTIG');
@@ -377,7 +377,7 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(component.customer()).toEqual(mockCustomer);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
 
         expect(component.customerState()).toBe(CustomerState.VALID);
         expect(component.customerStateText()).toBe('GÜLTIG');
@@ -430,7 +430,7 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(component.customer()).toEqual(mockCustomer);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
 
         expect(component.customerState()).toBe(CustomerState.VALID_WARN);
         expect(component.customerStateText()).toBe('GÜLTIG - läuft bald ab');
@@ -480,7 +480,7 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(component.customer()).toEqual(mockCustomer);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
 
         expect(component.customerState()).toBe(CustomerState.INVALID);
         expect(component.customerStateText()).toBe('UNGÜLTIG');
@@ -531,7 +531,7 @@ describe('CheckinComponent', () => {
         fixture.detectChanges();
 
         expect(component.customer()).toEqual(mockCustomer);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
 
         expect(component.customerState()).toBe(CustomerState.LOCKED);
         expect(component.customerStateText()).toBe('GESPERRT');
@@ -559,8 +559,23 @@ describe('CheckinComponent', () => {
         expect(component.customer()).toBeUndefined();
         expect(component.customerState()).toBeUndefined();
         expect(component.customerNotes()).toEqual([]);
-        expect(customerApiService.getCustomer).toHaveBeenCalledWith(testCustomerId);
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(testCustomerId, expect.anything());
         expect(toastr.info).toHaveBeenCalledWith(`Kunde ${testCustomerId} nicht gefunden!`);
+    });
+
+    it('searchForCustomerId non-404 error shows error toast', () => {
+        const fixture = TestBed.createComponent(CheckinComponent);
+        const component = fixture.componentInstance;
+        component.customerNotes.set([]);
+
+        customerApiService.getCustomer.mockReturnValue(throwError(() => ({ status: 500 })));
+        const testCustomerId = 1234;
+        component.customerId.set(testCustomerId);
+
+        component.searchForCustomerId();
+
+        expect(customerApiService.getCustomer).toHaveBeenCalledWith(testCustomerId, expect.anything());
+        expect(toastr.error).toHaveBeenCalledWith('Interner Serverfehler!', 'Fehler beim Laden des Kunden!');
     });
 
     it('searchForCustomerId found notes', async () => {

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
@@ -1,5 +1,5 @@
 import {Component, computed, DestroyRef, effect, ElementRef, inject, signal, viewChild} from '@angular/core';
-import {HttpContext, HttpErrorResponse} from '@angular/common/http';
+import {HttpErrorResponse} from '@angular/common/http';
 import {CustomerApiService, CustomerData} from '../../../../api/customer-api.service';
 import {Subscription} from 'rxjs';
 import dayjs from 'dayjs';
@@ -26,7 +26,7 @@ import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faTrashCan} from '@fortawesome/free-solid-svg-icons';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {extractErrorMessage} from '../../../../common/api/problem-detail';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
     selector: 'tafel-checkin',
@@ -227,8 +227,7 @@ export class CheckinComponent {
     };
 
     if (this.customerId()) {
-      const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-      this.customerApiService.getCustomer(this.customerId()!, context).subscribe(observer);
+      this.customerApiService.getCustomer(this.customerId()!, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
     } else {
       this.toastr.warning('Keine Kundennummer angegeben!');
     }

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
@@ -1,4 +1,5 @@
 import {Component, computed, DestroyRef, effect, ElementRef, inject, signal, viewChild} from '@angular/core';
+import {HttpContext, HttpErrorResponse} from '@angular/common/http';
 import {CustomerApiService, CustomerData} from '../../../../api/customer-api.service';
 import {Subscription} from 'rxjs';
 import dayjs from 'dayjs';
@@ -24,6 +25,8 @@ import {MatOption, MatSelect} from '@angular/material/select';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faTrashCan} from '@fortawesome/free-solid-svg-icons';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {extractErrorMessage} from '../../../../common/api/problem-detail';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
     selector: 'tafel-checkin',
@@ -212,17 +215,20 @@ export class CheckinComponent {
             this.ticketNumberEdit.set(this.ticketNumber() != null);
           });
       },
-      error: (error: any) => {
+      error: (error: HttpErrorResponse) => {
         if (error.status === 404) {
           this.processCustomer(undefined);
           this.customerNotes.set([]);
           this.toastr.info(`Kunde ${this.customerId()} nicht gefunden!`);
+        } else {
+          this.toastr.error(extractErrorMessage(error), 'Fehler beim Laden des Kunden!');
         }
       },
     };
 
     if (this.customerId()) {
-      this.customerApiService.getCustomer(this.customerId()!).subscribe(observer);
+      const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+      this.customerApiService.getCustomer(this.customerId()!, context).subscribe(observer);
     } else {
       this.toastr.warning('Keine Kundennummer angegeben!');
     }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.spec.ts
@@ -463,7 +463,7 @@ describe('CustomerDetailComponent', () => {
 
     expect(customerApiService.deleteCustomer).toHaveBeenCalled();
     expect(location.path()).not.toBe('/kunden/suchen');
-    expect(toastr.error).toHaveBeenCalledWith('Löschen fehlgeschlagen!');
+    expect(toastr.error).toHaveBeenCalledWith('Es ist ein unerwarteter Fehler aufgetreten.', 'Löschen fehlgeschlagen!');
   });
 
   it('prolong customer', () => {
@@ -485,7 +485,7 @@ describe('CustomerDetailComponent', () => {
 
     component.prolongCustomer(3);
 
-    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false);
+    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false, expect.anything());
     expect(component.customerData()).toEqual(expectedCustomerData);
   });
 
@@ -695,7 +695,7 @@ describe('CustomerDetailComponent', () => {
     component.ticketNumberInput.set(55);
     component.assignTicket();
 
-    expect(distributionApiService.assignCustomer).toHaveBeenCalledWith(mockCustomer.id, 55);
+    expect(distributionApiService.assignCustomer).toHaveBeenCalledWith(mockCustomer.id, 55, expect.anything());
     expect(component.ticketNumber()).toBe(55);
     expect(component.ticketNumberInput()).toBeNull();
     expect(toastr.success).toHaveBeenCalledWith('Ticket wurde zugewiesen!');
@@ -718,7 +718,7 @@ describe('CustomerDetailComponent', () => {
 
     component.deleteTicket();
 
-    expect(distributionTicketApiService.deleteCurrentTicketOfCustomer).toHaveBeenCalledWith(mockCustomer.id);
+    expect(distributionTicketApiService.deleteCurrentTicketOfCustomer).toHaveBeenCalledWith(mockCustomer.id, expect.anything());
     expect(component.ticketNumber()).toBeNull();
     expect(toastr.success).toHaveBeenCalledWith('Ticket wurde gelöscht!');
   });
@@ -768,7 +768,7 @@ describe('CustomerDetailComponent', () => {
         message: mockMessage
       }
     });
-    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(mockCustomer, true);
+    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(mockCustomer, true, expect.anything());
   });
 
   it('openConfirmUpdateCustomerDialog does not call API when dialog is cancelled', () => {
@@ -813,7 +813,7 @@ describe('CustomerDetailComponent', () => {
 
     component.prolongCustomer(3);
 
-    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false);
+    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false, expect.anything());
   });
 
   it('prolong customer with non-409 error shows error toast', () => {
@@ -835,8 +835,8 @@ describe('CustomerDetailComponent', () => {
 
     component.prolongCustomer(3);
 
-    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false);
-    expect(toastr.error).toHaveBeenCalledWith('Verlängerung fehlgeschlagen!');
+    expect(customerApiService.updateCustomer).toHaveBeenCalledWith(expectedCustomerData, false, expect.anything());
+    expect(toastr.error).toHaveBeenCalledWith('Internal server error', 'Verlängerung fehlgeschlagen!');
   });
 
   function getTextByTestId(fixture: ComponentFixture<CustomerDetailComponent>, testId: string): string {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
@@ -8,7 +8,7 @@ import {
   CustomerData,
   CustomerUpdateResponse
 } from '../../../../api/customer-api.service';
-import {HttpContext, HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpErrorResponse, HttpResponse} from '@angular/common/http';
 import {
   CustomerNoteApiService,
   CustomerNoteItem,
@@ -43,7 +43,7 @@ import {
 } from '../../components/confirm-customer-save-dialog/confirm-customer-save-dialog.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {extractErrorMessage} from '../../../../common/api/problem-detail';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-detail',
@@ -164,8 +164,7 @@ export class CustomerDetailComponent {
     this.dialog.open(DeleteCustomerDialogComponent)
       .afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-        this.customerApiService.deleteCustomer(this.customerData().id!, context).subscribe({
+        this.customerApiService.deleteCustomer(this.customerData().id!, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
           next: async () => {
             this.toastr.success('Kunde wurde gelöscht!');
             await this.router.navigate(['/kunden/suchen']);
@@ -185,8 +184,7 @@ export class CustomerDetailComponent {
       }
     }).afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-        this.customerApiService.updateCustomer(customerData, true, context).subscribe({
+        this.customerApiService.updateCustomer(customerData, true, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
           next: () => {
             this.toastr.success('Kunde wurde verlängert!');
           },
@@ -219,8 +217,7 @@ export class CustomerDetailComponent {
       },
     };
 
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    this.customerApiService.updateCustomer(updatedCustomerData, false, context).subscribe(observer);
+    this.customerApiService.updateCustomer(updatedCustomerData, false, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
   }
 
   disableCustomer() {
@@ -294,8 +291,7 @@ export class CustomerDetailComponent {
   assignTicket() {
     const ticketNumber = this.ticketNumberInput()!;
     const customerId = this.customerData().id!;
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    this.distributionApiService.assignCustomer(customerId, ticketNumber, context).subscribe({
+    this.distributionApiService.assignCustomer(customerId, ticketNumber, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
       next: () => {
         this.ticketNumber.set(ticketNumber);
         this.ticketNumberInput.set(null);
@@ -309,8 +305,7 @@ export class CustomerDetailComponent {
 
   deleteTicket() {
     const customerId = this.customerData().id!;
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    this.distributionTicketApiService.deleteCurrentTicketOfCustomer(customerId, context).subscribe({
+    this.distributionTicketApiService.deleteCurrentTicketOfCustomer(customerId, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
       next: () => {
         this.ticketNumber.set(null);
         this.toastr.success('Ticket wurde gelöscht!');

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.ts
@@ -8,7 +8,7 @@ import {
   CustomerData,
   CustomerUpdateResponse
 } from '../../../../api/customer-api.service';
-import {HttpResponse} from '@angular/common/http';
+import {HttpContext, HttpErrorResponse, HttpResponse} from '@angular/common/http';
 import {
   CustomerNoteApiService,
   CustomerNoteItem,
@@ -42,6 +42,8 @@ import {
   ConfirmCustomerSaveDialog
 } from '../../components/confirm-customer-save-dialog/confirm-customer-save-dialog.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {extractErrorMessage} from '../../../../common/api/problem-detail';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-detail',
@@ -162,13 +164,14 @@ export class CustomerDetailComponent {
     this.dialog.open(DeleteCustomerDialogComponent)
       .afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        this.customerApiService.deleteCustomer(this.customerData().id!).subscribe({
+        const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+        this.customerApiService.deleteCustomer(this.customerData().id!, context).subscribe({
           next: async () => {
             this.toastr.success('Kunde wurde gelöscht!');
             await this.router.navigate(['/kunden/suchen']);
           },
-          error: () => {
-            this.toastr.error('Löschen fehlgeschlagen!');
+          error: (error: HttpErrorResponse) => {
+            this.toastr.error(extractErrorMessage(error), 'Löschen fehlgeschlagen!');
           },
         });
       }
@@ -182,12 +185,13 @@ export class CustomerDetailComponent {
       }
     }).afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        this.customerApiService.updateCustomer(customerData, true).subscribe({
+        const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+        this.customerApiService.updateCustomer(customerData, true, context).subscribe({
           next: () => {
             this.toastr.success('Kunde wurde verlängert!');
           },
-          error: () => {
-            this.toastr.error('Verlängerung fehlgeschlagen!');
+          error: (error: HttpErrorResponse) => {
+            this.toastr.error(extractErrorMessage(error), 'Verlängerung fehlgeschlagen!');
           },
         });
       }
@@ -206,16 +210,17 @@ export class CustomerDetailComponent {
         const customer = response.data;
         this.customerData.set(customer);
       },
-      error: (error: any) => {
+      error: (error: HttpErrorResponse) => {
         if (error.status === 409) {
-          this.openConfirmUpdateCustomerDialog(updatedCustomerData, error.error.detail);
+          this.openConfirmUpdateCustomerDialog(updatedCustomerData, extractErrorMessage(error));
         } else {
-          this.toastr.error('Verlängerung fehlgeschlagen!');
+          this.toastr.error(extractErrorMessage(error), 'Verlängerung fehlgeschlagen!');
         }
       },
     };
 
-    this.customerApiService.updateCustomer(updatedCustomerData, false).subscribe(observer);
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    this.customerApiService.updateCustomer(updatedCustomerData, false, context).subscribe(observer);
   }
 
   disableCustomer() {
@@ -289,27 +294,29 @@ export class CustomerDetailComponent {
   assignTicket() {
     const ticketNumber = this.ticketNumberInput()!;
     const customerId = this.customerData().id!;
-    this.distributionApiService.assignCustomer(customerId, ticketNumber).subscribe({
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    this.distributionApiService.assignCustomer(customerId, ticketNumber, context).subscribe({
       next: () => {
         this.ticketNumber.set(ticketNumber);
         this.ticketNumberInput.set(null);
         this.toastr.success('Ticket wurde zugewiesen!');
       },
-      error: () => {
-        this.toastr.error('Ticket-Zuweisung fehlgeschlagen!');
+      error: (error: HttpErrorResponse) => {
+        this.toastr.error(extractErrorMessage(error), 'Ticket-Zuweisung fehlgeschlagen!');
       }
     });
   }
 
   deleteTicket() {
     const customerId = this.customerData().id!;
-    this.distributionTicketApiService.deleteCurrentTicketOfCustomer(customerId).subscribe({
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    this.distributionTicketApiService.deleteCurrentTicketOfCustomer(customerId, context).subscribe({
       next: () => {
         this.ticketNumber.set(null);
         this.toastr.success('Ticket wurde gelöscht!');
       },
-      error: () => {
-        this.toastr.error('Ticket-Löschung fehlgeschlagen!');
+      error: (error: HttpErrorResponse) => {
+        this.toastr.error(extractErrorMessage(error), 'Ticket-Löschung fehlgeschlagen!');
       }
     });
   }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-existing-customer.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-existing-customer.component.spec.ts
@@ -170,7 +170,7 @@ describe('CustomerEditComponent - Editing an existing customer', () => {
       firstname: testCustomerData.firstname,
       birthDate: testCustomerData.birthDate,
       gender: testCustomerData.gender
-    }), false);
+    }), false, expect.anything());
     expect(router.navigate).toHaveBeenCalledWith(['/kunden/detail', testCustomerData.id]);
   });
 
@@ -206,7 +206,7 @@ describe('CustomerEditComponent - Editing an existing customer', () => {
       firstname: testCustomerData.firstname,
       birthDate: testCustomerData.birthDate,
       gender: testCustomerData.gender
-    }), false);
+    }), false, expect.anything());
     expect(router.navigate).toHaveBeenCalledWith(['/kunden/detail', testCustomerData.id]);
   });
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-new-customer.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit-new-customer.component.spec.ts
@@ -164,7 +164,7 @@ describe('CustomerEditComponent - Creating a new customer', () => {
       lastname: testCustomerData.lastname,
       firstname: testCustomerData.firstname,
       birthDate: testCustomerData.birthDate
-    }), false);
+    }), false, expect.anything());
     expect(router.navigate).toHaveBeenCalledWith(['/kunden/detail', testCustomerData.id]);
   });
 
@@ -294,8 +294,8 @@ describe('CustomerEditComponent - Creating a new customer', () => {
         message: mockMessage
       }
     });
-    expect(apiService.createCustomer).toHaveBeenNthCalledWith(1, expect.objectContaining(testCustomerData), false);
-    expect(apiService.createCustomer).toHaveBeenNthCalledWith(2, expect.objectContaining(testCustomerData), true);
+    expect(apiService.createCustomer).toHaveBeenNthCalledWith(1, expect.objectContaining(testCustomerData), false, expect.anything());
+    expect(apiService.createCustomer).toHaveBeenNthCalledWith(2, expect.objectContaining(testCustomerData), true, expect.anything());
     expect(router.navigate).toHaveBeenCalledWith(['/kunden/detail', testCustomerData.id]);
   });
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
@@ -1,5 +1,5 @@
 import {afterRenderEffect, Component, computed, inject, input, linkedSignal, viewChild} from '@angular/core';
-import {HttpContext, HttpErrorResponse} from '@angular/common/http';
+import {HttpErrorResponse} from '@angular/common/http';
 import {CustomerFormComponent} from '../../components/customer-form/customer-form.component';
 import {
   CustomerApiService,
@@ -16,7 +16,7 @@ import {
 } from '../../components/confirm-customer-save-dialog/confirm-customer-save-dialog.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {extractErrorMessage} from '../../../../common/api/problem-detail';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-edit',
@@ -86,8 +86,6 @@ export class CustomerEditComponent {
       return;
     }
 
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-
     if (!this.editMode()) {
       const observer = {
         next: (response: CustomerCreationResponse) => {
@@ -98,7 +96,7 @@ export class CustomerEditComponent {
           const errorMessage = extractErrorMessage(error);
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
-              this.customerApiService.createCustomer(this.customerUpdated(), true, context).subscribe({
+              this.customerApiService.createCustomer(this.customerUpdated(), true, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
                 next: (response: CustomerCreationResponse) => {
                   const customer = response.data;
                   this.toastr.success('Kunde wurde gespeichert!');
@@ -115,7 +113,7 @@ export class CustomerEditComponent {
         },
       };
 
-      this.customerApiService.createCustomer(this.customerUpdated(), false, context).subscribe(observer);
+      this.customerApiService.createCustomer(this.customerUpdated(), false, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
     } else {
       const observer = {
         next: (response: CustomerUpdateResponse) => {
@@ -126,7 +124,7 @@ export class CustomerEditComponent {
           const errorMessage = extractErrorMessage(error);
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
-              this.customerApiService.updateCustomer(this.customerUpdated(), true, context).subscribe({
+              this.customerApiService.updateCustomer(this.customerUpdated(), true, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe({
                 next: (response: CustomerUpdateResponse) => {
                   const customer = response.data;
                   this.toastr.success('Kunde wurde gespeichert!');
@@ -142,7 +140,7 @@ export class CustomerEditComponent {
           }
         },
       };
-      this.customerApiService.updateCustomer(this.customerUpdated(), false, context).subscribe(observer);
+      this.customerApiService.updateCustomer(this.customerUpdated(), false, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
     }
   }
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-edit/customer-edit.component.ts
@@ -1,4 +1,5 @@
 import {afterRenderEffect, Component, computed, inject, input, linkedSignal, viewChild} from '@angular/core';
+import {HttpContext, HttpErrorResponse} from '@angular/common/http';
 import {CustomerFormComponent} from '../../components/customer-form/customer-form.component';
 import {
   CustomerApiService,
@@ -14,6 +15,8 @@ import {
   ConfirmCustomerSaveDialog
 } from '../../components/confirm-customer-save-dialog/confirm-customer-save-dialog.component';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {extractErrorMessage} from '../../../../common/api/problem-detail';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-edit',
@@ -83,24 +86,26 @@ export class CustomerEditComponent {
       return;
     }
 
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+
     if (!this.editMode()) {
       const observer = {
         next: (response: CustomerCreationResponse) => {
           const customer = response.data;
           this.router.navigate(['/kunden/detail', customer.id]);
         },
-        error: (error: any) => {
-          const errorMessage = error.error.detail;
+        error: (error: HttpErrorResponse) => {
+          const errorMessage = extractErrorMessage(error);
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
-              this.customerApiService.createCustomer(this.customerUpdated(), true).subscribe({
+              this.customerApiService.createCustomer(this.customerUpdated(), true, context).subscribe({
                 next: (response: CustomerCreationResponse) => {
                   const customer = response.data;
                   this.toastr.success('Kunde wurde gespeichert!');
                   this.router.navigate(['/kunden/detail', customer.id]);
                 },
-                error: () => {
-                  this.toastr.error(errorMessage, 'Speichern fehlgeschlagen!');
+                error: (retryError: HttpErrorResponse) => {
+                  this.toastr.error(extractErrorMessage(retryError), 'Speichern fehlgeschlagen!');
                 },
               });
             });
@@ -110,25 +115,25 @@ export class CustomerEditComponent {
         },
       };
 
-      this.customerApiService.createCustomer(this.customerUpdated(), false).subscribe(observer);
+      this.customerApiService.createCustomer(this.customerUpdated(), false, context).subscribe(observer);
     } else {
       const observer = {
         next: (response: CustomerUpdateResponse) => {
           const customer = response.data;
           this.router.navigate(['/kunden/detail', customer.id]);
         },
-        error: (error: any) => {
-          const errorMessage = error.error.detail;
+        error: (error: HttpErrorResponse) => {
+          const errorMessage = extractErrorMessage(error);
           if (error.status === 409) {
             this.openConfirmCustomerSaveDialog(errorMessage, () => {
-              this.customerApiService.updateCustomer(this.customerUpdated(), true).subscribe({
+              this.customerApiService.updateCustomer(this.customerUpdated(), true, context).subscribe({
                 next: (response: CustomerUpdateResponse) => {
                   const customer = response.data;
                   this.toastr.success('Kunde wurde gespeichert!');
                   this.router.navigate(['/kunden/detail', customer.id]);
                 },
-                error: () => {
-                  this.toastr.error(errorMessage, 'Speichern fehlgeschlagen!');
+                error: (retryError: HttpErrorResponse) => {
+                  this.toastr.error(extractErrorMessage(retryError), 'Speichern fehlgeschlagen!');
                 },
               });
             });
@@ -137,7 +142,7 @@ export class CustomerEditComponent {
           }
         },
       };
-      this.customerApiService.updateCustomer(this.customerUpdated(), false).subscribe(observer);
+      this.customerApiService.updateCustomer(this.customerUpdated(), false, context).subscribe(observer);
     }
   }
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
@@ -1,5 +1,4 @@
 import {Component, inject, signal} from '@angular/core';
-import {HttpContext} from '@angular/common/http';
 import {Router} from '@angular/router';
 import {CustomerApiService, CustomerData, CustomerSearchResult} from '../../../../api/customer-api.service';
 import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
@@ -17,7 +16,7 @@ import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofocus.directive';
 import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-search',
@@ -70,8 +69,7 @@ export class CustomerSearchComponent {
         }
       }
     };
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    this.customerApiService.getCustomer(customerId, context).subscribe(observer);
+    this.customerApiService.getCustomer(customerId, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
   }
 
   private navigateToCustomerDetail(customerId: number) {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
@@ -1,4 +1,5 @@
 import {Component, inject, signal} from '@angular/core';
+import {HttpContext} from '@angular/common/http';
 import {Router} from '@angular/router';
 import {CustomerApiService, CustomerData, CustomerSearchResult} from '../../../../api/customer-api.service';
 import {FormBuilder, ReactiveFormsModule} from '@angular/forms';
@@ -16,6 +17,7 @@ import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofocus.directive';
 import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-customer-search',
@@ -68,7 +70,8 @@ export class CustomerSearchComponent {
         }
       }
     };
-    this.customerApiService.getCustomer(customerId).subscribe(observer);
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    this.customerApiService.getCustomer(customerId, context).subscribe(observer);
   }
 
   private navigateToCustomerDetail(customerId: number) {

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.spec.ts
@@ -78,7 +78,7 @@ describe('UserEditComponent', () => {
 
             expect(component.isSaveEnabled()).toBe(true);
             expect(userFormComponentMock.markAllAsTouched).toHaveBeenCalled();
-            expect(apiService.createUser).toHaveBeenCalledWith(expect.objectContaining(mockUser));
+            expect(apiService.createUser).toHaveBeenCalledWith(expect.objectContaining(mockUser), expect.anything());
             expect(router.navigate).toHaveBeenCalledWith(['/benutzer/detail', mockUser.id]);
         });
     });
@@ -141,7 +141,7 @@ describe('UserEditComponent', () => {
             component.save();
 
             expect(component.userData()).toEqual(mockUser);
-            expect(apiService.updateUser).toHaveBeenCalledWith(expect.objectContaining(mockUser));
+            expect(apiService.updateUser).toHaveBeenCalledWith(expect.objectContaining(mockUser), expect.anything());
             expect(router.navigate).toHaveBeenCalledWith(['/benutzer/detail', mockUser.id]);
         });
     });

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
@@ -1,9 +1,12 @@
 import {afterRenderEffect, Component, inject, input, linkedSignal, viewChild} from '@angular/core';
+import {HttpContext, HttpErrorResponse} from '@angular/common/http';
 import {Router} from '@angular/router';
 import {UserApiService, UserData, UserPermission} from '../../../../api/user-api.service';
 import {UserFormComponent} from '../../components/user-form/user-form.component';
 import {MatButtonModule} from '@angular/material/button';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {extractErrorMessage} from '../../../../common/api/problem-detail';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-user-edit',
@@ -51,15 +54,16 @@ export class UserEditComponent {
       next: (user: UserData) => {
         this.router.navigate(['/benutzer/detail', user.id]);
       },
-      error: (error: any) => {
-        this.toastr.error(error.error.detail || 'Fehler beim Speichern des Benutzers');
+      error: (error: HttpErrorResponse) => {
+        this.toastr.error(extractErrorMessage(error));
       },
     };
 
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
     if (!this.userData()) {
-      this.userApiService.createUser(this.userUpdated()!).subscribe(observer);
+      this.userApiService.createUser(this.userUpdated()!, context).subscribe(observer);
     } else {
-      this.userApiService.updateUser(this.userUpdated()!).subscribe(observer);
+      this.userApiService.updateUser(this.userUpdated()!, context).subscribe(observer);
     }
   }
 

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-edit/user-edit.component.ts
@@ -1,12 +1,12 @@
 import {afterRenderEffect, Component, inject, input, linkedSignal, viewChild} from '@angular/core';
-import {HttpContext, HttpErrorResponse} from '@angular/common/http';
+import {HttpErrorResponse} from '@angular/common/http';
 import {Router} from '@angular/router';
 import {UserApiService, UserData, UserPermission} from '../../../../api/user-api.service';
 import {UserFormComponent} from '../../components/user-form/user-form.component';
 import {MatButtonModule} from '@angular/material/button';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {extractErrorMessage} from '../../../../common/api/problem-detail';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-user-edit',
@@ -59,11 +59,10 @@ export class UserEditComponent {
       },
     };
 
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
     if (!this.userData()) {
-      this.userApiService.createUser(this.userUpdated()!, context).subscribe(observer);
+      this.userApiService.createUser(this.userUpdated()!, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
     } else {
-      this.userApiService.updateUser(this.userUpdated()!, context).subscribe(observer);
+      this.userApiService.updateUser(this.userUpdated()!, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
     }
   }
 

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
@@ -1,5 +1,4 @@
 import {Component, inject, signal} from '@angular/core';
-import {HttpContext} from '@angular/common/http';
 import {CommonModule} from '@angular/common';
 import {Router} from '@angular/router';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -19,7 +18,7 @@ import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofo
 import {form, FormField} from '@angular/forms/signals';
 import {MatDividerModule} from '@angular/material/divider';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
-import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
+import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-user-search',
@@ -75,8 +74,8 @@ export class UserSearchComponent {
         }
       }
     };
-    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
-    this.userApiService.getUserForPersonnelNumber(this.searchForm.personnelNumber().value(), context).subscribe(observer);
+    const personnelNumber = this.searchForm.personnelNumber().value();
+    this.userApiService.getUserForPersonnelNumber(personnelNumber, SUPPRESS_ERROR_TOAST_CONTEXT).subscribe(observer);
   }
 
   navigateToUserDetail(userId: number | undefined) {

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
@@ -1,4 +1,5 @@
 import {Component, inject, signal} from '@angular/core';
+import {HttpContext} from '@angular/common/http';
 import {CommonModule} from '@angular/common';
 import {Router} from '@angular/router';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -18,6 +19,7 @@ import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofo
 import {form, FormField} from '@angular/forms/signals';
 import {MatDividerModule} from '@angular/material/divider';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {SUPPRESS_ERROR_TOAST} from '../../../../common/http/suppress-error-toast.token';
 
 @Component({
   selector: 'tafel-user-search',
@@ -73,7 +75,8 @@ export class UserSearchComponent {
         }
       }
     };
-    this.userApiService.getUserForPersonnelNumber(this.searchForm.personnelNumber().value()).subscribe(observer);
+    const context = new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+    this.userApiService.getUserForPersonnelNumber(this.searchForm.personnelNumber().value(), context).subscribe(observer);
   }
 
   navigateToUserDetail(userId: number | undefined) {


### PR DESCRIPTION
## Summary
Closes #2880.

The generic HTTP error interceptor used a hardcoded status-code whitelist (`400, 401, 404, 409`) to decide when to stay silent, on the assumption those were always handled locally — that assumption didn't hold everywhere, causing both silent gaps and duplicate toasts, and it fell back to Angular's raw technical `error.message` for unrecognized bodies.

Replaces the whitelist with Angular's native per-request opt-out (`HttpContext`/`HttpContextToken`): the interceptor now shows a user-safe toast **by default** for any error, and only requests that fully own their own error presentation (save flows, search-by-id lookups, login, app-boot session check, etc.) opt out via a new `SUPPRESS_ERROR_TOAST` token.

- Adds `SUPPRESS_ERROR_TOAST` (`common/http/suppress-error-toast.token.ts`) and a shared `ProblemDetail` model + `extractErrorMessage()` helper (`common/api/problem-detail.ts`) matching the backend's RFC 7807 shape, replacing ad hoc `error.error.detail` casts.
- Fixes several confirmed duplicate-toast bugs (`customer-edit`, `customer-search`, `user-search`, `customer-detail`'s prolong/delete/assign/ticket actions) and a duplicate-message bug on locked-account login.
- `AuthenticationService.loadUserInfo()` (runs on every app boot, returns 401 for every logged-out visitor) is opted out — otherwise every visit to `/login` would flash an error toast before the form even renders.
- Extends the status-to-message map to cover statuses that show up without any controller ever explicitly sending them: `0` (no connection reached the server), `500` (bodyless container-level error page), `502`/`503`/`504` (reverse-proxy/gateway responses).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test-ci` (610 tests passing)
- [ ] Manual smoke test: wrong-password login, customer save conflict (409), an unmapped backend error, logged-out landing page (no stray toast on load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)