### PR TITLE
refactor(backend)!: standardize REST DTO naming convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,9 @@ The application uses PostgreSQL with Flyway for schema management. Migration fil
 - Services: Suffix with `Service`, mark internal services in `internal/` package
 - Entities: Suffix with `Entity`, located in `database/model/`
 - Repositories: Suffix with `Repository`, use Spring Data JPA
-- Models: Suffix with `Model` or `ResponseModel` for DTOs
+- Models: DTOs bound to a REST endpoint follow the naming convention in [API
+  Structure](#rest-dto-naming-convention) below; `Model`/`ResponseModel` filenames (not type names)
+  remain fine for the file a DTO group lives in (e.g. `HouseholdResponseModel.kt`)
 - Use constructor injection for dependencies
 - Use `@Transactional` on service methods that modify data
 - Converters in `internal/converter/` package convert entities to models
@@ -303,6 +305,50 @@ endpoints return `201`, delete endpoints return `204` — this is a project-wide
 just a pattern that happens to repeat. SSE endpoints for a given resource live under a sibling
 `.../sse/...` controller (e.g. `DistributionController` + `DistributionSseController`) so their
 URLs stay stable even as the REST resource's own base path changes.
+
+### REST DTO naming convention
+
+Every type that appears directly in a controller method's signature (a `@RequestBody` parameter,
+or the return type once `ResponseEntity<T>`/`PagedResponse<T>`/`XxxListResponse` is unwrapped to
+`T`) gets one of exactly three suffixes, decided by how that type is actually used across the API
+— not by guessing what "feels" like a request or response:
+
+1. **`Request`** — the type is bound to `@RequestBody` somewhere. If the identical type is *also*
+   directly returned (the old "reuse the domain model for both directions" pattern), split it into
+   a same-named `XxxRequest`/`XxxResponse` pair rather than reusing one bare type for both (e.g.
+   `Car` → `CarRequest`/`CarResponse`, `Household` → `HouseholdRequest`/`HouseholdResponse`). This
+   is deliberate churn: it decouples the write and read wire contracts so either can evolve without
+   dragging the other along, even though the two classes are field-for-field identical on day one.
+2. **`Response`** — the type is returned directly from an endpoint (never a request body) and is
+   not merely a list element (see `Item` below). Covers both full resources with no request-body
+   counterpart (`Employee` → `EmployeeResponse`) and bare action-result types that previously had no
+   suffix or a stray one like `Data`/`Result` (`StatisticsData` → `StatisticsResponse`,
+   `DistributionCloseValidationResult` → `DistributionCloseResponse`).
+3. **`Item`** — the type is *only* ever the element type of a `PagedResponse<T>` or an
+   `XxxListResponse`'s `List<T>` — it never appears as a request body and is never itself returned
+   as a standalone single-resource response (`Route` → `RouteItem`, `SchoolStarterPackageEntry` →
+   `SchoolStarterPackageItem`). A type that already has a dedicated create/update response role
+   (e.g. `HouseholdNoteItem`, created via `POST` and also listed via `PagedResponse`) keeps the
+   `Item` suffix rather than splitting into `Request`/`Response` — the "is it ever a request body"
+   test is what actually matters, not "does some endpoint return one instance of it directly."
+
+Two established generic wrappers are exempt from all of the above and keep their existing names:
+`PagedResponse<T>` (`common/api/PagedResponse.kt`) for paginated lists, and a per-resource
+`XxxListResponse` for non-paginated full-list responses.
+
+**Nested value objects** that are embedded fields inside a `Request`/`Response`/`Item` type but are
+never *themselves* bound to a controller signature (not a request body, not a controller's direct
+return type, not the direct element type of a list endpoint) keep their plain domain name — no
+suffix. Examples: `Person`, `HouseholdAddress`, `HouseholdIssuer`, `ShelterContact` → renamed to
+`ShelterContactItem` for consistency with sibling repeatable-record types (`HouseholdNoteItem`,
+`StaticValueItem`'s successor), while `Person`/`HouseholdAddress`/`HouseholdIssuer` stay bare since
+they're single embedded values, not repeatable records. Enums never take a suffix.
+
+When a service method needs to operate on data that's structurally identical across a
+`Request`/`Response` split (e.g. validating a household's persons list, which exists on both
+`HouseholdRequest` and `HouseholdResponse`), prefer taking the narrower shared shape (a
+`List<Person>`, not a `Household`) over adding overloads or a shared supertype — see
+`HouseholdService.validate`/`mapToValidationPersons`.
 
 - `/api/users`: User management
 - `/api/households`: Household (customer) CRUD operations — the frontend's `customer-api.service.ts` calls this and translates to/from the old flat `CustomerData` shape; every other frontend file still just sees `CustomerData`

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
@@ -37,10 +37,10 @@ class UserController(
     }
 
     @GetMapping("/info")
-    fun getUserInfo(): ResponseEntity<UserInfo> {
+    fun getUserInfo(): ResponseEntity<UserInfoResponse> {
         val authenticatedUser = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
 
-        val userInfo = UserInfo(
+        val userInfo = UserInfoResponse(
             username = authenticatedUser.username!!,
             permissions = authenticatedUser.authorities.mapNotNull { it.authority },
         )
@@ -80,7 +80,7 @@ class UserController(
 
     @GetMapping("/{userId}")
     @PreAuthorize("hasAuthority('USER_MANAGEMENT')")
-    fun getUser(@PathVariable userId: Long): ResponseEntity<User> {
+    fun getUser(@PathVariable userId: Long): ResponseEntity<UserResponse> {
         val userDetails = userDetailsManager.loadUserById(userId)
             ?: throw NotFoundException("Benutzer (ID: $userId) nicht gefunden!")
         val user = mapToResponse(userDetails)
@@ -89,7 +89,7 @@ class UserController(
 
     @GetMapping("/personnel-number/{personnelNumber}")
     @PreAuthorize("hasAuthority('USER_MANAGEMENT')")
-    fun getUserByPersonnelNumber(@PathVariable personnelNumber: String): ResponseEntity<User> {
+    fun getUserByPersonnelNumber(@PathVariable personnelNumber: String): ResponseEntity<UserResponse> {
         val userDetails = userDetailsManager.loadUserByPersonnelNumber(personnelNumber.trim())
             ?: throw NotFoundException("Benutzer (Personalnummer: $personnelNumber) nicht gefunden!")
         val user = mapToResponse(userDetails)
@@ -104,7 +104,7 @@ class UserController(
         @RequestParam lastname: String? = null,
         @RequestParam enabled: Boolean? = null,
         @RequestParam page: Int? = null,
-    ): PagedResponse<User> {
+    ): PagedResponse<UserResponse> {
         val userSearchResult = userDetailsManager.loadUsers(
             username = username?.trim(),
             firstname = firstname?.trim(),
@@ -125,8 +125,8 @@ class UserController(
     @PreAuthorize("hasAuthority('USER_MANAGEMENT')")
     @Transactional
     fun createUser(
-        @Valid @RequestBody user: User,
-    ): ResponseEntity<User> {
+        @Valid @RequestBody user: UserRequest,
+    ): ResponseEntity<UserResponse> {
         validateIfUserExists(user)
 
         val tafelUser = mapToTafelUser(user)
@@ -136,7 +136,7 @@ class UserController(
         return ResponseEntity.status(HttpStatus.CREATED).body(userResponse)
     }
 
-    private fun validateIfUserExists(user: User) {
+    private fun validateIfUserExists(user: UserRequest) {
         try {
             userDetailsManager.loadUserByUsername(user.username)
             throw ConflictException("Benutzer (Benutzername: ${user.username}) existiert bereits!")
@@ -154,8 +154,8 @@ class UserController(
     @Transactional
     fun updateUser(
         @PathVariable userId: Long,
-        @Valid @RequestBody user: User,
-    ): ResponseEntity<User> {
+        @Valid @RequestBody user: UserRequest,
+    ): ResponseEntity<UserResponse> {
         userDetailsManager.loadUserById(userId)
             ?: throw NotFoundException("Benutzer (ID: $userId) nicht vorhanden!")
 
@@ -197,7 +197,7 @@ class UserController(
         return ResponseEntity.ok(PermissionsListResponse(permissions = permissions))
     }
 
-    private fun mapToTafelUser(user: User): TafelUser = TafelUser(
+    private fun mapToTafelUser(user: UserRequest): TafelUser = TafelUser(
         id = user.id,
         username = user.username,
         personnelNumber = user.personnelNumber,
@@ -209,7 +209,7 @@ class UserController(
         authorities = user.permissions.map { SimpleGrantedAuthority(it.key) },
     )
 
-    private fun mapToResponse(user: TafelUser): User = User(
+    private fun mapToResponse(user: TafelUser): UserResponse = UserResponse(
         id = user.id,
         username = user.username,
         personnelNumber = user.personnelNumber,
@@ -225,9 +225,9 @@ class UserController(
             .sortedBy { it.title },
     )
 
-    private fun mapToUserPermission(key: String): UserPermission {
+    private fun mapToUserPermission(key: String): UserPermissionItem {
         val permissionEnum = UserPermissions.valueOfKey(key)
-        return UserPermission(
+        return UserPermissionItem(
             key = permissionEnum.key,
             title = permissionEnum.title,
             category = permissionEnum.category.title,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserModel.kt
@@ -18,7 +18,7 @@ data class ChangePasswordResponse(
 )
 
 @ExcludeFromTestCoverage
-data class User(
+data class UserRequest(
     val id: Long?,
     @field:NotBlank
     val personnelNumber: String,
@@ -32,11 +32,25 @@ data class User(
     val password: String? = null,
     val passwordRepeat: String? = null,
     val passwordChangeRequired: Boolean,
-    val permissions: List<UserPermission>,
+    val permissions: List<UserPermissionItem>,
 )
 
 @ExcludeFromTestCoverage
-data class UserPermission(
+data class UserResponse(
+    val id: Long?,
+    val personnelNumber: String,
+    val username: String,
+    val firstname: String,
+    val lastname: String,
+    val enabled: Boolean,
+    val password: String? = null,
+    val passwordRepeat: String? = null,
+    val passwordChangeRequired: Boolean,
+    val permissions: List<UserPermissionItem>,
+)
+
+@ExcludeFromTestCoverage
+data class UserPermissionItem(
     val key: String,
     val title: String,
     val category: String = "",
@@ -48,12 +62,12 @@ data class GeneratedPasswordResponse(
 )
 
 @ExcludeFromTestCoverage
-data class UserInfo(
+data class UserInfoResponse(
     val username: String,
     val permissions: List<String>,
 )
 
 @ExcludeFromTestCoverage
 data class PermissionsListResponse(
-    val permissions: List<UserPermission>,
+    val permissions: List<UserPermissionItem>,
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
@@ -21,14 +21,16 @@ Entities backing this module are **not** colocated with it: they live under `dat
 ### `country` — `@NamedInterface("country")`
 - [`CountryController`](country/CountryController.kt): `GET /api/countries`, requires only
   `isAuthenticated()` (no specific permission) — returns the full country list, unpaginated.
-- [`CountryModel.kt`](country/CountryModel.kt): exposes `Country(id, code, name)` and
-  `CountryListResponse`.
+- [`CountryModel.kt`](country/CountryModel.kt): exposes `CountryItem(id, code, name)` and
+  `CountryListResponse`. `CountryItem` never appears as a standalone single-resource response or a
+  request body - it's only ever an element of `CountryListResponse.items` or an embedded field on
+  `Person`, hence the `Item` suffix rather than a `Request`/`Response` split.
 - Backed by `CountryRepository`/`CountryEntity` in `database/model/staticdata` (table
   `static_countries`).
 - **Only consumer:** the `household` module. `HouseholdConverter` resolves a `Person`'s
   `CountryEntity` by id (`countryRepository.findById(person.country.id)`), and
-  `HouseholdConverter.mapCountryToResponse` maps it back to the `base.country.Country` DTO for the
-  `Person.country` field in `HouseholdResponseModel.kt`. `household`'s `package-info.java` lists
+  `HouseholdConverter.mapCountryToResponse` maps it back to the `base.country.CountryItem` DTO for
+  the `Person.country` field in `HouseholdResponseModel.kt`. `household`'s `package-info.java` lists
   `base::country` in `allowedDependencies` accordingly. No other module references
   `modules.base.country`.
 
@@ -37,8 +39,9 @@ Entities backing this module are **not** colocated with it: they live under `dat
   name/personnel number) and `POST /api/employees` (create), both gated behind `LOGISTICS`
   authority (not a typo — employee management is treated as a logistics concern, since employees are
   mainly used to track who staffed a distribution/collection).
-- [`EmployeeModel.kt`](employee/EmployeeModel.kt): `Employee(id, personnelNumber, firstname,
-  lastname)`, `EmployeeListResponse`, `EmployeeCreateRequest`.
+- [`EmployeeModel.kt`](employee/EmployeeModel.kt): `EmployeeResponse(id, personnelNumber,
+  firstname, lastname)`, `EmployeeListResponse`, `EmployeeRequest` (used for both create and
+  update).
 - Backed by `EmployeeRepository`/`EmployeeEntity` in `database/model/base` (table `employees`).
 - **Only consumer:** the `logistics` module (`FoodCollectionService`, `FoodCollectionsModel`), which
   declares `base::employee` in its `allowedDependencies`. Note that `household` does **not** depend

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryModel.kt
@@ -4,11 +4,11 @@ import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 
 @ExcludeFromTestCoverage
 data class CountryListResponse(
-    val items: List<Country> = emptyList(),
+    val items: List<CountryItem> = emptyList(),
 )
 
 @ExcludeFromTestCoverage
-data class Country(
+data class CountryItem(
     val id: Long,
     val code: String,
     val name: String,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryService.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.base.country.internal
 
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,8 +13,8 @@ class CountryService(
     // JPA no-arg constructor, so the assertions below are genuinely required (removing either is a compile
     // error). Sonar (kotlin:S6619) flags the `code` assertion as dead regardless of which null-check syntax
     // is used - confirmed false positive, suppressed rather than reworded.
-    fun listCountries(): List<Country> = countryRepository.findAll().map {
-        Country(
+    fun listCountries(): List<CountryItem> = countryRepository.findAll().map {
+        CountryItem(
             id = it.id!!,
             code = it.code!!, // NOSONAR kotlin:S6619
             name = it.name!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
@@ -29,12 +29,12 @@ class EmployeeController(
 
     @PostMapping
     fun saveEmployee(
-        @Valid @RequestBody employeeCreateRequest: EmployeeCreateRequest,
-    ): ResponseEntity<Employee> = ResponseEntity.status(HttpStatus.CREATED).body(employeeService.saveEmployee(employeeCreateRequest))
+        @Valid @RequestBody employeeRequest: EmployeeRequest,
+    ): ResponseEntity<EmployeeResponse> = ResponseEntity.status(HttpStatus.CREATED).body(employeeService.saveEmployee(employeeRequest))
 
     @PutMapping("/{employeeId}")
     fun updateEmployee(
         @PathVariable employeeId: Long,
-        @Valid @RequestBody employeeUpdateRequest: EmployeeCreateRequest,
-    ): Employee = employeeService.updateEmployee(employeeId, employeeUpdateRequest)
+        @Valid @RequestBody employeeRequest: EmployeeRequest,
+    ): EmployeeResponse = employeeService.updateEmployee(employeeId, employeeRequest)
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeModel.kt
@@ -3,21 +3,21 @@ package at.wrk.tafel.admin.backend.modules.base.employee
 import jakarta.validation.constraints.NotBlank
 
 data class EmployeeListResponse(
-    val items: List<Employee>,
+    val items: List<EmployeeResponse>,
     val totalCount: Long,
     val currentPage: Int,
     val totalPages: Int,
     val pageSize: Int,
 )
 
-data class Employee(
+data class EmployeeResponse(
     val id: Long,
     val personnelNumber: String,
     val firstname: String,
     val lastname: String,
 )
 
-data class EmployeeCreateRequest(
+data class EmployeeRequest(
     @field:NotBlank
     val personnelNumber: String,
     @field:NotBlank

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
@@ -2,9 +2,9 @@ package at.wrk.tafel.admin.backend.modules.base.employee.internal
 
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
-import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeRequest
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import org.springframework.data.domain.PageRequest
@@ -35,38 +35,38 @@ class EmployeeService(
     }
 
     @Transactional
-    fun saveEmployee(employeeCreateRequest: EmployeeCreateRequest): Employee {
-        if (employeeRepository.existsByPersonnelNumber(employeeCreateRequest.personnelNumber)) {
-            throw ConflictException("Mitarbeiter ${employeeCreateRequest.personnelNumber} ist bereits vorhanden!")
+    fun saveEmployee(employeeRequest: EmployeeRequest): EmployeeResponse {
+        if (employeeRepository.existsByPersonnelNumber(employeeRequest.personnelNumber)) {
+            throw ConflictException("Mitarbeiter ${employeeRequest.personnelNumber} ist bereits vorhanden!")
         }
 
         val employeeEntity = EmployeeEntity().apply {
-            personnelNumber = employeeCreateRequest.personnelNumber.trim()
-            firstname = employeeCreateRequest.firstname.trim()
-            lastname = employeeCreateRequest.lastname.trim()
+            personnelNumber = employeeRequest.personnelNumber.trim()
+            firstname = employeeRequest.firstname.trim()
+            lastname = employeeRequest.lastname.trim()
         }
         employeeRepository.save(employeeEntity)
-        return mapEntityToEmployee(employeeRepository.findByPersonnelNumber(employeeCreateRequest.personnelNumber)!!)
+        return mapEntityToEmployee(employeeRepository.findByPersonnelNumber(employeeRequest.personnelNumber)!!)
     }
 
     @Transactional
-    fun updateEmployee(employeeId: Long, employeeUpdateRequest: EmployeeCreateRequest): Employee {
+    fun updateEmployee(employeeId: Long, employeeRequest: EmployeeRequest): EmployeeResponse {
         val employeeEntity = employeeRepository.findByIdOrNull(employeeId)
             ?: throw NotFoundException("Employee with id $employeeId not found")
 
-        if (employeeRepository.existsByPersonnelNumberAndIdNot(employeeUpdateRequest.personnelNumber, employeeId)) {
-            throw ConflictException("Mitarbeiter ${employeeUpdateRequest.personnelNumber} ist bereits vorhanden!")
+        if (employeeRepository.existsByPersonnelNumberAndIdNot(employeeRequest.personnelNumber, employeeId)) {
+            throw ConflictException("Mitarbeiter ${employeeRequest.personnelNumber} ist bereits vorhanden!")
         }
 
-        employeeEntity.personnelNumber = employeeUpdateRequest.personnelNumber.trim()
-        employeeEntity.firstname = employeeUpdateRequest.firstname.trim()
-        employeeEntity.lastname = employeeUpdateRequest.lastname.trim()
+        employeeEntity.personnelNumber = employeeRequest.personnelNumber.trim()
+        employeeEntity.firstname = employeeRequest.firstname.trim()
+        employeeEntity.lastname = employeeRequest.lastname.trim()
 
         val savedEntity = employeeRepository.save(employeeEntity)
         return mapEntityToEmployee(savedEntity)
     }
 
-    private fun mapEntityToEmployee(it: EmployeeEntity) = Employee(
+    private fun mapEntityToEmployee(it: EmployeeEntity) = EmployeeResponse(
         id = it.id!!,
         personnelNumber = it.personnelNumber!!,
         firstname = it.firstname!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/ScannerController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/checkin/ScannerController.kt
@@ -24,9 +24,9 @@ class ScannerController(
     fun getScanners(): ScannersResponse = ScannersResponse(scannerIds = scannerService.getScannerIds())
 
     @PostMapping("/register")
-    fun registerScanner(@RequestParam("scannerId") existingScannerId: Int?): ScannerRegistration {
+    fun registerScanner(@RequestParam("scannerId") existingScannerId: Int?): ScannerRegistrationResponse {
         val scannerId = scannerService.registerScanner(existingScannerId)
-        return ScannerRegistration(scannerId = scannerId)
+        return ScannerRegistrationResponse(scannerId = scannerId)
     }
 
     @PostMapping("/{scannerId}/results")
@@ -48,7 +48,7 @@ data class ScanResult(
 )
 
 @ExcludeFromTestCoverage
-data class ScannerRegistration(
+data class ScannerRegistrationResponse(
     val scannerId: Int,
 )
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionController.kt
@@ -30,8 +30,8 @@ class DistributionController(
 
     @PostMapping("/new")
     @PreAuthorize("hasAuthority('DISTRIBUTION_LCM')")
-    fun createNewDistribution(): DistributionItemUpdate {
-        val update = DistributionItemUpdate(distribution = service.createNewDistributionItem())
+    fun createNewDistribution(): DistributionUpdateResponse {
+        val update = DistributionUpdateResponse(distribution = service.createNewDistributionItem())
 
         sseOutboxService.saveOutboxEntry(
             notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
@@ -44,7 +44,7 @@ class DistributionController(
     @PostMapping("/statistics")
     @PreAuthorize("hasAuthority('LOGISTICS')")
     @TafelActiveDistributionRequired
-    fun saveDistributionStatistic(@Valid @RequestBody statisticData: DistributionStatisticData): ResponseEntity<Unit> {
+    fun saveDistributionStatistic(@Valid @RequestBody statisticData: DistributionStatisticRequest): ResponseEntity<Unit> {
         service.updateDistributionStatisticData(statisticData.employeeCount, statisticData.selectedShelterIds)
         return ResponseEntity.ok().build()
     }
@@ -52,21 +52,21 @@ class DistributionController(
     @PostMapping("/notes")
     @PreAuthorize("isAuthenticated()")
     @TafelActiveDistributionRequired
-    fun saveDistributionNotes(@Valid @RequestBody noteData: DistributionNoteData): ResponseEntity<Unit> {
+    fun saveDistributionNotes(@Valid @RequestBody noteData: DistributionNoteRequest): ResponseEntity<Unit> {
         service.updateDistributionNoteData(noteData.notes)
         return ResponseEntity.ok().build()
     }
 
     /**
      * `forceClose` only overrides validation *warnings*, never hard errors: if
-     * [DistributionCloseValidationResult.hasOnlyWarnings] is false (i.e. there's at least one real
+     * [DistributionCloseResponse.hasOnlyWarnings] is false (i.e. there's at least one real
      * error), the distribution is not closed regardless of `forceClose`, and the validation
      * result is returned instead so the caller can see why.
      */
     @PostMapping("/close")
     @PreAuthorize("hasAuthority('DISTRIBUTION_LCM')")
     @TafelActiveDistributionRequired
-    fun closeDistribution(@RequestParam forceClose: Boolean = false): ResponseEntity<DistributionCloseValidationResult> {
+    fun closeDistribution(@RequestParam forceClose: Boolean = false): ResponseEntity<DistributionCloseResponse> {
         val closeValidationResult = service.validateClose()
         return if (closeValidationResult.isInvalid()) {
             if (forceClose && closeValidationResult.hasOnlyWarnings()) {
@@ -79,13 +79,13 @@ class DistributionController(
         }
     }
 
-    private fun closeAndNotify(): ResponseEntity<DistributionCloseValidationResult> {
+    private fun closeAndNotify(): ResponseEntity<DistributionCloseResponse> {
         service.closeDistribution()
 
         // update clients about new state - no active distribution
         sseOutboxService.saveOutboxEntry(
             notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
-            payload = DistributionItemUpdate(distribution = null),
+            payload = DistributionUpdateResponse(distribution = null),
         )
 
         return ResponseEntity.ok().build()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionSseController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionSseController.kt
@@ -4,7 +4,7 @@ import at.wrk.tafel.admin.backend.common.sse.SseUtil
 import at.wrk.tafel.admin.backend.database.common.sseoutbox.SseOutboxService
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionController.Companion.DISTRIBUTION_UPDATE_NOTIFICATION_NAME
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
-import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItemUpdate
+import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionUpdateResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -24,13 +24,13 @@ class DistributionSseController(
         // initial data
         sseOutboxService.sendEvent(
             sseEmitter,
-            DistributionItemUpdate(distribution = service.getCurrentDistributionItem()),
+            DistributionUpdateResponse(distribution = service.getCurrentDistributionItem()),
         )
 
         sseOutboxService.forwardNotificationEventsToSse(
             sseEmitter = sseEmitter,
             notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
-            resultType = DistributionItemUpdate::class.java,
+            resultType = DistributionUpdateResponse::class.java,
         )
 
         return sseEmitter

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/README.md
@@ -45,7 +45,7 @@ and `sendMails()` (manual re-send, see below).
 ### Controllers
 - **DistributionController** — `/api/distributions*`: list, create, close, notes, statistics,
   household-list PDF, manual mail re-send, and the `/api/sse/distributions` SSE stream that pushes
-  `DistributionItemUpdate` whenever the current distribution starts/ends.
+  `DistributionUpdateResponse` whenever the current distribution starts/ends.
 - **DistributionTicketController** (`internal/ticket/`) — `/api/distributions/tickets/households/{id}`:
   get/delete the ticket assigned to a household.
 - **DistributionTicketScreenController** (`internal/ticket/`) — `/api/distributions/ticket-screen/*`

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/DistributionService.kt
@@ -14,7 +14,7 @@ import at.wrk.tafel.admin.backend.modules.base.exception.BusinessRuleException
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionClosedEvent
-import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionCloseValidationResult
+import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionCloseResponse
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListItem
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.HouseholdListPdfModel
@@ -215,7 +215,7 @@ class DistributionService(
     }
 
     @Transactional(readOnly = true)
-    fun validateClose(): DistributionCloseValidationResult {
+    fun validateClose(): DistributionCloseResponse {
         val errors = mutableListOf<String>()
         val warnings = mutableListOf<String>()
 
@@ -235,7 +235,7 @@ class DistributionService(
             }
 
             return if (errors.isNotEmpty()) {
-                DistributionCloseValidationResult(
+                DistributionCloseResponse(
                     errors = errors,
                     warnings = emptyList(),
                 )
@@ -248,14 +248,14 @@ class DistributionService(
                     warnings.add("Die Route(n) ${missingRoutes.joinToString(", ")} wurden nicht erfasst!")
                 }
 
-                DistributionCloseValidationResult(
+                DistributionCloseResponse(
                     errors = emptyList(),
                     warnings = warnings,
                 )
             }
         }
 
-        return DistributionCloseValidationResult(
+        return DistributionCloseResponse(
             errors = errors,
             warnings = warnings,
         )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/model/DistributionResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/model/DistributionResponseModel.kt
@@ -11,7 +11,7 @@ data class DistributionListResponse(
 )
 
 @ExcludeFromTestCoverage
-data class DistributionItemUpdate(
+data class DistributionUpdateResponse(
     val distribution: DistributionItem?,
 )
 
@@ -36,19 +36,19 @@ data class TicketNumberResponse(
 )
 
 @ExcludeFromTestCoverage
-data class DistributionStatisticData(
+data class DistributionStatisticRequest(
     @field:PositiveOrZero
     val employeeCount: Int,
     val selectedShelterIds: List<Long>,
 )
 
 @ExcludeFromTestCoverage
-data class DistributionNoteData(
+data class DistributionNoteRequest(
     val notes: String,
 )
 
 @ExcludeFromTestCoverage
-data class DistributionCloseValidationResult(
+data class DistributionCloseResponse(
     val errors: List<String>,
     val warnings: List<String>,
 ) {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenController.kt
@@ -25,7 +25,7 @@ class DistributionTicketScreenController(
 
     @PostMapping("/show-text")
     @PreAuthorize("hasAnyAuthority('CHECKIN', 'SCANNER')")
-    fun showText(@Valid @RequestBody request: TicketScreenShowText) {
+    fun showText(@Valid @RequestBody request: TicketScreenShowTextRequest) {
         saveToOutbox(text = request.text, value = request.value)
     }
 
@@ -66,7 +66,7 @@ class DistributionTicketScreenController(
     private fun saveToOutbox(text: String, value: String?) {
         sseOutboxService.saveOutboxEntry(
             TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-            TicketScreenShowText(
+            TicketScreenShowTextRequest(
                 text = text,
                 value = value,
             ),
@@ -75,7 +75,7 @@ class DistributionTicketScreenController(
 }
 
 @ExcludeFromTestCoverage
-data class TicketScreenShowText(
+data class TicketScreenShowTextRequest(
     @field:NotBlank
     val text: String,
     val value: String?,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenSseController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenSseController.kt
@@ -29,13 +29,13 @@ class DistributionTicketScreenSseController(
         if (service.hasCurrentDistribution()) {
             currentTicketNumber = service.getCurrentTicketNumberValue()
         }
-        val payload = TicketScreenShowText(TICKET_SCREEN_TITLE, currentTicketNumber?.toString())
+        val payload = TicketScreenShowTextRequest(TICKET_SCREEN_TITLE, currentTicketNumber?.toString())
         sseOutboxService.sendEvent(sseEmitter, payload)
 
         sseOutboxService.forwardNotificationEventsToSse(
             sseEmitter = sseEmitter,
             notificationName = TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-            resultType = TicketScreenShowText::class.java,
+            resultType = TicketScreenShowTextRequest::class.java,
         )
 
         return sseEmitter

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
@@ -25,7 +25,7 @@ class HouseholdController(
 ) {
     @PostMapping("/validate")
     @PreAuthorize("hasAuthority('CUSTOMER')")
-    fun validate(@Valid @RequestBody household: Household): ValidateHouseholdResponse {
+    fun validate(@Valid @RequestBody household: HouseholdRequest): ValidateHouseholdResponse {
         val result = householdService.validate(household)
         return ValidateHouseholdResponse(
             valid = result.valid,
@@ -40,7 +40,7 @@ class HouseholdController(
     @PreAuthorize("hasAuthority('CUSTOMER')")
     fun createHousehold(
         @RequestParam force: Boolean = false,
-        @Valid @RequestBody household: Household,
+        @Valid @RequestBody household: HouseholdRequest,
     ): ResponseEntity<HouseholdCreationResponse> {
         val authenticatedUser = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
         val isSupervisor = authenticatedUser.hasRole("SUPERVISOR")
@@ -60,7 +60,7 @@ class HouseholdController(
     fun updateHousehold(
         @PathVariable householdId: Long,
         @RequestParam force: Boolean = false,
-        @Valid @RequestBody household: Household,
+        @Valid @RequestBody household: HouseholdRequest,
     ): HouseholdUpdateResponse {
         val authenticatedUser = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
         val isSupervisor = authenticatedUser.hasRole("SUPERVISOR")
@@ -74,7 +74,7 @@ class HouseholdController(
 
     @GetMapping("/{householdId}")
     @PreAuthorize("hasAuthority('CUSTOMER')")
-    fun getHousehold(@PathVariable householdId: Long): Household = householdService.findByHouseholdId(householdId)
+    fun getHousehold(@PathVariable householdId: Long): HouseholdResponse = householdService.findByHouseholdId(householdId)
         ?: throw NotFoundException("Kunde Nr. $householdId nicht gefunden!")
 
     @GetMapping
@@ -86,7 +86,7 @@ class HouseholdController(
         @RequestParam postProcessing: Boolean? = null,
         @RequestParam costContribution: Boolean? = null,
         @RequestParam valid: Boolean? = null,
-    ): PagedResponse<Household> {
+    ): PagedResponse<HouseholdResponse> {
         val householdSearchResult = householdService.getHouseholds(
             firstname = firstname?.trim(),
             lastname = lastname?.trim(),

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModel.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.household
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
@@ -14,18 +14,18 @@ import java.time.LocalDateTime
 
 @ExcludeFromTestCoverage
 data class HouseholdCreationResponse(
-    val data: Household,
+    val data: HouseholdResponse,
     val errorMsg: String?,
 )
 
 @ExcludeFromTestCoverage
 data class HouseholdUpdateResponse(
-    val data: Household,
+    val data: HouseholdResponse,
     val errorMsg: String?,
 )
 
 @ExcludeFromTestCoverage
-data class Household(
+data class HouseholdRequest(
     val id: Long? = null,
     val issuer: HouseholdIssuer? = null,
     val issuedAt: LocalDate? = null,
@@ -42,6 +42,34 @@ data class Household(
     val pendingCostContribution: BigDecimal? = null,
     val singleParent: Boolean? = null,
     @field:Valid
+    val persons: List<Person> = emptyList(),
+) {
+    /**
+     * The single person of this household flagged as main person.
+     */
+    fun mainPerson(): Person? = persons.firstOrNull { it.isMainPerson }
+
+    /**
+     * Every household member except the main person.
+     */
+    fun additionalPersons(): List<Person> = persons.filterNot { it.isMainPerson }
+}
+
+@ExcludeFromTestCoverage
+data class HouseholdResponse(
+    val id: Long? = null,
+    val issuer: HouseholdIssuer? = null,
+    val issuedAt: LocalDate? = null,
+    val address: HouseholdAddress,
+    val telephoneNumber: String? = null,
+    val email: String? = null,
+    val validUntil: LocalDate? = null,
+    val locked: Boolean? = null,
+    val lockedAt: LocalDateTime? = null,
+    val lockedBy: String? = null,
+    val lockReason: String? = null,
+    val pendingCostContribution: BigDecimal? = null,
+    val singleParent: Boolean? = null,
     val persons: List<Person> = emptyList(),
 ) {
     /**
@@ -89,7 +117,7 @@ data class Person(
     val birthDate: LocalDate?,
     @field:NotNull
     val gender: PersonGender?,
-    val country: Country,
+    val country: CountryItem,
     val employer: String? = null,
     val income: BigDecimal? = null,
     val incomeDue: LocalDate? = null,
@@ -121,8 +149,8 @@ enum class PersonGender {
 
 @ExcludeFromTestCoverage
 data class HouseholdDuplicationItem(
-    val household: Household,
-    val similarHouseholds: List<Household>,
+    val household: HouseholdResponse,
+    val similarHouseholds: List<HouseholdResponse>,
 )
 
 @ExcludeFromTestCoverage
@@ -133,7 +161,7 @@ data class HouseholdMergeRequest(
 
 @ExcludeFromTestCoverage
 data class HouseholdAboveLimitItem(
-    val household: Household,
+    val household: HouseholdResponse,
     val totalSum: BigDecimal,
     val limit: BigDecimal,
     val amountExceededLimit: BigDecimal,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationService.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.household.internal
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
-import at.wrk.tafel.admin.backend.modules.household.Household
+import at.wrk.tafel.admin.backend.modules.household.HouseholdResponse
 import at.wrk.tafel.admin.backend.modules.household.internal.converter.HouseholdConverter
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -164,6 +164,6 @@ data class HouseholdDuplicateSearchResult(
 
 @ExcludeFromTestCoverage
 data class HouseholdDuplicateSearchResultItem(
-    val household: Household,
-    val similarHouseholds: List<Household>,
+    val household: HouseholdResponse,
+    val similarHouseholds: List<HouseholdResponse>,
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -10,11 +10,13 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs.Companion.validHousehold
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
-import at.wrk.tafel.admin.backend.modules.household.Household
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAboveLimitItem
 import at.wrk.tafel.admin.backend.modules.household.HouseholdCreationResponse
 import at.wrk.tafel.admin.backend.modules.household.HouseholdPdfType
+import at.wrk.tafel.admin.backend.modules.household.HouseholdRequest
+import at.wrk.tafel.admin.backend.modules.household.HouseholdResponse
 import at.wrk.tafel.admin.backend.modules.household.HouseholdUpdateResponse
+import at.wrk.tafel.admin.backend.modules.household.Person
 import at.wrk.tafel.admin.backend.modules.household.internal.converter.HouseholdConverter
 import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValidatorPerson
 import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValidatorResult
@@ -36,18 +38,18 @@ class HouseholdService(
     private val householdConverter: HouseholdConverter,
 ) {
 
-    fun validate(household: Household): IncomeValidatorResult = incomeValidatorService.validate(mapToValidationPersons(household))
+    fun validate(household: HouseholdRequest): IncomeValidatorResult = incomeValidatorService.validate(mapToValidationPersons(household.mainPerson(), household.additionalPersons()))
 
     fun existsByHouseholdId(householdId: Long): Boolean = householdRepository.existsByHouseholdId(householdId)
 
     @Transactional(readOnly = true)
-    fun findByHouseholdId(householdId: Long): Household? = householdRepository.findByHouseholdId(householdId)?.let { householdConverter.mapEntityToHousehold(it) }
+    fun findByHouseholdId(householdId: Long): HouseholdResponse? = householdRepository.findByHouseholdId(householdId)?.let { householdConverter.mapEntityToHousehold(it) }
 
     @Transactional
-    fun createHousehold(household: Household, force: Boolean, isSupervisor: Boolean): HouseholdCreationResponse {
+    fun createHousehold(household: HouseholdRequest, force: Boolean, isSupervisor: Boolean): HouseholdCreationResponse {
         val entity = householdConverter.mapHouseholdToEntity(household)
 
-        val valid = incomeValidatorService.validate(mapToValidationPersons(household)).valid
+        val valid = incomeValidatorService.validate(mapToValidationPersons(household.mainPerson(), household.additionalPersons())).valid
         if (!valid && isSupervisor) {
             if (!force) {
                 throw ConflictException("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
@@ -78,14 +80,14 @@ class HouseholdService(
     @Transactional
     fun updateHousehold(
         householdId: Long,
-        household: Household,
+        household: HouseholdRequest,
         force: Boolean,
         isSupervisor: Boolean,
     ): HouseholdUpdateResponse {
         val existingEntity = householdRepository.getReferenceByHouseholdId(householdId)
         val mappedEntity = householdConverter.mapHouseholdToEntity(household, existingEntity)
 
-        val valid = incomeValidatorService.validate(mapToValidationPersons(household)).valid
+        val valid = incomeValidatorService.validate(mapToValidationPersons(household.mainPerson(), household.additionalPersons())).valid
         if (!valid && isSupervisor) {
             if (!force) {
                 throw ConflictException("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
@@ -181,7 +183,7 @@ class HouseholdService(
             .map { householdConverter.mapEntityToHousehold(it) }
 
         val itemsAboveLimit = households.mapNotNull { household ->
-            val result = incomeValidatorService.validate(mapToValidationPersons(household))
+            val result = incomeValidatorService.validate(mapToValidationPersons(household.mainPerson(), household.additionalPersons()))
             if (!result.valid) {
                 HouseholdAboveLimitItem(
                     household = household,
@@ -259,8 +261,7 @@ class HouseholdService(
         householdRepository.delete(household)
     }
 
-    private fun mapToValidationPersons(household: Household): List<IncomeValidatorPerson> {
-        val mainPerson = household.mainPerson()
+    private fun mapToValidationPersons(mainPerson: Person?, additionalPersons: List<Person>): List<IncomeValidatorPerson> {
         val mainValidatorPerson = mainPerson?.let {
             IncomeValidatorPerson(
                 birthDate = it.birthDate!!,
@@ -269,7 +270,7 @@ class HouseholdService(
             )
         }
 
-        val additionalValidatorPersons = household.additionalPersons().map {
+        val additionalValidatorPersons = additionalPersons.map {
             IncomeValidatorPerson(
                 birthDate = it.birthDate,
                 monthlyIncome = it.income,
@@ -291,7 +292,7 @@ class HouseholdService(
 
 @ExcludeFromTestCoverage
 data class HouseholdSearchResult(
-    val items: List<Household>,
+    val items: List<HouseholdResponse>,
     val totalCount: Long,
     val currentPage: Int,
     val totalPages: Int,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverter.kt
@@ -9,10 +9,11 @@ import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.person.PersonRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
-import at.wrk.tafel.admin.backend.modules.base.country.Country
-import at.wrk.tafel.admin.backend.modules.household.Household
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAddress
 import at.wrk.tafel.admin.backend.modules.household.HouseholdIssuer
+import at.wrk.tafel.admin.backend.modules.household.HouseholdRequest
+import at.wrk.tafel.admin.backend.modules.household.HouseholdResponse
 import at.wrk.tafel.admin.backend.modules.household.Person
 import at.wrk.tafel.admin.backend.modules.household.PersonGender
 import org.springframework.data.repository.findByIdOrNull
@@ -29,7 +30,7 @@ class HouseholdConverter(
     private val userRepository: UserRepository,
 ) {
 
-    fun mapHouseholdToEntity(householdUpdate: Household, storedEntity: HouseholdEntity? = null): HouseholdEntity {
+    fun mapHouseholdToEntity(householdUpdate: HouseholdRequest, storedEntity: HouseholdEntity? = null): HouseholdEntity {
         val user = SecurityContextHolder.getContext().authentication as TafelJwtAuthentication
         val userEntity = userRepository.findByUsername(user.username!!)
         val householdEntity = storedEntity ?: HouseholdEntity()
@@ -107,14 +108,14 @@ class HouseholdConverter(
         return householdEntity
     }
 
-    fun mapEntityToHousehold(householdEntity: HouseholdEntity): Household {
+    fun mapEntityToHousehold(householdEntity: HouseholdEntity): HouseholdResponse {
         val mainPersonEntity = householdEntity.mainPerson ?: householdEntity.persons.firstOrNull { it.isMainPerson }
         val additionalPersons = householdEntity.persons
             .filterNot { it.isMainPerson }
             .map { mapPerson(it) }
             .sortedBy { "${it.lastname} ${it.firstname}" }
 
-        return Household(
+        return HouseholdResponse(
             id = householdEntity.householdId,
             issuer = householdEntity.issuer?.let {
                 HouseholdIssuer(
@@ -166,7 +167,7 @@ class HouseholdConverter(
     // JPA no-arg constructor, so the assertions below are genuinely required (removing either is a compile
     // error). Sonar (kotlin:S6619) flags the `code` assertion as dead regardless of which null-check syntax
     // is used - confirmed false positive, suppressed rather than reworded.
-    private fun mapCountryToResponse(country: CountryEntity): Country = Country(
+    private fun mapCountryToResponse(country: CountryEntity): CountryItem = CountryItem(
         id = country.id!!,
         code = country.code!!, // NOSONAR kotlin:S6619
         name = country.name!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/CarsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/CarsController.kt
@@ -1,9 +1,10 @@
 package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.CarService
-import at.wrk.tafel.admin.backend.modules.logistics.model.Car
 import at.wrk.tafel.admin.backend.modules.logistics.model.CarListResponse
 import at.wrk.tafel.admin.backend.modules.logistics.model.CarReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -31,15 +32,15 @@ class CarsController(
     @PostMapping
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun createCar(
-        @Valid @RequestBody car: Car,
-    ): ResponseEntity<Car> = ResponseEntity.status(HttpStatus.CREATED).body(carService.createCar(car))
+        @Valid @RequestBody car: CarRequest,
+    ): ResponseEntity<CarResponse> = ResponseEntity.status(HttpStatus.CREATED).body(carService.createCar(car))
 
     @PutMapping("/{carId}")
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun updateCar(
         @PathVariable carId: Long,
-        @Valid @RequestBody updatedCar: Car,
-    ): Car = carService.updateCar(carId, updatedCar)
+        @Valid @RequestBody updatedCar: CarRequest,
+    ): CarResponse = carService.updateCar(carId, updatedCar)
 
     @PostMapping("/reorder")
     @PreAuthorize("hasAuthority('SETTINGS')")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCategoriesController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCategoriesController.kt
@@ -2,8 +2,9 @@ package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.FoodCategoryService
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoriesListResponse
-import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -39,15 +40,15 @@ class FoodCategoriesController(
     @PostMapping
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun createFoodCategory(
-        @Valid @RequestBody category: FoodCategory,
-    ): ResponseEntity<FoodCategory> = ResponseEntity.status(HttpStatus.CREATED).body(foodCategoriesService.createFoodCategory(category))
+        @Valid @RequestBody category: FoodCategoryRequest,
+    ): ResponseEntity<FoodCategoryResponse> = ResponseEntity.status(HttpStatus.CREATED).body(foodCategoriesService.createFoodCategory(category))
 
     @PutMapping("/{foodCategoryId}")
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun updateFoodCategory(
         @PathVariable foodCategoryId: Long,
-        @Valid @RequestBody category: FoodCategory,
-    ): FoodCategory = foodCategoriesService.updateFoodCategory(foodCategoryId, category)
+        @Valid @RequestBody category: FoodCategoryRequest,
+    ): FoodCategoryResponse = foodCategoriesService.updateFoodCategory(foodCategoryId, category)
 
     @PostMapping("/reorder")
     @PreAuthorize("hasAuthority('SETTINGS')")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCollectionsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCollectionsController.kt
@@ -19,7 +19,7 @@ class FoodCollectionsController(
     @TafelActiveDistributionRequired
     fun getFoodCollection(
         @PathVariable routeId: Long,
-    ): ResponseEntity<FoodCollectionData> {
+    ): ResponseEntity<FoodCollectionResponse> {
         val data = foodCollectionService.getFoodCollection(routeId)
             ?: return ResponseEntity.noContent().build()
         return ResponseEntity.ok(data)
@@ -29,7 +29,7 @@ class FoodCollectionsController(
     @TafelActiveDistributionRequired
     fun saveFoodCollectionRouteData(
         @PathVariable routeId: Long,
-        @Valid @RequestBody request: FoodCollectionSaveRouteData,
+        @Valid @RequestBody request: FoodCollectionSaveRouteRequest,
     ): ResponseEntity<Unit> {
         foodCollectionService.saveRouteData(routeId, request)
         return ResponseEntity.ok().build()
@@ -39,7 +39,7 @@ class FoodCollectionsController(
     @TafelActiveDistributionRequired
     fun saveFoodCollectionItems(
         @PathVariable routeId: Long,
-        @Valid @RequestBody request: FoodCollectionItems,
+        @Valid @RequestBody request: FoodCollectionItemsRequest,
     ): ResponseEntity<Unit> {
         foodCollectionService.saveItems(routeId, request)
         return ResponseEntity.ok().build()
@@ -50,7 +50,7 @@ class FoodCollectionsController(
     fun getFoodCollectionItemsPerShop(
         @PathVariable routeId: Long,
         @PathVariable shopId: Long,
-    ): ResponseEntity<FoodCollectionItems> {
+    ): ResponseEntity<FoodCollectionItemsResponse> {
         val data = foodCollectionService.getItemsPerShop(routeId, shopId) ?: return ResponseEntity.noContent().build()
         return ResponseEntity.ok(data)
     }
@@ -60,7 +60,7 @@ class FoodCollectionsController(
     fun saveFoodCollectionItemsPerShop(
         @PathVariable routeId: Long,
         @PathVariable shopId: Long,
-        @Valid @RequestBody request: FoodCollectionSaveItemsPerShopData,
+        @Valid @RequestBody request: FoodCollectionSaveItemsPerShopRequest,
     ): ResponseEntity<Unit> {
         foodCollectionService.saveItemsPerShop(routeId, shopId, request)
         return ResponseEntity.ok().build()
@@ -70,7 +70,7 @@ class FoodCollectionsController(
     @TafelActiveDistributionRequired
     fun patchFoodCollectionItem(
         @PathVariable routeId: Long,
-        @Valid @RequestBody request: FoodCollectionItem,
+        @Valid @RequestBody request: FoodCollectionItemRequest,
     ): ResponseEntity<Unit> {
         foodCollectionService.patchItem(routeId, request)
         return ResponseEntity.ok().build()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersController.kt
@@ -1,9 +1,10 @@
 package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.ShelterService
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterListResponse
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -31,15 +32,15 @@ class SheltersController(
     @PostMapping
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun createShelter(
-        @Valid @RequestBody shelter: Shelter,
-    ): ResponseEntity<Shelter> = ResponseEntity.status(HttpStatus.CREATED).body(shelterService.createShelter(shelter))
+        @Valid @RequestBody shelter: ShelterRequest,
+    ): ResponseEntity<ShelterResponse> = ResponseEntity.status(HttpStatus.CREATED).body(shelterService.createShelter(shelter))
 
     @PutMapping("/{shelterId}")
     @PreAuthorize("hasAuthority('SETTINGS')")
     fun updateShelter(
         @PathVariable shelterId: Long,
-        @Valid @RequestBody updatedShelter: Shelter,
-    ): Shelter = shelterService.updateShelter(shelterId, updatedShelter)
+        @Valid @RequestBody updatedShelter: ShelterRequest,
+    ): ShelterResponse = shelterService.updateShelter(shelterId, updatedShelter)
 
     @PostMapping("/reorder")
     @PreAuthorize("hasAuthority('SETTINGS')")

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarService.kt
@@ -3,7 +3,8 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.CarEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.CarRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Car
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarResponse
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,16 +15,16 @@ class CarService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getActiveCars(): List<Car> = carRepository.findByEnabledIsTrue()
+    fun getActiveCars(): List<CarResponse> = carRepository.findByEnabledIsTrue()
         .map { mapCar(it) }
         .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
     @Transactional(readOnly = true)
-    fun getAllCars(): List<Car> = carRepository.findAll()
+    fun getAllCars(): List<CarResponse> = carRepository.findAll()
         .map { mapCar(it) }
         .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
-    fun createCar(car: Car): Car {
+    fun createCar(car: CarRequest): CarResponse {
         val carEntity = CarEntity().apply {
             licensePlate = car.licensePlate
             name = car.name
@@ -35,7 +36,7 @@ class CarService(
         return mapCar(savedEntity)
     }
 
-    fun updateCar(carId: Long, updatedCar: Car): Car {
+    fun updateCar(carId: Long, updatedCar: CarRequest): CarResponse {
         val carEntity = carRepository.findByIdOrNull(carId)
             ?: throw NotFoundException("Car with id $carId not found")
 
@@ -61,7 +62,7 @@ class CarService(
 
     private fun nextSortOrder(): Int = (carRepository.findAll().maxOfOrNull { it.sortOrder ?: 0 } ?: 0) + 1
 
-    private fun mapCar(carEntity: CarEntity): Car = Car(
+    private fun mapCar(carEntity: CarEntity): CarResponse = CarResponse(
         id = carEntity.id!!,
         licensePlate = carEntity.licensePlate!!,
         name = carEntity.name!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryService.kt
@@ -3,7 +3,8 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryResponse
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -13,16 +14,16 @@ class FoodCategoryService(
     private val foodCategoriesRepository: FoodCategoryRepository,
 ) {
 
-    fun getActiveFoodCategories(): List<FoodCategory> = sortCategories(foodCategoriesRepository.findByEnabledIsTrue())
+    fun getActiveFoodCategories(): List<FoodCategoryResponse> = sortCategories(foodCategoriesRepository.findByEnabledIsTrue())
         .map { mapFoodCategory(it) }
 
-    fun getAllFoodCategories(): List<FoodCategory> = sortCategories(foodCategoriesRepository.findAll().toList())
+    fun getAllFoodCategories(): List<FoodCategoryResponse> = sortCategories(foodCategoriesRepository.findAll().toList())
         // Return/deposit item categories ("Kisten") are out of scope for this admin listing -
         // they will get their own dedicated form later.
         .filter { it.returnItem != true }
         .map { mapFoodCategory(it) }
 
-    fun createFoodCategory(category: FoodCategory): FoodCategory {
+    fun createFoodCategory(category: FoodCategoryRequest): FoodCategoryResponse {
         val entity = FoodCategoryEntity().apply {
             name = category.name
             weightPerUnit = category.weightPerUnit
@@ -35,7 +36,7 @@ class FoodCategoryService(
         return mapFoodCategory(savedEntity)
     }
 
-    fun updateFoodCategory(foodCategoryId: Long, updatedCategory: FoodCategory): FoodCategory {
+    fun updateFoodCategory(foodCategoryId: Long, updatedCategory: FoodCategoryRequest): FoodCategoryResponse {
         val entity = foodCategoriesRepository.findByIdOrNull(foodCategoryId)
             ?: throw NotFoundException("FoodCategory with id $foodCategoryId not found")
 
@@ -75,7 +76,7 @@ class FoodCategoryService(
             ),
         )
 
-    private fun mapFoodCategory(foodCategoryEntity: FoodCategoryEntity): FoodCategory = FoodCategory(
+    private fun mapFoodCategory(foodCategoryEntity: FoodCategoryEntity): FoodCategoryResponse = FoodCategoryResponse(
         id = foodCategoryEntity.id,
         name = foodCategoryEntity.name!!,
         weightPerUnit = foodCategoryEntity.weightPerUnit,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionService.kt
@@ -8,7 +8,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.getCurrentDistribution
 import at.wrk.tafel.admin.backend.database.model.logistics.*
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.logistics.model.*
 import org.springframework.data.repository.findByIdOrNull
@@ -28,7 +28,7 @@ class FoodCollectionService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getFoodCollection(routeId: Long): FoodCollectionData? {
+    fun getFoodCollection(routeId: Long): FoodCollectionResponse? {
         val distribution = distributionRepository.getCurrentDistribution()!!
 
         val foodCollection = distribution.foodCollections.firstOrNull { it.route?.id == routeId }
@@ -44,7 +44,7 @@ class FoodCollectionService(
                 entity?.let { mapEmployee(it) }
             }
 
-            FoodCollectionData(
+            FoodCollectionResponse(
                 routeId = foodCollection.route!!.id!!,
                 carId = foodCollection.car?.id,
                 driver = driver,
@@ -57,14 +57,14 @@ class FoodCollectionService(
     }
 
     @Transactional
-    fun saveRouteData(routeId: Long, data: FoodCollectionSaveRouteData) {
+    fun saveRouteData(routeId: Long, data: FoodCollectionSaveRouteRequest) {
         val distribution = distributionRepository.getCurrentDistribution()!!
 
         foodCollectionRepository.save(mapRouteData(distribution, routeId, data))
     }
 
     @Transactional
-    fun saveItems(routeId: Long, data: FoodCollectionItems) {
+    fun saveItems(routeId: Long, data: FoodCollectionItemsRequest) {
         val distribution = distributionRepository.getCurrentDistribution()!!
 
         foodCollectionRepository.save(mapAllItems(distribution, routeId, data))
@@ -74,7 +74,7 @@ class FoodCollectionService(
     fun saveItemsPerShop(
         routeId: Long,
         shopId: Long,
-        data: FoodCollectionSaveItemsPerShopData,
+        data: FoodCollectionSaveItemsPerShopRequest,
     ) {
         val distributionEntity = distributionRepository.getCurrentDistribution()!!
 
@@ -94,7 +94,7 @@ class FoodCollectionService(
     }
 
     @Transactional(readOnly = true)
-    fun getItemsPerShop(routeId: Long, shopId: Long): FoodCollectionItems? {
+    fun getItemsPerShop(routeId: Long, shopId: Long): FoodCollectionItemsResponse? {
         val distributionEntity = distributionRepository.getCurrentDistribution()!!
 
         val collectionForRoute = distributionEntity.foodCollections.firstOrNull {
@@ -105,7 +105,7 @@ class FoodCollectionService(
                 item.shop?.id == shopId
             } ?: emptyList()
 
-            return FoodCollectionItems(
+            return FoodCollectionItemsResponse(
                 items = mapItemsEntityToItems(items),
             )
         }
@@ -114,7 +114,7 @@ class FoodCollectionService(
     }
 
     @Transactional
-    fun patchItem(routeId: Long, data: FoodCollectionItem) {
+    fun patchItem(routeId: Long, data: FoodCollectionItemRequest) {
         // concurrent auto-save requests for the same category/shop otherwise race on the
         // read-modify-write below and can both try to insert the same item, violating the
         // food_collections_items_pk unique constraint
@@ -170,7 +170,7 @@ class FoodCollectionService(
             ?: throw NotFoundException("Route $routeId nicht gefunden!")
     }
 
-    private fun mapEmployee(employee: EmployeeEntity): Employee = Employee(
+    private fun mapEmployee(employee: EmployeeEntity): EmployeeResponse = EmployeeResponse(
         id = employee.id!!,
         personnelNumber = employee.personnelNumber!!,
         firstname = employee.firstname!!,
@@ -180,7 +180,7 @@ class FoodCollectionService(
     private fun mapRouteData(
         distributionEntity: DistributionEntity,
         routeId: Long,
-        data: FoodCollectionSaveRouteData,
+        data: FoodCollectionSaveRouteRequest,
     ): FoodCollectionEntity {
         val entity = distributionEntity.foodCollections.firstOrNull {
             it.route?.id == routeId
@@ -204,7 +204,7 @@ class FoodCollectionService(
     private fun mapAllItems(
         distributionEntity: DistributionEntity,
         routeId: Long,
-        data: FoodCollectionItems,
+        data: FoodCollectionItemsRequest,
     ): FoodCollectionEntity {
         val entity = distributionEntity.foodCollections.firstOrNull {
             it.route?.id == routeId

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteService.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
-import at.wrk.tafel.admin.backend.modules.logistics.model.Route
+import at.wrk.tafel.admin.backend.modules.logistics.model.RouteItem
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,12 +12,12 @@ class RouteService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getRoutes(): List<Route> {
+    fun getRoutes(): List<RouteItem> {
         val routes: List<RouteEntity> = routeRepository.findAll()
         return routes.map { mapRoute(it) }
     }
 
-    private fun mapRoute(routeEntity: RouteEntity): Route = Route(
+    private fun mapRoute(routeEntity: RouteEntity): RouteItem = RouteItem(
         id = routeEntity.id!!,
         name = routeEntity.name!!,
     )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterService.kt
@@ -4,8 +4,9 @@ import at.wrk.tafel.admin.backend.database.model.logistics.ShelterContactEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
-import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContact
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContactItem
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterResponse
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,16 +17,16 @@ class ShelterService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getActiveShelters(): List<Shelter> = shelterRepository.findByEnabledIsTrue()
+    fun getActiveShelters(): List<ShelterResponse> = shelterRepository.findByEnabledIsTrue()
         .map { mapShelter(it) }
         .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
     @Transactional(readOnly = true)
-    fun getAllShelters(): List<Shelter> = shelterRepository.findAll()
+    fun getAllShelters(): List<ShelterResponse> = shelterRepository.findAll()
         .map { mapShelter(it) }
         .sortedWith(compareBy({ it.sortOrder }, { it.name }))
 
-    fun createShelter(shelter: Shelter): Shelter {
+    fun createShelter(shelter: ShelterRequest): ShelterResponse {
         val shelterEntity = ShelterEntity().apply {
             name = shelter.name
             addressStreet = shelter.addressStreet
@@ -54,7 +55,7 @@ class ShelterService(
         return mapShelter(savedEntity)
     }
 
-    private fun mapShelter(shelterEntity: ShelterEntity): Shelter = Shelter(
+    private fun mapShelter(shelterEntity: ShelterEntity): ShelterResponse = ShelterResponse(
         id = shelterEntity.id!!,
         name = shelterEntity.name!!,
         addressStreet = shelterEntity.addressStreet!!,
@@ -68,7 +69,7 @@ class ShelterService(
         enabled = shelterEntity.enabled!!,
         sortOrder = shelterEntity.sortOrder ?: 0,
         contacts = shelterEntity.contacts.map {
-            ShelterContact(
+            ShelterContactItem(
                 firstname = it.firstname,
                 lastname = it.lastname,
                 phone = it.phone!!,
@@ -76,7 +77,7 @@ class ShelterService(
         },
     )
 
-    fun updateShelter(shelterId: Long, updatedShelter: Shelter): Shelter {
+    fun updateShelter(shelterId: Long, updatedShelter: ShelterRequest): ShelterResponse {
         val shelterEntity = shelterRepository.findByIdOrNull(shelterId)
             ?: throw NotFoundException("Shelter with id $shelterId not found")
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopService.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shop
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShopItem
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,13 +13,13 @@ class ShopService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getShopsForRouteId(routeId: Long): List<Shop> {
+    fun getShopsForRouteId(routeId: Long): List<ShopItem> {
         val route =
             routeRepository.findByIdOrNull(routeId) ?: throw NotFoundException("Route $routeId nicht gefunden!")
         return route.stops.sortedBy { it.time }
             .mapNotNull { it.shop }
             .map { shop ->
-                Shop(
+                ShopItem(
                     id = shop.id!!,
                     number = shop.number!!,
                     name = shop.name!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/CarsResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/CarsResponseModel.kt
@@ -6,15 +6,24 @@ import jakarta.validation.constraints.NotEmpty
 
 @ExcludeFromTestCoverage
 data class CarListResponse(
-    val cars: List<Car>,
+    val cars: List<CarResponse>,
 )
 
 @ExcludeFromTestCoverage
-data class Car(
+data class CarRequest(
     val id: Long?,
     @field:NotBlank
     val licensePlate: String,
     @field:NotBlank
+    val name: String,
+    val enabled: Boolean,
+    val sortOrder: Int,
+)
+
+@ExcludeFromTestCoverage
+data class CarResponse(
+    val id: Long?,
+    val licensePlate: String,
     val name: String,
     val enabled: Boolean,
     val sortOrder: Int,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCategoriesResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCategoriesResponseModel.kt
@@ -8,15 +8,25 @@ import java.math.BigDecimal
 
 @ExcludeFromTestCoverage
 data class FoodCategoriesListResponse(
-    val categories: List<FoodCategory>,
+    val categories: List<FoodCategoryResponse>,
 )
 
 @ExcludeFromTestCoverage
-data class FoodCategory(
+data class FoodCategoryRequest(
     val id: Long?,
     @field:NotBlank
     val name: String,
     @field:PositiveOrZero
+    val weightPerUnit: BigDecimal?,
+    val returnItem: Boolean,
+    val sortOrder: Int,
+    val enabled: Boolean,
+)
+
+@ExcludeFromTestCoverage
+data class FoodCategoryResponse(
+    val id: Long?,
+    val name: String,
     val weightPerUnit: BigDecimal?,
     val returnItem: Boolean,
     val sortOrder: Int,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCollectionsModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCollectionsModel.kt
@@ -1,25 +1,25 @@
 package at.wrk.tafel.admin.backend.modules.logistics.model
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
 
 @ExcludeFromTestCoverage
-data class FoodCollectionData(
+data class FoodCollectionResponse(
     val routeId: Long,
     val carId: Long?,
-    val driver: Employee?,
-    val coDriver: Employee?,
+    val driver: EmployeeResponse?,
+    val coDriver: EmployeeResponse?,
     val kmStart: Int?,
     val kmEnd: Int?,
     val items: List<FoodCollectionItem>,
 )
 
 @ExcludeFromTestCoverage
-data class FoodCollectionSaveRouteData(
+data class FoodCollectionSaveRouteRequest(
     @field:Positive
     val carId: Long,
     @field:Positive
@@ -33,9 +33,14 @@ data class FoodCollectionSaveRouteData(
 )
 
 @ExcludeFromTestCoverage
-data class FoodCollectionItems(
+data class FoodCollectionItemsRequest(
     @field:NotEmpty
     @field:Valid
+    val items: List<FoodCollectionItem>,
+)
+
+@ExcludeFromTestCoverage
+data class FoodCollectionItemsResponse(
     val items: List<FoodCollectionItem>,
 )
 
@@ -50,7 +55,17 @@ data class FoodCollectionItem(
 )
 
 @ExcludeFromTestCoverage
-data class FoodCollectionSaveItemsPerShopData(
+data class FoodCollectionItemRequest(
+    @field:Positive
+    val categoryId: Long,
+    @field:Positive
+    val shopId: Long,
+    @field:PositiveOrZero
+    val amount: Int,
+)
+
+@ExcludeFromTestCoverage
+data class FoodCollectionSaveItemsPerShopRequest(
     @field:NotEmpty
     @field:Valid
     val items: List<FoodCollectionCategoryAmount>,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/RouteResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/RouteResponseModel.kt
@@ -4,22 +4,22 @@ import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 
 @ExcludeFromTestCoverage
 data class RouteListResponse(
-    val routes: List<Route>,
+    val routes: List<RouteItem>,
 )
 
 @ExcludeFromTestCoverage
-data class Route(
+data class RouteItem(
     val id: Long,
     val name: String,
 )
 
 @ExcludeFromTestCoverage
 data class RouteShopsResponse(
-    val shops: List<Shop>,
+    val shops: List<ShopItem>,
 )
 
 @ExcludeFromTestCoverage
-data class Shop(
+data class ShopItem(
     val id: Long,
     val number: Int,
     val name: String,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModel.kt
@@ -9,11 +9,11 @@ import jakarta.validation.constraints.PositiveOrZero
 
 @ExcludeFromTestCoverage
 data class ShelterListResponse(
-    val shelters: List<Shelter>,
+    val shelters: List<ShelterResponse>,
 )
 
 @ExcludeFromTestCoverage
-data class Shelter(
+data class ShelterRequest(
     val id: Long?,
     @field:NotBlank
     val name: String,
@@ -33,7 +33,24 @@ data class Shelter(
     val enabled: Boolean,
     val sortOrder: Int,
     @field:Valid
-    val contacts: List<ShelterContact>,
+    val contacts: List<ShelterContactItem>,
+)
+
+@ExcludeFromTestCoverage
+data class ShelterResponse(
+    val id: Long?,
+    val name: String,
+    var addressStreet: String,
+    var addressHouseNumber: String,
+    var addressStairway: String?,
+    var addressDoor: String?,
+    var addressPostalCode: Int,
+    var addressCity: String,
+    val note: String?,
+    val personsCount: Int,
+    val enabled: Boolean,
+    val sortOrder: Int,
+    val contacts: List<ShelterContactItem>,
 )
 
 @ExcludeFromTestCoverage
@@ -43,7 +60,7 @@ data class ShelterReorderRequest(
 )
 
 @ExcludeFromTestCoverage
-data class ShelterContact(
+data class ShelterContactItem(
     val firstname: String?,
     val lastname: String?,
     @field:NotBlank

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/README.md
@@ -87,7 +87,7 @@ There are no explicit `@NamedInterface`/`@org.springframework.modulith.NamedInte
 in this module. Spring Modulith's default rule applies instead: **a module's root package is its default
 public API; everything under `internal` is hidden from other modules.** Concretely, the classes sitting
 directly in `modules.reporting` (`DailyReportService`, `StatisticExportService`, `StatisticExportFile`,
-`StatisticsController` and the `StatisticsSettings`/`StatisticsData`/... DTOs) are importable by other
+`StatisticsController` and the `StatisticsSettingsResponse`/`StatisticsResponse`/... DTOs) are importable by other
 modules; everything in `modules.reporting.internal.*` (the `StatisticsService`, the PDF model, the
 exporters, and the listener below) is not. In practice nothing outside `reporting` imports
 `DailyReportService`/`StatisticExportService`/`StatisticExportFile` anymore (checked) — they're only public

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
@@ -24,13 +24,13 @@ class StatisticsController(
 ) {
 
     @GetMapping("/settings")
-    fun getSettings(): StatisticsSettings = statisticsService.getSettings()
+    fun getSettings(): StatisticsSettingsResponse = statisticsService.getSettings()
 
     @GetMapping("/data")
     fun getData(
         @RequestParam fromDate: LocalDate,
         @RequestParam toDate: LocalDate,
-    ): StatisticsData = statisticsService.getData(fromDate, toDate)
+    ): StatisticsResponse = statisticsService.getData(fromDate, toDate)
 
     @GetMapping("/generate-csv", produces = [MediaType.TEXT_PLAIN_VALUE])
     fun generateCsv(
@@ -46,7 +46,7 @@ class StatisticsController(
         @RequestParam ageMin: Int,
         @RequestParam ageMax: Int,
         @RequestParam page: Int? = null,
-    ): PagedResponse<SchoolStarterPackageEntry> = statisticsService.getSchoolStarterPackageData(ageMin, ageMax, page)
+    ): PagedResponse<SchoolStarterPackageItem> = statisticsService.getSchoolStarterPackageData(ageMin, ageMax, page)
 
     @GetMapping("/generate-school-starter-package-csv", produces = [MediaType.TEXT_PLAIN_VALUE])
     fun generateSchoolStarterPackageCsv(
@@ -72,7 +72,7 @@ class StatisticsController(
     }
 }
 
-data class StatisticsSettings(
+data class StatisticsSettingsResponse(
     val availableYears: List<Int>,
     val distributions: List<StatisticsDistribution>,
 )
@@ -82,27 +82,27 @@ data class StatisticsDistribution(
     val endDate: LocalDateTime,
 )
 
-data class StatisticsData(
-    val beneficiaryCustomers: StatisticsDetailData,
-    val beneficiaryPersons: StatisticsDetailData,
-    val beneficiaryCustomersWithChildren: StatisticsDetailData,
-    val singleParentHouseholds: StatisticsDetailData,
-    val sheltersCount: StatisticsDetailData,
-    val sheltersAverage: StatisticsDetailData,
-    val sheltersPersonsCount: StatisticsDetailData,
-    val shopsCount: StatisticsDetailData,
-    val shopItemsTotal: StatisticsDetailData,
-    val shopItemsAverage: StatisticsDetailData,
+data class StatisticsResponse(
+    val beneficiaryCustomers: StatisticsDetail,
+    val beneficiaryPersons: StatisticsDetail,
+    val beneficiaryCustomersWithChildren: StatisticsDetail,
+    val singleParentHouseholds: StatisticsDetail,
+    val sheltersCount: StatisticsDetail,
+    val sheltersAverage: StatisticsDetail,
+    val sheltersPersonsCount: StatisticsDetail,
+    val shopsCount: StatisticsDetail,
+    val shopItemsTotal: StatisticsDetail,
+    val shopItemsAverage: StatisticsDetail,
 )
 
-data class StatisticsDetailData(
+data class StatisticsDetail(
     val title: String,
     val subTitle: String,
     val labels: List<String>,
     val dataPoints: List<Number>,
 )
 
-data class SchoolStarterPackageEntry(
+data class SchoolStarterPackageItem(
     val householdId: Long,
     val firstname: String,
     val lastname: String,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
@@ -6,11 +6,11 @@ import at.wrk.tafel.admin.backend.common.csv.CsvUtil
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.person.PersonRepository
-import at.wrk.tafel.admin.backend.modules.reporting.SchoolStarterPackageEntry
-import at.wrk.tafel.admin.backend.modules.reporting.StatisticsData
-import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDetailData
+import at.wrk.tafel.admin.backend.modules.reporting.SchoolStarterPackageItem
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDetail
 import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDistribution
-import at.wrk.tafel.admin.backend.modules.reporting.StatisticsSettings
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticsResponse
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticsSettingsResponse
 import jakarta.persistence.EntityManager
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.domain.Specification
@@ -35,11 +35,11 @@ class StatisticsService(
         private val INTEGER_FORMATTER = NumberFormat.getIntegerInstance()
     }
 
-    fun getSettings(): StatisticsSettings {
+    fun getSettings(): StatisticsSettingsResponse {
         val closedDistributions = distributionRepository.getDistributionEntityByEndedAtIsNotNullOrderByStartedAtDesc()
             .filter { it.endedAt != null && it.startedAt != null }
 
-        return StatisticsSettings(
+        return StatisticsSettingsResponse(
             availableYears = closedDistributions
                 .mapNotNull { it.startedAt?.year }
                 .distinct()
@@ -55,9 +55,9 @@ class StatisticsService(
     }
 
     @Transactional(readOnly = true)
-    fun getData(fromDate: LocalDate, toDate: LocalDate): StatisticsData {
+    fun getData(fromDate: LocalDate, toDate: LocalDate): StatisticsResponse {
         val countBeneficiaryCustomers = countBeneficiaryCustomers(fromDate, toDate)
-        val countBeneficiaryCustomersData = StatisticsDetailData(
+        val countBeneficiaryCustomersData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countBeneficiaryCustomers.lastOrNull()?.value?.toLong() ?: 0L),
             subTitle = "Bezugsberechtigte Haushalte",
             labels = countBeneficiaryCustomers.map { it.label },
@@ -65,7 +65,7 @@ class StatisticsService(
         )
 
         val countBeneficiaryPersons = countBeneficiaryPersons(fromDate, toDate)
-        val countBeneficiaryPersonsData = StatisticsDetailData(
+        val countBeneficiaryPersonsData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countBeneficiaryPersons.lastOrNull()?.value?.toLong() ?: 0L),
             subTitle = "Bezugsberechtigte Personen",
             labels = countBeneficiaryPersons.map { it.label },
@@ -73,7 +73,7 @@ class StatisticsService(
         )
 
         val countBeneficiaryCustomersWithChildren = countBeneficiaryCustomersWithChildren(fromDate, toDate)
-        val countBeneficiaryCustomersWithChildrenData = StatisticsDetailData(
+        val countBeneficiaryCustomersWithChildrenData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countBeneficiaryCustomersWithChildren.lastOrNull()?.value?.toLong() ?: 0L),
             subTitle = "Bezugsberechtigte Haushalte mit Kindern (Alter <= 15)",
             labels = countBeneficiaryCustomersWithChildren.map { it.label },
@@ -81,7 +81,7 @@ class StatisticsService(
         )
 
         val countSingleParentHouseholds = countSingleParentHouseholds(fromDate, toDate)
-        val countSingleParentHouseholdsData = StatisticsDetailData(
+        val countSingleParentHouseholdsData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countSingleParentHouseholds.lastOrNull()?.value?.toLong() ?: 0L),
             subTitle = "Alleinerzieher (Haushalte)",
             labels = countSingleParentHouseholds.map { it.label },
@@ -89,7 +89,7 @@ class StatisticsService(
         )
 
         val countShelters = countShelters(fromDate, toDate)
-        val countSheltersData = StatisticsDetailData(
+        val countSheltersData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countShelters.sumOf { it.value.toLong() }),
             subTitle = "Notschlafstellen (Anzahl)",
             labels = countShelters.map { it.label },
@@ -100,7 +100,7 @@ class StatisticsService(
         val averageSheltersDivisor = max(averageShelters.count { it.value.toDouble() > 0 }, 1)
         val averageSheltersTotalAverage = (averageShelters.sumOf { it.value.toDouble() } / averageSheltersDivisor)
             .let { String.format("%.2f", it) }
-        val averageSheltersData = StatisticsDetailData(
+        val averageSheltersData = StatisticsDetail(
             title = averageSheltersTotalAverage,
             subTitle = "Notschlafstellen (Durchschnitt pro Ausgabe)",
             labels = averageShelters.map { it.label },
@@ -108,7 +108,7 @@ class StatisticsService(
         )
 
         val countSheltersPersons = countSheltersPersons(fromDate, toDate)
-        val countSheltersPersonsData = StatisticsDetailData(
+        val countSheltersPersonsData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countSheltersPersons.sumOf { it.value.toLong() }),
             subTitle = "Versorgte Personen (Anzahl)",
             labels = countSheltersPersons.map { it.label },
@@ -116,7 +116,7 @@ class StatisticsService(
         )
 
         val countShops = countShops(fromDate, toDate)
-        val countShopsData = StatisticsDetailData(
+        val countShopsData = StatisticsDetail(
             title = INTEGER_FORMATTER.format(countShops.sumOf { it.value.toLong() }),
             subTitle = "Spender (Anzahl)",
             labels = countShops.map { it.label },
@@ -124,7 +124,7 @@ class StatisticsService(
         )
 
         val totalShopItems = totalShopItems(fromDate, toDate)
-        val totalShopItemsData = StatisticsDetailData(
+        val totalShopItemsData = StatisticsDetail(
             title = "${INTEGER_FORMATTER.format(totalShopItems.sumOf { it.value.toLong() })} kg",
             subTitle = "Warenmenge (Gesamt)",
             labels = totalShopItems.map { it.label },
@@ -136,14 +136,14 @@ class StatisticsService(
         val averageShopItemsTotalAverage =
             (averageShopItems.sumOf { it.value.toDouble() } / averageShopItemsDivisor)
                 .let { String.format("%.2f", it) }
-        val averageShopItemsData = StatisticsDetailData(
+        val averageShopItemsData = StatisticsDetail(
             title = "$averageShopItemsTotalAverage kg",
             subTitle = "Warenmenge (Durchschnitt pro Spender)",
             labels = averageShopItems.map { it.label },
             dataPoints = averageShopItems.map { it.value },
         )
 
-        return StatisticsData(
+        return StatisticsResponse(
             beneficiaryCustomers = countBeneficiaryCustomersData,
             beneficiaryPersons = countBeneficiaryPersonsData,
             beneficiaryCustomersWithChildren = countBeneficiaryCustomersWithChildrenData,
@@ -432,7 +432,7 @@ class StatisticsService(
         ageMin: Int,
         ageMax: Int,
         page: Int? = null,
-    ): PagedResponse<SchoolStarterPackageEntry> {
+    ): PagedResponse<SchoolStarterPackageItem> {
         val today = LocalDate.now()
         val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
         val pagedResult = personRepository.findAll(schoolStarterPackageSpec(ageMin, ageMax, today), pageRequest)
@@ -464,10 +464,10 @@ class StatisticsService(
         return PersonEntity.Specs.orderByHouseholdId(spec)
     }
 
-    private fun PersonEntity.toSchoolStarterPackageEntry(today: LocalDate): SchoolStarterPackageEntry {
+    private fun PersonEntity.toSchoolStarterPackageEntry(today: LocalDate): SchoolStarterPackageItem {
         val age = ChronoUnit.YEARS.between(birthDate, today).toInt()
 
-        return SchoolStarterPackageEntry(
+        return SchoolStarterPackageItem(
             householdId = household!!.householdId!!,
             firstname = firstname.orEmpty(),
             lastname = lastname.orEmpty(),

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/README.md
@@ -30,11 +30,12 @@ repositories without that counting as a `modules`-to-`modules` dependency at all
   - `GET /api/settings/static-values`, `POST /api/settings/static-values/{staticValueId}`
 - **`internal/SettingsService`** — all the logic for both concerns (no further internal
   decomposition despite the two concerns being unrelated).
-- **`model/SettingsResponseModel.kt`** — `MailRecipients` / `MailRecipientsPerMailType` /
-  `MailRecipientAdresses` (note the model's own `MailRecipientType` enum duplicates
-  `database.model.base.RecipientType` value-for-value: `TO`/`CC`/`BCC` — the service converts
-  between them by name via `.uppercase()`/`.valueOf(...)`, not by direct reuse).
-- **`model/StaticValueSettingsModel.kt`** — `StaticValueListResponse` / `StaticValueItem`.
+- **`model/SettingsResponseModel.kt`** — `MailRecipientsRequest` / `MailRecipientsResponse` /
+  `MailRecipientsPerMailType` / `MailRecipientAdresses` (note the model's own `MailRecipientType`
+  enum duplicates `database.model.base.RecipientType` value-for-value: `TO`/`CC`/`BCC` — the
+  service converts between them by name via `.uppercase()`/`.valueOf(...)`, not by direct reuse).
+- **`model/StaticValueSettingsModel.kt`** — `StaticValueListResponse` / `StaticValueRequest` /
+  `StaticValueResponse`.
 
 ## Mail recipients
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/SettingsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/SettingsController.kt
@@ -1,9 +1,11 @@
 package at.wrk.tafel.admin.backend.modules.settings
 
 import at.wrk.tafel.admin.backend.modules.settings.internal.SettingsService
-import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
-import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueItem
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsResponse
 import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueListResponse
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueResponse
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,10 +23,10 @@ class SettingsController(
 ) {
 
     @GetMapping("/mail-recipients")
-    fun getMailRecipientSettings(): MailRecipients = settingsService.getMailRecipients()
+    fun getMailRecipientSettings(): MailRecipientsResponse = settingsService.getMailRecipients()
 
     @PutMapping("/mail-recipients")
-    fun updateMailRecipientSettings(@Valid @RequestBody settings: MailRecipients) {
+    fun updateMailRecipientSettings(@Valid @RequestBody settings: MailRecipientsRequest) {
         settingsService.updateMailRecipients(settings)
     }
 
@@ -34,6 +36,6 @@ class SettingsController(
     @PutMapping("/static-values/{staticValueId}")
     fun updateStaticValue(
         @PathVariable staticValueId: Long,
-        @Valid @RequestBody staticValue: StaticValueItem,
-    ): StaticValueItem = settingsService.updateStaticValue(staticValueId, staticValue)
+        @Valid @RequestBody staticValue: StaticValueRequest,
+    ): StaticValueResponse = settingsService.updateStaticValue(staticValueId, staticValue)
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsService.kt
@@ -9,10 +9,12 @@ import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepositor
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientAdresses
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientType
-import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsPerMailType
-import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueItem
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsResponse
 import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueListResponse
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueResponse
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -30,7 +32,7 @@ class SettingsService(
         private val FICTIVE_END_DATE = LocalDate.of(2999, 12, 31)
     }
 
-    fun getMailRecipients(): MailRecipients {
+    fun getMailRecipients(): MailRecipientsResponse {
         val recipientsPerMailType = mailRecipientRepository.findAll().groupBy { it.mailType }
         val mailRecipients = recipientsPerMailType.entries.map {
             val mailType = it.key
@@ -39,7 +41,7 @@ class SettingsService(
             mapToMailRecipientSetting(mailType!!, recipients)
         }
 
-        return MailRecipients(mailRecipients = mailRecipients)
+        return MailRecipientsResponse(mailRecipients = mailRecipients)
     }
 
     private fun mapToMailRecipientSetting(
@@ -60,7 +62,7 @@ class SettingsService(
     }
 
     @Transactional
-    fun updateMailRecipients(settings: MailRecipients) {
+    fun updateMailRecipients(settings: MailRecipientsRequest) {
         val recipients = settings.mailRecipients.flatMap { mailRecipient ->
             mailRecipient.recipients.flatMap { (updatedRecipientType, updatedRecipients) ->
                 updatedRecipients
@@ -104,7 +106,7 @@ class SettingsService(
         cacheNames = ["staticValueLatestForPersonCount", "staticValueSingle", "staticValueList"],
         allEntries = true,
     )
-    fun updateStaticValue(staticValueId: Long, item: StaticValueItem): StaticValueItem {
+    fun updateStaticValue(staticValueId: Long, item: StaticValueRequest): StaticValueResponse {
         val entity = staticValueRepository.findByIdOrNull(staticValueId)
             ?: throw NotFoundException("Statischer Wert mit ID $staticValueId nicht gefunden")
 
@@ -137,7 +139,7 @@ class SettingsService(
         return validFrom != null && validTo != null && !today.isBefore(validFrom) && !today.isAfter(validTo)
     }
 
-    private fun mapStaticValue(entity: StaticValueEntity): StaticValueItem = StaticValueItem(
+    private fun mapStaticValue(entity: StaticValueEntity): StaticValueResponse = StaticValueResponse(
         id = entity.id,
         type = entity.type!!.name,
         validFrom = entity.validFrom!!,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/SettingsResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/SettingsResponseModel.kt
@@ -5,8 +5,13 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 
 @ExcludeFromTestCoverage
-data class MailRecipients(
+data class MailRecipientsRequest(
     @field:Valid
+    val mailRecipients: List<MailRecipientsPerMailType>,
+)
+
+@ExcludeFromTestCoverage
+data class MailRecipientsResponse(
     val mailRecipients: List<MailRecipientsPerMailType>,
 )
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/StaticValueSettingsModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/StaticValueSettingsModel.kt
@@ -8,11 +8,11 @@ import java.time.LocalDate
 
 @ExcludeFromTestCoverage
 data class StaticValueListResponse(
-    val staticValues: List<StaticValueItem>,
+    val staticValues: List<StaticValueResponse>,
 )
 
 @ExcludeFromTestCoverage
-data class StaticValueItem(
+data class StaticValueRequest(
     val id: Long?,
     @field:NotBlank
     val type: String,
@@ -25,5 +25,17 @@ data class StaticValueItem(
     @field:PositiveOrZero
     val countChildren: Int?,
     @field:PositiveOrZero
+    val age: Int?,
+)
+
+@ExcludeFromTestCoverage
+data class StaticValueResponse(
+    val id: Long?,
+    val type: String,
+    val validFrom: LocalDate,
+    val validTo: LocalDate,
+    val amount: BigDecimal?,
+    val countAdults: Int?,
+    val countChildren: Int?,
     val age: Int?,
 )

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/model/UserModelTest.kt
@@ -26,8 +26,8 @@ class UserModelTest {
     }
 
     @Test
-    fun `user with blank required fields is invalid`() {
-        val user = User(
+    fun `user request with blank required fields is invalid`() {
+        val user = UserRequest(
             id = null,
             personnelNumber = "",
             username = "",
@@ -45,8 +45,8 @@ class UserModelTest {
     }
 
     @Test
-    fun `user with filled required fields is valid`() {
-        val user = User(
+    fun `user request with filled required fields is valid`() {
+        val user = UserRequest(
             id = null,
             personnelNumber = "123",
             username = "username",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/CountryControllerTest.kt
@@ -20,8 +20,8 @@ class CountryControllerTest {
 
     @Test
     fun `list countries`() {
-        val country1 = Country(id = 1, code = "AA", name = "Name A")
-        val country2 = Country(id = 2, code = "BB", name = "Name B")
+        val country1 = CountryItem(id = 1, code = "AA", name = "Name A")
+        val country2 = CountryItem(id = 2, code = "BB", name = "Name B")
 
         every { countryService.listCountries() } returns listOf(country1, country2)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/country/internal/CountryServiceTest.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.base.country.internal
 
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry2
 import io.mockk.every
@@ -29,8 +29,8 @@ class CountryServiceTest {
 
         assertThat(countries).isEqualTo(
             listOf(
-                Country(id = testCountry1.id!!, code = testCountry1.code!!, name = testCountry1.name!!),
-                Country(id = testCountry2.id!!, code = testCountry2.code!!, name = testCountry2.name!!),
+                CountryItem(id = testCountry1.id!!, code = testCountry1.code!!, name = testCountry1.name!!),
+                CountryItem(id = testCountry2.id!!, code = testCountry2.code!!, name = testCountry2.name!!),
             ),
         )
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeControllerTest.kt
@@ -24,7 +24,7 @@ class EmployeeControllerTest {
     fun `find employees`() {
         val response = EmployeeListResponse(
             items = listOf(
-                Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
+                EmployeeResponse(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
             ),
             totalCount = 1,
             currentPage = 1,
@@ -40,12 +40,12 @@ class EmployeeControllerTest {
 
     @Test
     fun `save employee`() {
-        val employeeCreateRequest = EmployeeCreateRequest(
+        val employeeCreateRequest = EmployeeRequest(
             personnelNumber = "00001",
             firstname = "first 1",
             lastname = "last 1",
         )
-        val savedEmployee = Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1")
+        val savedEmployee = EmployeeResponse(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1")
         every { employeeService.saveEmployee(employeeCreateRequest) } returns savedEmployee
 
         val result = employeeController.saveEmployee(employeeCreateRequest)
@@ -58,12 +58,12 @@ class EmployeeControllerTest {
     @Test
     fun `update employee`() {
         val employeeId = 1L
-        val employeeUpdateRequest = EmployeeCreateRequest(
+        val employeeUpdateRequest = EmployeeRequest(
             personnelNumber = "00001",
             firstname = "first 1",
             lastname = "last 1",
         )
-        val updatedEmployee = Employee(id = employeeId, personnelNumber = "00001", firstname = "first 1", lastname = "last 1")
+        val updatedEmployee = EmployeeResponse(id = employeeId, personnelNumber = "00001", firstname = "first 1", lastname = "last 1")
         every { employeeService.updateEmployee(employeeId, employeeUpdateRequest) } returns updatedEmployee
 
         val result = employeeController.updateEmployee(employeeId, employeeUpdateRequest)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeModelTest.kt
@@ -8,7 +8,7 @@ class EmployeeModelTest {
 
     @Test
     fun `employee create request with blank fields is invalid`() {
-        val request = EmployeeCreateRequest(personnelNumber = "", firstname = "", lastname = "")
+        val request = EmployeeRequest(personnelNumber = "", firstname = "", lastname = "")
 
         val violations = validator.validate(request)
 
@@ -18,7 +18,7 @@ class EmployeeModelTest {
 
     @Test
     fun `employee create request with filled fields is valid`() {
-        val request = EmployeeCreateRequest(personnelNumber = "123", firstname = "Max", lastname = "Mustermann")
+        val request = EmployeeRequest(personnelNumber = "123", firstname = "Max", lastname = "Mustermann")
 
         val violations = validator.validate(request)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
@@ -2,9 +2,9 @@ package at.wrk.tafel.admin.backend.modules.base.employee.internal
 
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
-import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeCreateRequest
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeRequest
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import io.mockk.every
@@ -56,8 +56,8 @@ class EmployeeServiceTest {
         assertThat(response).isEqualTo(
             EmployeeListResponse(
                 items = listOf(
-                    Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
-                    Employee(id = 2, personnelNumber = "00002", firstname = "first 2", lastname = "last 2"),
+                    EmployeeResponse(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
+                    EmployeeResponse(id = 2, personnelNumber = "00002", firstname = "first 2", lastname = "last 2"),
                 ),
                 totalCount = 123,
                 currentPage = 1,
@@ -83,7 +83,7 @@ class EmployeeServiceTest {
 
         assertThat(response.items).isEqualTo(
             listOf(
-                Employee(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
+                EmployeeResponse(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
             ),
         )
     }
@@ -99,7 +99,7 @@ class EmployeeServiceTest {
 
     @Test
     fun `save employee`() {
-        val employeeCreateRequest = EmployeeCreateRequest(
+        val employeeCreateRequest = EmployeeRequest(
             personnelNumber = "   00001",
             firstname = "first 1  ",
             lastname = "last 1    ",
@@ -133,7 +133,7 @@ class EmployeeServiceTest {
             firstname = "Old firstname"
             lastname = "Old lastname"
         }
-        val employeeUpdateRequest = EmployeeCreateRequest(
+        val employeeUpdateRequest = EmployeeRequest(
             personnelNumber = "  00002",
             firstname = "New firstname  ",
             lastname = "New lastname   ",
@@ -145,7 +145,7 @@ class EmployeeServiceTest {
         val result = employeeService.updateEmployee(employeeId, employeeUpdateRequest)
 
         assertThat(result).isEqualTo(
-            Employee(
+            EmployeeResponse(
                 id = employeeId,
                 personnelNumber = "00002",
                 firstname = "New firstname",
@@ -169,7 +169,7 @@ class EmployeeServiceTest {
         val exception = assertThrows<NotFoundException> {
             employeeService.updateEmployee(
                 99L,
-                EmployeeCreateRequest(personnelNumber = "00001", firstname = "first", lastname = "last"),
+                EmployeeRequest(personnelNumber = "00001", firstname = "first", lastname = "last"),
             )
         }
         assertThat(exception.body.detail).isEqualTo("Employee with id 99 not found")
@@ -190,7 +190,7 @@ class EmployeeServiceTest {
         val exception = assertThrows<ConflictException> {
             employeeService.updateEmployee(
                 employeeId,
-                EmployeeCreateRequest(personnelNumber = "00002", firstname = "first", lastname = "last"),
+                EmployeeRequest(personnelNumber = "00002", firstname = "first", lastname = "last"),
             )
         }
         assertThat(exception.body.detail).isEqualTo("Mitarbeiter 00002 ist bereits vorhanden!")

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionControllerTest.kt
@@ -42,7 +42,7 @@ internal class DistributionControllerTest {
 
         controller.createNewDistribution()
 
-        val distributionItemResponse = DistributionItemUpdate(distribution = distributionItem)
+        val distributionItemResponse = DistributionUpdateResponse(distribution = distributionItem)
 
         verify {
             sseOutboxService.saveOutboxEntry(
@@ -82,7 +82,7 @@ internal class DistributionControllerTest {
 
     @Test
     fun `save distribution statistic`() {
-        val statisticData = DistributionStatisticData(
+        val statisticData = DistributionStatisticRequest(
             employeeCount = 100,
             selectedShelterIds = listOf(1, 2, 3),
         )
@@ -100,7 +100,7 @@ internal class DistributionControllerTest {
 
     @Test
     fun `save distribution note`() {
-        val noteData = DistributionNoteData(
+        val noteData = DistributionNoteRequest(
             notes = "dummy notes",
         )
 
@@ -119,7 +119,7 @@ internal class DistributionControllerTest {
         val distributionEntity = DistributionEntity()
         distributionEntity.id = 123
         every { service.getCurrentDistribution() } returns distributionEntity
-        every { service.validateClose() } returns DistributionCloseValidationResult(
+        every { service.validateClose() } returns DistributionCloseResponse(
             errors = emptyList(),
             warnings = emptyList(),
         )
@@ -131,7 +131,7 @@ internal class DistributionControllerTest {
 
         verify { service.closeDistribution() }
 
-        val distributionItemResponseSlot = slot<DistributionItemUpdate>()
+        val distributionItemResponseSlot = slot<DistributionUpdateResponse>()
         verify {
             sseOutboxService.saveOutboxEntry(
                 notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
@@ -140,7 +140,7 @@ internal class DistributionControllerTest {
         }
 
         assertThat(distributionItemResponseSlot.captured).isEqualTo(
-            DistributionItemUpdate(
+            DistributionUpdateResponse(
                 distribution = null,
             ),
         )
@@ -152,7 +152,7 @@ internal class DistributionControllerTest {
         distributionEntity.id = 123
         every { service.getCurrentDistribution() } returns distributionEntity
 
-        val validationResult = DistributionCloseValidationResult(
+        val validationResult = DistributionCloseResponse(
             errors = listOf("Error 1", "Error 2"),
             warnings = emptyList(),
         )
@@ -178,7 +178,7 @@ internal class DistributionControllerTest {
         distributionEntity.id = 123
         every { service.getCurrentDistribution() } returns distributionEntity
 
-        val validationResult = DistributionCloseValidationResult(
+        val validationResult = DistributionCloseResponse(
             errors = emptyList(),
             warnings = listOf("Warning 1", "Warning 2"),
         )
@@ -204,7 +204,7 @@ internal class DistributionControllerTest {
         distributionEntity.id = 123
         every { service.getCurrentDistribution() } returns distributionEntity
 
-        val validationResult = DistributionCloseValidationResult(
+        val validationResult = DistributionCloseResponse(
             errors = emptyList(),
             warnings = listOf("Warning 1", "Warning 2"),
         )
@@ -217,7 +217,7 @@ internal class DistributionControllerTest {
 
         verify { service.closeDistribution() }
 
-        val distributionItemResponseSlot = slot<DistributionItemUpdate>()
+        val distributionItemResponseSlot = slot<DistributionUpdateResponse>()
         verify {
             sseOutboxService.saveOutboxEntry(
                 notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
@@ -226,7 +226,7 @@ internal class DistributionControllerTest {
         }
 
         assertThat(distributionItemResponseSlot.captured).isEqualTo(
-            DistributionItemUpdate(
+            DistributionUpdateResponse(
                 distribution = null,
             ),
         )
@@ -238,7 +238,7 @@ internal class DistributionControllerTest {
         distributionEntity.id = 123
         every { service.getCurrentDistribution() } returns distributionEntity
 
-        val validationResult = DistributionCloseValidationResult(
+        val validationResult = DistributionCloseResponse(
             errors = listOf("Error 1", "Error 2"),
             warnings = listOf("Warning 1", "Warning 2"),
         )

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionSseControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/DistributionSseControllerTest.kt
@@ -4,7 +4,7 @@ import at.wrk.tafel.admin.backend.database.common.sseoutbox.SseOutboxService
 import at.wrk.tafel.admin.backend.modules.distribution.DistributionController.Companion.DISTRIBUTION_UPDATE_NOTIFICATION_NAME
 import at.wrk.tafel.admin.backend.modules.distribution.internal.DistributionService
 import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItem
-import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionItemUpdate
+import at.wrk.tafel.admin.backend.modules.distribution.internal.model.DistributionUpdateResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -42,13 +42,13 @@ internal class DistributionSseControllerTest {
         verifySequence {
             sseOutboxService.sendEvent(
                 sseEmitter,
-                DistributionItemUpdate(distribution = distributionItem),
+                DistributionUpdateResponse(distribution = distributionItem),
             )
 
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = sseEmitter,
                 notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
-                resultType = DistributionItemUpdate::class.java,
+                resultType = DistributionUpdateResponse::class.java,
             )
         }
     }
@@ -63,7 +63,7 @@ internal class DistributionSseControllerTest {
         verifySequence {
             sseOutboxService.sendEvent(
                 sseEmitter,
-                DistributionItemUpdate(
+                DistributionUpdateResponse(
                     distribution = null,
                 ),
             )
@@ -71,7 +71,7 @@ internal class DistributionSseControllerTest {
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = sseEmitter,
                 notificationName = DISTRIBUTION_UPDATE_NOTIFICATION_NAME,
-                resultType = DistributionItemUpdate::class.java,
+                resultType = DistributionUpdateResponse::class.java,
             )
         }
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/model/DistributionResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/model/DistributionResponseModelTest.kt
@@ -27,7 +27,7 @@ class DistributionResponseModelTest {
 
     @Test
     fun `distribution statistic data with negative count is invalid`() {
-        val data = DistributionStatisticData(employeeCount = -1, selectedShelterIds = emptyList())
+        val data = DistributionStatisticRequest(employeeCount = -1, selectedShelterIds = emptyList())
 
         val violations = validator.validate(data)
 
@@ -37,7 +37,7 @@ class DistributionResponseModelTest {
 
     @Test
     fun `distribution statistic data with no shelters selected is valid`() {
-        val data = DistributionStatisticData(employeeCount = 0, selectedShelterIds = emptyList())
+        val data = DistributionStatisticRequest(employeeCount = 0, selectedShelterIds = emptyList())
 
         val violations = validator.validate(data)
 
@@ -46,7 +46,7 @@ class DistributionResponseModelTest {
 
     @Test
     fun `distribution statistic data with valid values is valid`() {
-        val data = DistributionStatisticData(employeeCount = 0, selectedShelterIds = listOf(1L))
+        val data = DistributionStatisticRequest(employeeCount = 0, selectedShelterIds = listOf(1L))
 
         val violations = validator.validate(data)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenControllerTest.kt
@@ -29,7 +29,7 @@ internal class DistributionTicketScreenControllerTest {
     fun `show text`() {
         val testText = "Test Text"
         val testValue = "123213"
-        val requestBody = TicketScreenShowText(
+        val requestBody = TicketScreenShowTextRequest(
             text = testText,
             value = testValue,
         )
@@ -39,7 +39,7 @@ internal class DistributionTicketScreenControllerTest {
         verify {
             sseOutboxService.saveOutboxEntry(
                 TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                TicketScreenShowText(
+                TicketScreenShowTextRequest(
                     text = testText,
                     value = testValue,
                 ),
@@ -57,7 +57,7 @@ internal class DistributionTicketScreenControllerTest {
         verify {
             sseOutboxService.saveOutboxEntry(
                 TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                TicketScreenShowText(
+                TicketScreenShowTextRequest(
                     text = "Ticket",
                     value = "50",
                 ),
@@ -74,7 +74,7 @@ internal class DistributionTicketScreenControllerTest {
         verify {
             sseOutboxService.saveOutboxEntry(
                 TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                TicketScreenShowText(
+                TicketScreenShowTextRequest(
                     text = "Ticket",
                     value = null,
                 ),
@@ -93,7 +93,7 @@ internal class DistributionTicketScreenControllerTest {
         verify {
             sseOutboxService.saveOutboxEntry(
                 TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                TicketScreenShowText(
+                TicketScreenShowTextRequest(
                     text = "Ticket",
                     value = previousTicketNumber.toString(),
                 ),
@@ -107,7 +107,7 @@ internal class DistributionTicketScreenControllerTest {
 
         controller.showPreviousTicket()
 
-        val payloadSlot = slot<TicketScreenShowText>()
+        val payloadSlot = slot<TicketScreenShowTextRequest>()
         verify { service.reopenAndGetPreviousTicket() }
         verify {
             sseOutboxService.saveOutboxEntry(
@@ -132,7 +132,7 @@ internal class DistributionTicketScreenControllerTest {
         verify {
             sseOutboxService.saveOutboxEntry(
                 TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                TicketScreenShowText(
+                TicketScreenShowTextRequest(
                     text = "Ticket",
                     value = nextTicketNumber.toString(),
                 ),
@@ -146,7 +146,7 @@ internal class DistributionTicketScreenControllerTest {
 
         controller.showNextTicket(TicketScreenShowNextTicketRequest(costContributionPaid = true))
 
-        val payloadSlot = slot<TicketScreenShowText>()
+        val payloadSlot = slot<TicketScreenShowTextRequest>()
         verify { service.closeCurrentTicketAndGetNext(true) }
         verify {
             sseOutboxService.saveOutboxEntry(

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenSseControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/DistributionTicketScreenSseControllerTest.kt
@@ -26,7 +26,7 @@ internal class DistributionTicketScreenSseControllerTest {
 
     @Test
     fun `listen for changes with active distribution`() {
-        val testValue = TicketScreenShowText(text = "Ticket", value = "50")
+        val testValue = TicketScreenShowTextRequest(text = "Ticket", value = "50")
 
         every { service.hasCurrentDistribution() } returns true
         every { service.getCurrentTicketNumberValue() } returns 50
@@ -38,7 +38,7 @@ internal class DistributionTicketScreenSseControllerTest {
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = emitter,
                 notificationName = TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                resultType = TicketScreenShowText::class.java,
+                resultType = TicketScreenShowTextRequest::class.java,
             )
         }
 
@@ -47,14 +47,14 @@ internal class DistributionTicketScreenSseControllerTest {
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = emitter,
                 notificationName = TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                resultType = TicketScreenShowText::class.java,
+                resultType = TicketScreenShowTextRequest::class.java,
             )
         }
     }
 
     @Test
     fun `listen for changes without active distribution`() {
-        val testValue = TicketScreenShowText(text = "Ticket", value = null)
+        val testValue = TicketScreenShowTextRequest(text = "Ticket", value = null)
 
         every { service.hasCurrentDistribution() } returns false
 
@@ -65,7 +65,7 @@ internal class DistributionTicketScreenSseControllerTest {
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = emitter,
                 notificationName = TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                resultType = TicketScreenShowText::class.java,
+                resultType = TicketScreenShowTextRequest::class.java,
             )
         }
 
@@ -74,7 +74,7 @@ internal class DistributionTicketScreenSseControllerTest {
             sseOutboxService.forwardNotificationEventsToSse(
                 sseEmitter = emitter,
                 notificationName = TICKET_SCREEN_SHOW_VALUE_NOTIFICATION_NAME,
-                resultType = TicketScreenShowText::class.java,
+                resultType = TicketScreenShowTextRequest::class.java,
             )
         }
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/TicketScreenShowTextRequestTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/distribution/internal/ticket/TicketScreenShowTextRequestTest.kt
@@ -4,11 +4,11 @@ import at.wrk.tafel.admin.backend.common.validation.BeanValidationTestSupport.va
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class TicketScreenShowTextTest {
+class TicketScreenShowTextRequestTest {
 
     @Test
-    fun `ticket screen show text with blank text is invalid`() {
-        val request = TicketScreenShowText(text = "", value = null)
+    fun `ticket screen show text request with blank text is invalid`() {
+        val request = TicketScreenShowTextRequest(text = "", value = null)
 
         val violations = validator.validate(request)
 
@@ -17,8 +17,8 @@ class TicketScreenShowTextTest {
     }
 
     @Test
-    fun `ticket screen show text with filled text is valid`() {
-        val request = TicketScreenShowText(text = "Ticket", value = "1")
+    fun `ticket screen show text request with filled text is valid`() {
+        val request = TicketScreenShowTextRequest(text = "Ticket", value = "1")
 
         val violations = validator.validate(request)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdControllerTest.kt
@@ -1,6 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.household
 
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.household.internal.*
@@ -38,7 +38,8 @@ class HouseholdControllerTest {
     @InjectMockKs
     private lateinit var controller: HouseholdController
 
-    private lateinit var testHousehold: Household
+    private lateinit var testHouseholdRequest: HouseholdRequest
+    private lateinit var testHouseholdResponse: HouseholdResponse
     private val isSupervisor = false
 
     @BeforeEach
@@ -49,76 +50,93 @@ class HouseholdControllerTest {
                 testUserEntity.username,
                 true,
             )
-        testHousehold = Household(
-            id = 100,
-            issuer = HouseholdIssuer(
-                personnelNumber = "test-personnelnumber",
-                firstname = "test-firstname",
-                lastname = "test-lastname",
+
+        val issuer = HouseholdIssuer(
+            personnelNumber = "test-personnelnumber",
+            firstname = "test-firstname",
+            lastname = "test-lastname",
+        )
+        val address = HouseholdAddress(
+            street = "Test-Straße",
+            houseNumber = "100",
+            stairway = "1",
+            door = "21",
+            postalCode = 1010,
+            city = "Wien",
+        )
+        val persons = listOf(
+            Person(
+                id = 1,
+                isMainPerson = true,
+                firstname = "Max",
+                lastname = "Mustermann",
+                birthDate = LocalDate.now().minusYears(30),
+                gender = PersonGender.FEMALE,
+                country = CountryItem(
+                    id = 1,
+                    code = "AT",
+                    name = "Österreich",
+                ),
+                employer = "Employer 123",
+                income = BigDecimal("1000"),
+                incomeDue = LocalDate.now(),
             ),
+            Person(
+                id = 2,
+                isMainPerson = false,
+                firstname = "Add pers 1",
+                lastname = "Add pers 1",
+                birthDate = LocalDate.now().minusYears(5),
+                gender = PersonGender.FEMALE,
+                income = BigDecimal("100"),
+                incomeDue = LocalDate.now(),
+                receivesFamilyAllowance = false,
+                country = CountryItem(
+                    id = 1,
+                    code = "AT",
+                    name = "Österreich",
+                ),
+                excludeFromHousehold = false,
+            ),
+            Person(
+                id = 3,
+                isMainPerson = false,
+                firstname = "Add pers 2",
+                lastname = "Add pers 2",
+                birthDate = LocalDate.now().minusYears(2),
+                gender = PersonGender.MALE,
+                receivesFamilyAllowance = true,
+                country = CountryItem(
+                    id = 1,
+                    code = "AT",
+                    name = "Österreich",
+                ),
+                excludeFromHousehold = true,
+            ),
+        )
+
+        testHouseholdRequest = HouseholdRequest(
+            id = 100,
+            issuer = issuer,
             issuedAt = LocalDate.now(),
             telephoneNumber = "0043660123123",
             email = "test@mail.com",
-            address = HouseholdAddress(
-                street = "Test-Straße",
-                houseNumber = "100",
-                stairway = "1",
-                door = "21",
-                postalCode = 1010,
-                city = "Wien",
-            ),
+            address = address,
             validUntil = LocalDate.now(),
             locked = false,
-            persons = listOf(
-                Person(
-                    id = 1,
-                    isMainPerson = true,
-                    firstname = "Max",
-                    lastname = "Mustermann",
-                    birthDate = LocalDate.now().minusYears(30),
-                    gender = PersonGender.FEMALE,
-                    country = Country(
-                        id = 1,
-                        code = "AT",
-                        name = "Österreich",
-                    ),
-                    employer = "Employer 123",
-                    income = BigDecimal("1000"),
-                    incomeDue = LocalDate.now(),
-                ),
-                Person(
-                    id = 2,
-                    isMainPerson = false,
-                    firstname = "Add pers 1",
-                    lastname = "Add pers 1",
-                    birthDate = LocalDate.now().minusYears(5),
-                    gender = PersonGender.FEMALE,
-                    income = BigDecimal("100"),
-                    incomeDue = LocalDate.now(),
-                    receivesFamilyAllowance = false,
-                    country = Country(
-                        id = 1,
-                        code = "AT",
-                        name = "Österreich",
-                    ),
-                    excludeFromHousehold = false,
-                ),
-                Person(
-                    id = 3,
-                    isMainPerson = false,
-                    firstname = "Add pers 2",
-                    lastname = "Add pers 2",
-                    birthDate = LocalDate.now().minusYears(2),
-                    gender = PersonGender.MALE,
-                    receivesFamilyAllowance = true,
-                    country = Country(
-                        id = 1,
-                        code = "AT",
-                        name = "Österreich",
-                    ),
-                    excludeFromHousehold = true,
-                ),
-            ),
+            persons = persons,
+        )
+
+        testHouseholdResponse = HouseholdResponse(
+            id = 100,
+            issuer = issuer,
+            issuedAt = LocalDate.now(),
+            telephoneNumber = "0043660123123",
+            email = "test@mail.com",
+            address = address,
+            validUntil = LocalDate.now(),
+            locked = false,
+            persons = persons,
         )
     }
 
@@ -137,7 +155,7 @@ class HouseholdControllerTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val response = controller.validate(testHousehold)
+        val response = controller.validate(testHouseholdRequest)
 
         assertThat(response).isEqualTo(
             ValidateHouseholdResponse(
@@ -150,27 +168,27 @@ class HouseholdControllerTest {
         )
 
         verify {
-            householdService.validate(testHousehold)
+            householdService.validate(testHouseholdRequest)
         }
     }
 
     @Test
     fun `create household - given id and exists already`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns true
 
-        val exception = assertThrows<ConflictException> { controller.createHousehold(false, testHousehold) }
+        val exception = assertThrows<ConflictException> { controller.createHousehold(false, testHouseholdRequest) }
 
         assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 bereits vorhanden!")
     }
 
     @Test
     fun `create household - missing id so the household should be created`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns false
 
-        val response = controller.createHousehold(false, testHousehold)
+        val response = controller.createHousehold(false, testHouseholdRequest)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        verify { householdService.createHousehold(testHousehold, false, false) }
+        verify { householdService.createHousehold(testHouseholdRequest, false, false) }
     }
 
     @Test
@@ -183,29 +201,29 @@ class HouseholdControllerTest {
         )
         SecurityContextHolder.getContext().authentication = supervisorAuth
 
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns false
 
-        controller.createHousehold(true, testHousehold)
+        controller.createHousehold(true, testHouseholdRequest)
 
-        verify { householdService.createHousehold(testHousehold, true, true) }
+        verify { householdService.createHousehold(testHouseholdRequest, true, true) }
     }
 
     @Test
     fun `create household - force defaults to false when omitted`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns false
 
-        controller.createHousehold(household = testHousehold)
+        controller.createHousehold(household = testHouseholdRequest)
 
-        verify { householdService.createHousehold(testHousehold, false, false) }
+        verify { householdService.createHousehold(testHouseholdRequest, false, false) }
     }
 
     @Test
     fun `update household - does not exist`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns false
 
         val exception =
             assertThrows<NotFoundException> {
-                controller.updateHousehold(testHousehold.id!!, false, testHousehold)
+                controller.updateHousehold(testHouseholdRequest.id!!, false, testHouseholdRequest)
             }
 
         assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
@@ -214,106 +232,107 @@ class HouseholdControllerTest {
 
     @Test
     fun `update household - exists and should be updated`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns true
         every {
             householdService.updateHousehold(
-                testHousehold.id!!,
-                testHousehold,
+                testHouseholdRequest.id!!,
+                testHouseholdRequest,
                 false,
                 isSupervisor,
             )
-        } returns HouseholdUpdateResponse(data = testHousehold, errorMsg = null)
+        } returns HouseholdUpdateResponse(data = testHouseholdResponse, errorMsg = null)
 
-        val response = controller.updateHousehold(testHousehold.id!!, false, testHousehold)
+        val response = controller.updateHousehold(testHouseholdRequest.id!!, false, testHouseholdRequest)
 
-        assertThat(response.data).isEqualTo(testHousehold)
-        verify { householdService.updateHousehold(testHousehold.id!!, testHousehold, false, isSupervisor) }
+        assertThat(response.data).isEqualTo(testHouseholdResponse)
+        verify { householdService.updateHousehold(testHouseholdRequest.id!!, testHouseholdRequest, false, isSupervisor) }
     }
 
     @Test
     fun `update household with force=true`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns true
         every {
             householdService.updateHousehold(
-                testHousehold.id!!,
-                testHousehold,
+                testHouseholdRequest.id!!,
+                testHouseholdRequest,
                 true,
                 isSupervisor,
             )
-        } returns HouseholdUpdateResponse(data = testHousehold, errorMsg = null)
+        } returns HouseholdUpdateResponse(data = testHouseholdResponse, errorMsg = null)
 
-        val response = controller.updateHousehold(testHousehold.id!!, true, testHousehold)
+        val response = controller.updateHousehold(testHouseholdRequest.id!!, true, testHouseholdRequest)
 
-        assertThat(response.data).isEqualTo(testHousehold)
-        verify { householdService.updateHousehold(testHousehold.id!!, testHousehold, true, isSupervisor) }
+        assertThat(response.data).isEqualTo(testHouseholdResponse)
+        verify { householdService.updateHousehold(testHouseholdRequest.id!!, testHouseholdRequest, true, isSupervisor) }
     }
 
     @Test
     fun `update household - force defaults to false when omitted`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns true
         every {
             householdService.updateHousehold(
-                testHousehold.id!!,
-                testHousehold,
+                testHouseholdRequest.id!!,
+                testHouseholdRequest,
                 false,
                 isSupervisor,
             )
-        } returns HouseholdUpdateResponse(data = testHousehold, errorMsg = null)
+        } returns HouseholdUpdateResponse(data = testHouseholdResponse, errorMsg = null)
 
-        val response = controller.updateHousehold(householdId = testHousehold.id!!, household = testHousehold)
+        val response =
+            controller.updateHousehold(householdId = testHouseholdRequest.id!!, household = testHouseholdRequest)
 
-        assertThat(response.data).isEqualTo(testHousehold)
-        verify { householdService.updateHousehold(testHousehold.id!!, testHousehold, false, isSupervisor) }
+        assertThat(response.data).isEqualTo(testHouseholdResponse)
+        verify { householdService.updateHousehold(testHouseholdRequest.id!!, testHouseholdRequest, false, isSupervisor) }
     }
 
     @Test
     fun `get household - doesnt exist`() {
-        every { householdService.findByHouseholdId(testHousehold.id!!) } returns null
+        every { householdService.findByHouseholdId(testHouseholdResponse.id!!) } returns null
 
         val exception =
-            assertThrows<NotFoundException> { controller.getHousehold(testHousehold.id!!) }
+            assertThrows<NotFoundException> { controller.getHousehold(testHouseholdResponse.id!!) }
 
-        assertThat(exception.body.detail).isEqualTo("Kunde Nr. ${testHousehold.id} nicht gefunden!")
+        assertThat(exception.body.detail).isEqualTo("Kunde Nr. ${testHouseholdResponse.id} nicht gefunden!")
         assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
-        verify { householdService.findByHouseholdId(testHousehold.id!!) }
+        verify { householdService.findByHouseholdId(testHouseholdResponse.id!!) }
     }
 
     @Test
     fun `get household - exists`() {
-        every { householdService.findByHouseholdId(testHousehold.id!!) } returns testHousehold
+        every { householdService.findByHouseholdId(testHouseholdResponse.id!!) } returns testHouseholdResponse
 
-        val household = controller.getHousehold(testHousehold.id!!)
+        val household = controller.getHousehold(testHouseholdResponse.id!!)
 
-        verify { householdService.findByHouseholdId(testHousehold.id!!) }
-        assertThat(household).isEqualTo(testHousehold)
+        verify { householdService.findByHouseholdId(testHouseholdResponse.id!!) }
+        assertThat(household).isEqualTo(testHouseholdResponse)
     }
 
     @Test
     fun `delete household - doesnt exist`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns false
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns false
 
         val exception =
-            assertThrows<NotFoundException> { controller.deleteHousehold(testHousehold.id!!) }
+            assertThrows<NotFoundException> { controller.deleteHousehold(testHouseholdRequest.id!!) }
 
         assertThat(exception.body.detail).isEqualTo("Kunde Nr. 100 nicht vorhanden!")
         assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
-        verify { householdService.existsByHouseholdId(testHousehold.id!!) }
+        verify { householdService.existsByHouseholdId(testHouseholdRequest.id!!) }
     }
 
     @Test
     fun `delete household - exists`() {
-        every { householdService.existsByHouseholdId(testHousehold.id!!) } returns true
+        every { householdService.existsByHouseholdId(testHouseholdRequest.id!!) } returns true
 
-        val response = controller.deleteHousehold(testHousehold.id!!)
+        val response = controller.deleteHousehold(testHouseholdRequest.id!!)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
-        verify { householdService.existsByHouseholdId(testHousehold.id!!) }
+        verify { householdService.existsByHouseholdId(testHouseholdRequest.id!!) }
     }
 
     @Test
     fun `get households - mapped correctly`() {
         val testSearchResult = HouseholdSearchResult(
-            items = listOf(testHousehold),
+            items = listOf(testHouseholdResponse),
             totalCount = 123,
             currentPage = 2,
             totalPages = 10,
@@ -355,7 +374,7 @@ class HouseholdControllerTest {
     @Test
     fun `get households - all filters default when omitted`() {
         val testSearchResult = HouseholdSearchResult(
-            items = listOf(testHousehold),
+            items = listOf(testHouseholdResponse),
             totalCount = 123,
             currentPage = 1,
             totalPages = 10,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdResponseModelTest.kt
@@ -1,14 +1,14 @@
 package at.wrk.tafel.admin.backend.modules.household
 
 import at.wrk.tafel.admin.backend.common.validation.BeanValidationTestSupport.validator
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class HouseholdResponseModelTest {
 
-    private val country = Country(id = 1, code = "AT", name = "Austria")
+    private val country = CountryItem(id = 1, code = "AT", name = "Austria")
 
     private fun validAddress() = HouseholdAddress(
         street = "Street",
@@ -53,8 +53,8 @@ class HouseholdResponseModelTest {
     }
 
     @Test
-    fun `household with invalid email is invalid`() {
-        val household = Household(address = validAddress(), email = "not-an-email")
+    fun `household request with invalid email is invalid`() {
+        val household = HouseholdRequest(address = validAddress(), email = "not-an-email")
 
         val violations = validator.validate(household)
 
@@ -63,8 +63,8 @@ class HouseholdResponseModelTest {
     }
 
     @Test
-    fun `household cascades into address and persons`() {
-        val household = Household(
+    fun `household request cascades into address and persons`() {
+        val household = HouseholdRequest(
             address = HouseholdAddress(street = "", houseNumber = "1", postalCode = 1010, city = "Vienna"),
             persons = listOf(validPerson().copy(firstname = "")),
         )
@@ -76,8 +76,8 @@ class HouseholdResponseModelTest {
     }
 
     @Test
-    fun `household with valid values is valid`() {
-        val household = Household(address = validAddress(), email = "test@example.com", persons = listOf(validPerson()))
+    fun `household request with valid values is valid`() {
+        val household = HouseholdRequest(address = validAddress(), email = "test@example.com", persons = listOf(validPerson()))
 
         val violations = validator.validate(household)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdDuplicationServiceTest.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.household.internal
 
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
-import at.wrk.tafel.admin.backend.modules.household.Household
+import at.wrk.tafel.admin.backend.modules.household.HouseholdResponse
 import at.wrk.tafel.admin.backend.modules.household.internal.converter.HouseholdConverter
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -37,22 +37,22 @@ internal class HouseholdDuplicationServiceTest {
         val totalCount = 100L
 
         val householdEntity1 = mockk<HouseholdEntity>(relaxed = true)
-        val household1 = mockk<Household>(relaxed = true)
+        val household1 = mockk<HouseholdResponse>(relaxed = true)
         every { householdRepository.findByHouseholdId(1) } returns householdEntity1
         every { householdConverter.mapEntityToHousehold(householdEntity1) } returns household1
 
         val householdEntity2 = mockk<HouseholdEntity>(relaxed = true)
-        val household2 = mockk<Household>(relaxed = true)
+        val household2 = mockk<HouseholdResponse>(relaxed = true)
         every { householdRepository.findByHouseholdId(2) } returns householdEntity2
         every { householdConverter.mapEntityToHousehold(householdEntity2) } returns household2
 
         val householdEntity3 = mockk<HouseholdEntity>(relaxed = true)
-        val household3 = mockk<Household>(relaxed = true)
+        val household3 = mockk<HouseholdResponse>(relaxed = true)
         every { householdRepository.findByHouseholdId(3) } returns householdEntity3
         every { householdConverter.mapEntityToHousehold(householdEntity3) } returns household3
 
         val householdEntity4 = mockk<HouseholdEntity>(relaxed = true)
-        val household4 = mockk<Household>(relaxed = true)
+        val household4 = mockk<HouseholdResponse>(relaxed = true)
         every { householdRepository.findByHouseholdId(4) } returns householdEntity4
         every { householdConverter.mapEntityToHousehold(householdEntity4) } returns household4
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
@@ -6,13 +6,14 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
 import at.wrk.tafel.admin.backend.modules.base.exception.ConflictException
-import at.wrk.tafel.admin.backend.modules.household.Household
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAddress
 import at.wrk.tafel.admin.backend.modules.household.HouseholdCreationResponse
 import at.wrk.tafel.admin.backend.modules.household.HouseholdPdfType
+import at.wrk.tafel.admin.backend.modules.household.HouseholdRequest
+import at.wrk.tafel.admin.backend.modules.household.HouseholdResponse
 import at.wrk.tafel.admin.backend.modules.household.HouseholdUpdateResponse
 import at.wrk.tafel.admin.backend.modules.household.Person
 import at.wrk.tafel.admin.backend.modules.household.internal.converter.HouseholdConverter
@@ -66,7 +67,7 @@ class HouseholdServiceTest {
     @InjectMockKs
     private lateinit var service: HouseholdService
 
-    private val testCountry = Country(id = testCountry1.id!!, code = testCountry1.code!!, name = testCountry1.name!!)
+    private val testCountry = CountryItem(id = testCountry1.id!!, code = testCountry1.code!!, name = testCountry1.name!!)
 
     @BeforeEach
     fun beforeEach() {
@@ -85,7 +86,7 @@ class HouseholdServiceTest {
 
     @Test
     fun `validate household`() {
-        val testHousehold = Household(
+        val testHousehold = HouseholdRequest(
             id = 100,
             address = HouseholdAddress(
                 street = "street",
@@ -206,7 +207,7 @@ class HouseholdServiceTest {
         val testHouseholdEntity = mockk<HouseholdEntity>(relaxed = true)
         every { householdRepository.findByHouseholdId(any()) } returns testHouseholdEntity
 
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHousehold = mockk<HouseholdResponse>(relaxed = true)
         every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHousehold
 
         val household = service.findByHouseholdId(1)
@@ -216,12 +217,13 @@ class HouseholdServiceTest {
 
     @Test
     fun `create household writes the household first and points it at its main person afterwards`() {
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHouseholdRequest = mockk<HouseholdRequest>(relaxed = true)
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
         val mainPerson = PersonEntity().apply { isMainPerson = true }
         val testHouseholdEntity = HouseholdEntity().apply { persons = mutableListOf(mainPerson) }
 
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHousehold
-        every { householdConverter.mapHouseholdToEntity(testHousehold) } returns testHouseholdEntity
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
+        every { householdConverter.mapHouseholdToEntity(testHouseholdRequest) } returns testHouseholdEntity
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
             valid = true,
@@ -231,22 +233,23 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val result = service.createHousehold(testHousehold, force = false, isSupervisor = false)
+        val result = service.createHousehold(testHouseholdRequest, force = false, isSupervisor = false)
 
-        assertThat(result).isEqualTo(HouseholdCreationResponse(data = testHousehold, errorMsg = null))
+        assertThat(result).isEqualTo(HouseholdCreationResponse(data = testHouseholdResponse, errorMsg = null))
         assertThat(testHouseholdEntity.mainPerson).isEqualTo(mainPerson)
 
         verify(exactly = 2) { householdRepository.saveAndFlush(any()) }
-        verify(exactly = 1) { householdConverter.mapHouseholdToEntity(testHousehold) }
+        verify(exactly = 1) { householdConverter.mapHouseholdToEntity(testHouseholdRequest) }
     }
 
     @Test
     fun `create household - supervisor with invalid income and force=true should save`() {
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHouseholdRequest = mockk<HouseholdRequest>(relaxed = true)
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
         val testHouseholdEntity = HouseholdEntity()
 
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHousehold
-        every { householdConverter.mapHouseholdToEntity(testHousehold) } returns testHouseholdEntity
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
+        every { householdConverter.mapHouseholdToEntity(testHouseholdRequest) } returns testHouseholdEntity
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -257,20 +260,21 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val result = service.createHousehold(testHousehold, true, true)
+        val result = service.createHousehold(testHouseholdRequest, true, true)
 
-        assertThat(result).isEqualTo(HouseholdCreationResponse(data = testHousehold, errorMsg = null))
+        assertThat(result).isEqualTo(HouseholdCreationResponse(data = testHouseholdResponse, errorMsg = null))
         verify(exactly = 2) { householdRepository.saveAndFlush(testHouseholdEntity) }
-        verify(exactly = 1) { householdConverter.mapHouseholdToEntity(testHousehold) }
+        verify(exactly = 1) { householdConverter.mapHouseholdToEntity(testHouseholdRequest) }
     }
 
     @Test
     fun `create household - supervisor with invalid income and force=false should throw exception`() {
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHouseholdRequest = mockk<HouseholdRequest>(relaxed = true)
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
         val testHouseholdEntity = HouseholdEntity()
 
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHousehold
-        every { householdConverter.mapHouseholdToEntity(testHousehold) } returns testHouseholdEntity
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
+        every { householdConverter.mapHouseholdToEntity(testHouseholdRequest) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
             valid = false,
@@ -281,7 +285,7 @@ class HouseholdServiceTest {
         )
 
         val exception = assertThrows<ConflictException> {
-            service.createHousehold(testHousehold, false, true)
+            service.createHousehold(testHouseholdRequest, false, true)
         }
 
         assertThat(exception.body.detail).isEqualTo("Einkommen befindet sich über dem Limit (Toleranz wurde bereits berücksichtigt)")
@@ -291,11 +295,12 @@ class HouseholdServiceTest {
 
     @Test
     fun `create household - non-supervisor with invalid income should set validUntil to yesterday`() {
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHouseholdRequest = mockk<HouseholdRequest>(relaxed = true)
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
         val testHouseholdEntity = HouseholdEntity()
 
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHousehold
-        every { householdConverter.mapHouseholdToEntity(testHousehold) } returns testHouseholdEntity
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
+        every { householdConverter.mapHouseholdToEntity(testHouseholdRequest) } returns testHouseholdEntity
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -306,11 +311,11 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("4"),
         )
 
-        val result = service.createHousehold(testHousehold, force = false, isSupervisor = false)
+        val result = service.createHousehold(testHouseholdRequest, force = false, isSupervisor = false)
 
         assertThat(result).isEqualTo(
             HouseholdCreationResponse(
-                data = testHousehold,
+                data = testHouseholdResponse,
                 errorMsg = "Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet",
             ),
         )
@@ -322,8 +327,9 @@ class HouseholdServiceTest {
     fun `update household is valid`() {
         val householdId = 123L
 
-        val testHouseholdUpdate = mockk<Household>(relaxed = true)
+        val testHouseholdUpdate = mockk<HouseholdRequest>(relaxed = true)
         every { testHouseholdUpdate.id } returns householdId
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
 
         val existingMainPerson = PersonEntity().apply {
             id = 555
@@ -332,7 +338,7 @@ class HouseholdServiceTest {
         val testHouseholdEntity = HouseholdEntity().apply { persons = mutableListOf(existingMainPerson) }
         every { householdRepository.getReferenceByHouseholdId(householdId) } returns testHouseholdEntity
         every { householdConverter.mapHouseholdToEntity(any(), any()) } returns testHouseholdEntity
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdUpdate
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -346,7 +352,7 @@ class HouseholdServiceTest {
         val force = false
         val result = service.updateHousehold(testHouseholdUpdate.id!!, testHouseholdUpdate, force, false)
 
-        assertThat(result).isEqualTo(HouseholdUpdateResponse(data = testHouseholdUpdate, errorMsg = null))
+        assertThat(result).isEqualTo(HouseholdUpdateResponse(data = testHouseholdResponse, errorMsg = null))
         // the main person row already exists, so no second write is necessary
         verify(exactly = 1) { householdRepository.saveAndFlush(testHouseholdEntity) }
         assertThat(testHouseholdEntity.mainPerson).isEqualTo(existingMainPerson)
@@ -357,13 +363,14 @@ class HouseholdServiceTest {
     fun `update household is invalid and should set validUntil to yesterday when not supervisor`() {
         val householdId = 123L
 
-        val testHouseholdUpdate = mockk<Household>(relaxed = true)
+        val testHouseholdUpdate = mockk<HouseholdRequest>(relaxed = true)
         every { testHouseholdUpdate.id } returns householdId
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
 
         val testHouseholdEntity = HouseholdEntity()
         every { householdRepository.getReferenceByHouseholdId(householdId) } returns testHouseholdEntity
         every { householdConverter.mapHouseholdToEntity(any(), any()) } returns testHouseholdEntity
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdUpdate
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -379,7 +386,7 @@ class HouseholdServiceTest {
 
         assertThat(result).isEqualTo(
             HouseholdUpdateResponse(
-                data = testHouseholdUpdate,
+                data = testHouseholdResponse,
                 errorMsg = "Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet",
             ),
         )
@@ -391,7 +398,7 @@ class HouseholdServiceTest {
     fun `update household - supervisor with invalid income and force=false should throw exception`() {
         val householdId = 123L
 
-        val testHouseholdUpdate = mockk<Household>(relaxed = true)
+        val testHouseholdUpdate = mockk<HouseholdRequest>(relaxed = true)
         every { testHouseholdUpdate.id } returns householdId
 
         val testHouseholdEntity = HouseholdEntity()
@@ -419,16 +426,17 @@ class HouseholdServiceTest {
     fun `update household with force=true when supervisor tries to bypass validation`() {
         val householdId = 123L
 
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHousehold = mockk<HouseholdRequest>(relaxed = true)
         every { testHousehold.id } returns householdId
 
-        val testHouseholdUpdate = mockk<Household>(relaxed = true)
+        val testHouseholdUpdate = mockk<HouseholdRequest>(relaxed = true)
         every { testHouseholdUpdate.id } returns householdId
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
 
         val testHouseholdEntity = HouseholdEntity()
         every { householdRepository.getReferenceByHouseholdId(householdId) } returns testHouseholdEntity
         every { householdConverter.mapHouseholdToEntity(any(), any()) } returns testHouseholdEntity
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdUpdate
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -441,7 +449,7 @@ class HouseholdServiceTest {
 
         val result = service.updateHousehold(testHousehold.id!!, testHouseholdUpdate, true, true)
 
-        assertThat(result).isEqualTo(HouseholdUpdateResponse(data = testHouseholdUpdate, errorMsg = null))
+        assertThat(result).isEqualTo(HouseholdUpdateResponse(data = testHouseholdResponse, errorMsg = null))
         verify(exactly = 1) { householdConverter.mapHouseholdToEntity(any(), any()) }
     }
 
@@ -450,7 +458,7 @@ class HouseholdServiceTest {
         val testHouseholdEntity1 = mockk<HouseholdEntity>(relaxed = true)
         val testHouseholdEntity2 = mockk<HouseholdEntity>(relaxed = true)
 
-        val testHousehold = mockk<Household>(relaxed = true)
+        val testHousehold = mockk<HouseholdResponse>(relaxed = true)
         every { householdConverter.mapEntityToHousehold(any()) } returns testHousehold
 
         val selectedPage = 3
@@ -478,8 +486,8 @@ class HouseholdServiceTest {
         val testHouseholdEntity1 = mockk<HouseholdEntity>(relaxed = true)
         val testHouseholdEntity2 = mockk<HouseholdEntity>(relaxed = true)
 
-        val validHousehold = mockk<Household>(relaxed = true)
-        val invalidHousehold = mockk<Household>(relaxed = true)
+        val validHousehold = mockk<HouseholdResponse>(relaxed = true)
+        val invalidHousehold = mockk<HouseholdResponse>(relaxed = true)
 
         every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns listOf(
             testHouseholdEntity1,
@@ -521,7 +529,7 @@ class HouseholdServiceTest {
     @Test
     fun `get households above limit - paginates the computed result`() {
         val testHouseholdEntities = (1..30).map { mockk<HouseholdEntity>(relaxed = true) }
-        val invalidHouseholds = (1..30).map { mockk<Household>(relaxed = true) }
+        val invalidHouseholds = (1..30).map { mockk<HouseholdResponse>(relaxed = true) }
 
         every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns testHouseholdEntities
         testHouseholdEntities.forEachIndexed { index, entity ->
@@ -634,15 +642,16 @@ class HouseholdServiceTest {
     fun `update household with force=true when non-supervisor should still set validUntil to yesterday`() {
         val householdId = 123L
 
-        val testHouseholdUpdate = mockk<Household>(relaxed = true)
+        val testHouseholdUpdate = mockk<HouseholdRequest>(relaxed = true)
         every { testHouseholdUpdate.id } returns householdId
+        val testHouseholdResponse = mockk<HouseholdResponse>(relaxed = true)
 
         val testHouseholdEntity = HouseholdEntity().apply {
             validUntil = LocalDate.now()
         }
         every { householdRepository.getReferenceByHouseholdId(householdId) } returns testHouseholdEntity
         every { householdConverter.mapHouseholdToEntity(any(), any()) } returns testHouseholdEntity
-        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdUpdate
+        every { householdConverter.mapEntityToHousehold(testHouseholdEntity) } returns testHouseholdResponse
         every { householdRepository.saveAndFlush(any()) } returns testHouseholdEntity
 
         every { incomeValidatorService.validate(any()) } returns IncomeValidatorResult(
@@ -658,7 +667,7 @@ class HouseholdServiceTest {
 
         assertThat(result).isEqualTo(
             HouseholdUpdateResponse(
-                data = testHouseholdUpdate,
+                data = testHouseholdResponse,
                 errorMsg = "Kunde wurde als ungültig gespeichert da sich das Einkommen über dem Limit befindet",
             ),
         )

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverterTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/converter/HouseholdConverterTest.kt
@@ -8,11 +8,11 @@ import at.wrk.tafel.admin.backend.database.model.household.HouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.person.PersonRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.CountryRepository
-import at.wrk.tafel.admin.backend.modules.base.country.Country
+import at.wrk.tafel.admin.backend.modules.base.country.CountryItem
 import at.wrk.tafel.admin.backend.modules.base.country.testCountry1
-import at.wrk.tafel.admin.backend.modules.household.Household
 import at.wrk.tafel.admin.backend.modules.household.HouseholdAddress
 import at.wrk.tafel.admin.backend.modules.household.HouseholdIssuer
+import at.wrk.tafel.admin.backend.modules.household.HouseholdRequest
 import at.wrk.tafel.admin.backend.modules.household.Person
 import at.wrk.tafel.admin.backend.modules.household.PersonGender
 import at.wrk.tafel.admin.backend.security.testUser
@@ -53,7 +53,7 @@ internal class HouseholdConverterTest {
     @InjectMockKs
     private lateinit var converter: HouseholdConverter
 
-    private val testCountry = Country(
+    private val testCountry = CountryItem(
         id = 1,
         code = "AT",
         name = "Österreich",
@@ -72,7 +72,7 @@ internal class HouseholdConverterTest {
         incomeDue = LocalDate.now(),
     )
 
-    private val testHousehold = Household(
+    private val testHousehold = HouseholdRequest(
         id = 100,
         issuer = HouseholdIssuer(
             personnelNumber = "test-personnelnumber",
@@ -278,7 +278,7 @@ internal class HouseholdConverterTest {
         assertThat(mainPerson.employer).isEqualTo("Employer 123")
         assertThat(mainPerson.income).isEqualTo(BigDecimal("1000"))
         assertThat(mainPerson.country).isEqualTo(
-            Country(
+            CountryItem(
                 id = testCountry1.id!!,
                 code = testCountry1.code!!,
                 name = testCountry1.name!!,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/CarsControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/CarsControllerTest.kt
@@ -1,9 +1,10 @@
 package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.CarService
-import at.wrk.tafel.admin.backend.modules.logistics.model.Car
 import at.wrk.tafel.admin.backend.modules.logistics.model.CarListResponse
 import at.wrk.tafel.admin.backend.modules.logistics.model.CarReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -25,8 +26,8 @@ class CarsControllerTest {
 
     @Test
     fun `get active cars`() {
-        val car1 = Car(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
-        val car2 = Car(id = 2, licensePlate = "456", name = "Car 456", enabled = true, sortOrder = 2)
+        val car1 = CarResponse(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
+        val car2 = CarResponse(id = 2, licensePlate = "456", name = "Car 456", enabled = true, sortOrder = 2)
 
         every { carService.getActiveCars() } returns listOf(car1, car2)
 
@@ -38,8 +39,8 @@ class CarsControllerTest {
 
     @Test
     fun `get all cars`() {
-        val car1 = Car(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
-        val car2 = Car(id = 2, licensePlate = "456", name = "Car 456", enabled = false, sortOrder = 2)
+        val car1 = CarResponse(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
+        val car2 = CarResponse(id = 2, licensePlate = "456", name = "Car 456", enabled = false, sortOrder = 2)
 
         every { carService.getAllCars() } returns listOf(car1, car2)
 
@@ -51,14 +52,21 @@ class CarsControllerTest {
 
     @Test
     fun `update car`() {
-        val existingCar = Car(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
+        val existingCar = CarRequest(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 1)
         val updatedCar = existingCar.copy(licensePlate = "456", name = "Car 456", enabled = false)
+        val updatedResponse = CarResponse(
+            id = updatedCar.id,
+            licensePlate = updatedCar.licensePlate,
+            name = updatedCar.name,
+            enabled = updatedCar.enabled,
+            sortOrder = updatedCar.sortOrder,
+        )
 
-        every { carService.updateCar(any(), any()) } returns updatedCar
+        every { carService.updateCar(any(), any()) } returns updatedResponse
 
         val response = controller.updateCar(existingCar.id!!, updatedCar)
 
-        assertThat(response).isEqualTo(updatedCar)
+        assertThat(response).isEqualTo(updatedResponse)
         verify {
             carService.updateCar(existingCar.id, updatedCar)
         }
@@ -66,8 +74,8 @@ class CarsControllerTest {
 
     @Test
     fun `create car`() {
-        val newCar = Car(id = null, licensePlate = "New Plate", name = "New Car", enabled = true, sortOrder = 0)
-        val createdCar = newCar.copy(id = 42L, sortOrder = 1)
+        val newCar = CarRequest(id = null, licensePlate = "New Plate", name = "New Car", enabled = true, sortOrder = 0)
+        val createdCar = CarResponse(id = 42L, licensePlate = newCar.licensePlate, name = newCar.name, enabled = newCar.enabled, sortOrder = 1)
 
         every { carService.createCar(any()) } returns createdCar
 
@@ -82,7 +90,7 @@ class CarsControllerTest {
 
     @Test
     fun `reorder cars`() {
-        val car1 = Car(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 2)
+        val car1 = CarResponse(id = 1, licensePlate = "123", name = "Car 123", enabled = true, sortOrder = 2)
         val car2 = car1.copy(id = 2, name = "Car 456", sortOrder = 1)
         val request = CarReorderRequest(carIds = listOf(2L, 1L))
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCategoriesControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCategoriesControllerTest.kt
@@ -2,8 +2,9 @@ package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.FoodCategoryService
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoriesListResponse
-import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
 import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -26,8 +27,8 @@ class FoodCategoriesControllerTest {
 
     @Test
     fun `get active categories`() {
-        val category1 = testCategory(1)
-        val category2 = testCategory(2)
+        val category1 = testCategoryResponse(1)
+        val category2 = testCategoryResponse(2)
         every { foodCategoriesService.getActiveFoodCategories() } returns listOf(category1, category2)
 
         val categoriesListResponse = controller.getActiveFoodCategories()
@@ -39,8 +40,8 @@ class FoodCategoriesControllerTest {
 
     @Test
     fun `get all categories`() {
-        val category1 = testCategory(1)
-        val category2 = testCategory(2)
+        val category1 = testCategoryResponse(1)
+        val category2 = testCategoryResponse(2)
         every { foodCategoriesService.getAllFoodCategories() } returns listOf(category1, category2)
 
         val categoriesListResponse = controller.getAllFoodCategories()
@@ -52,8 +53,8 @@ class FoodCategoriesControllerTest {
 
     @Test
     fun `create category`() {
-        val newCategory = testCategory(null)
-        val createdCategory = newCategory.copy(id = 42L)
+        val newCategory = testCategoryRequest(null)
+        val createdCategory = testCategoryResponse(42)
 
         every { foodCategoriesService.createFoodCategory(any()) } returns createdCategory
 
@@ -66,20 +67,21 @@ class FoodCategoriesControllerTest {
 
     @Test
     fun `update category`() {
-        val updatedCategory = testCategory(1)
+        val updatedRequest = testCategoryRequest(1)
+        val updatedResponse = testCategoryResponse(1)
 
-        every { foodCategoriesService.updateFoodCategory(any(), any()) } returns updatedCategory
+        every { foodCategoriesService.updateFoodCategory(any(), any()) } returns updatedResponse
 
-        val response = controller.updateFoodCategory(1L, updatedCategory)
+        val response = controller.updateFoodCategory(1L, updatedRequest)
 
-        assertThat(response).isEqualTo(updatedCategory)
-        verify { foodCategoriesService.updateFoodCategory(1L, updatedCategory) }
+        assertThat(response).isEqualTo(updatedResponse)
+        verify { foodCategoriesService.updateFoodCategory(1L, updatedRequest) }
     }
 
     @Test
     fun `reorder categories`() {
-        val category1 = testCategory(1)
-        val category2 = testCategory(2)
+        val category1 = testCategoryResponse(1)
+        val category2 = testCategoryResponse(2)
         val request = FoodCategoryReorderRequest(categoryIds = listOf(2L, 1L))
 
         every { foodCategoriesService.reorderFoodCategories(request.categoryIds) } returns Unit
@@ -93,7 +95,16 @@ class FoodCategoriesControllerTest {
         verify { foodCategoriesService.reorderFoodCategories(request.categoryIds) }
     }
 
-    private fun testCategory(id: Long?) = FoodCategory(
+    private fun testCategoryRequest(id: Long?) = FoodCategoryRequest(
+        id = id,
+        name = "Category $id",
+        weightPerUnit = BigDecimal.TEN,
+        returnItem = false,
+        sortOrder = 10,
+        enabled = true,
+    )
+
+    private fun testCategoryResponse(id: Long?) = FoodCategoryResponse(
         id = id,
         name = "Category $id",
         weightPerUnit = BigDecimal.TEN,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCollectionsControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/FoodCollectionsControllerTest.kt
@@ -1,6 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.logistics
 
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import at.wrk.tafel.admin.backend.modules.logistics.internal.FoodCollectionService
 import at.wrk.tafel.admin.backend.modules.logistics.model.*
 import io.mockk.every
@@ -25,16 +25,16 @@ class FoodCollectionsControllerTest {
     @Test
     fun `get food collection`() {
         val routeId = 456L
-        val testFoodCollectionData = FoodCollectionData(
+        val testFoodCollectionData = FoodCollectionResponse(
             routeId = routeId,
             carId = 1,
-            driver = Employee(
+            driver = EmployeeResponse(
                 id = 1,
                 personnelNumber = "111",
                 firstname = "employee firstname 1",
                 lastname = "employee lastname 1",
             ),
-            coDriver = Employee(
+            coDriver = EmployeeResponse(
                 id = 2,
                 personnelNumber = "222",
                 firstname = "employee firstname 2",
@@ -73,7 +73,7 @@ class FoodCollectionsControllerTest {
     @Test
     fun `saves route data`() {
         val routeId = 123L
-        val request = FoodCollectionSaveRouteData(
+        val request = FoodCollectionSaveRouteRequest(
             carId = 1,
             driverId = 1,
             coDriverId = 2,
@@ -89,7 +89,7 @@ class FoodCollectionsControllerTest {
     @Test
     fun `save items`() {
         val routeId = 123L
-        val request = FoodCollectionItems(
+        val request = FoodCollectionItemsRequest(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = 1,
@@ -108,7 +108,7 @@ class FoodCollectionsControllerTest {
     fun `save items per shop`() {
         val routeId = 123L
         val shopId = 456L
-        val request = FoodCollectionSaveItemsPerShopData(
+        val request = FoodCollectionSaveItemsPerShopRequest(
             items = listOf(
                 FoodCollectionCategoryAmount(
                     categoryId = 1,
@@ -126,7 +126,7 @@ class FoodCollectionsControllerTest {
     fun `get items per shop`() {
         val routeId = 123L
         val shopId = 456L
-        val responseBody = FoodCollectionItems(
+        val responseBody = FoodCollectionItemsResponse(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = 1,
@@ -161,7 +161,7 @@ class FoodCollectionsControllerTest {
     @Test
     fun `patch a single item`() {
         val routeId = 123L
-        val request = FoodCollectionItem(
+        val request = FoodCollectionItemRequest(
             categoryId = 1,
             shopId = 2,
             amount = 3,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/RouteControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/RouteControllerTest.kt
@@ -2,10 +2,10 @@ package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.RouteService
 import at.wrk.tafel.admin.backend.modules.logistics.internal.ShopService
-import at.wrk.tafel.admin.backend.modules.logistics.model.Route
+import at.wrk.tafel.admin.backend.modules.logistics.model.RouteItem
 import at.wrk.tafel.admin.backend.modules.logistics.model.RouteListResponse
 import at.wrk.tafel.admin.backend.modules.logistics.model.RouteShopsResponse
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shop
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShopItem
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -28,11 +28,11 @@ class RouteControllerTest {
 
     @Test
     fun `get routes`() {
-        val route1 = Route(
+        val route1 = RouteItem(
             id = 1,
             name = "Route 1",
         )
-        val route2 = Route(
+        val route2 = RouteItem(
             id = 2,
             name = "Route 2",
         )
@@ -54,8 +54,8 @@ class RouteControllerTest {
     fun `get shops of route`() {
         val routeId = testRoute1.id!!
         val shopList = listOf(
-            Shop(id = 1, number = 111, name = "Billa", address = "Street 1, 1010 City"),
-            Shop(id = 2, number = 222, name = "Hofer", address = "Street 2, 1020 City"),
+            ShopItem(id = 1, number = 111, name = "Billa", address = "Street 1, 1010 City"),
+            ShopItem(id = 2, number = 222, name = "Hofer", address = "Street 2, 1020 City"),
         )
         every { shopService.getShopsForRouteId(routeId) } returns shopList
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/SheltersControllerTest.kt
@@ -1,9 +1,10 @@
 package at.wrk.tafel.admin.backend.modules.logistics
 
 import at.wrk.tafel.admin.backend.modules.logistics.internal.ShelterService
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterListResponse
 import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterReorderRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -25,7 +26,7 @@ class SheltersControllerTest {
 
     @Test
     fun `get active shelters`() {
-        val shelter1 = Shelter(
+        val shelter1 = ShelterResponse(
             id = 1,
             name = "Shelter 1",
             addressStreet = "Street",
@@ -52,7 +53,7 @@ class SheltersControllerTest {
 
     @Test
     fun `get all shelters`() {
-        val shelter1 = Shelter(
+        val shelter1 = ShelterResponse(
             id = 1,
             name = "Shelter 1",
             addressStreet = "Street",
@@ -79,7 +80,7 @@ class SheltersControllerTest {
 
     @Test
     fun `update shelter`() {
-        val existingShelter = Shelter(
+        val existingShelter = ShelterRequest(
             id = 1,
             name = "Shelter 1",
             addressStreet = "Street",
@@ -94,7 +95,7 @@ class SheltersControllerTest {
             sortOrder = 1,
             contacts = emptyList(),
         )
-        val updatedShelter = Shelter(
+        val updatedShelter = ShelterRequest(
             id = 1,
             name = "Shelter 2",
             addressStreet = "Street X",
@@ -109,11 +110,26 @@ class SheltersControllerTest {
             sortOrder = 1,
             contacts = emptyList(),
         )
-        every { service.updateShelter(any(), any()) } returns updatedShelter
+        val updatedResponse = ShelterResponse(
+            id = updatedShelter.id,
+            name = updatedShelter.name,
+            addressStreet = updatedShelter.addressStreet,
+            addressHouseNumber = updatedShelter.addressHouseNumber,
+            addressStairway = updatedShelter.addressStairway,
+            addressPostalCode = updatedShelter.addressPostalCode,
+            addressDoor = updatedShelter.addressDoor,
+            addressCity = updatedShelter.addressCity,
+            note = updatedShelter.note,
+            personsCount = updatedShelter.personsCount,
+            enabled = updatedShelter.enabled,
+            sortOrder = updatedShelter.sortOrder,
+            contacts = updatedShelter.contacts,
+        )
+        every { service.updateShelter(any(), any()) } returns updatedResponse
 
         val response = controller.updateShelter(existingShelter.id!!, updatedShelter)
 
-        assertThat(response).isEqualTo(updatedShelter)
+        assertThat(response).isEqualTo(updatedResponse)
         verify {
             service.updateShelter(existingShelter.id, updatedShelter)
         }
@@ -121,7 +137,7 @@ class SheltersControllerTest {
 
     @Test
     fun `create shelter`() {
-        val newShelter = Shelter(
+        val newShelter = ShelterRequest(
             id = 0L,
             name = "New Shelter",
             addressStreet = "New Street",
@@ -137,7 +153,21 @@ class SheltersControllerTest {
             contacts = emptyList(),
         )
 
-        val createdShelter = newShelter.copy(id = 42L, sortOrder = 1)
+        val createdShelter = ShelterResponse(
+            id = 42L,
+            name = newShelter.name,
+            addressStreet = newShelter.addressStreet,
+            addressHouseNumber = newShelter.addressHouseNumber,
+            addressStairway = newShelter.addressStairway,
+            addressPostalCode = newShelter.addressPostalCode,
+            addressDoor = newShelter.addressDoor,
+            addressCity = newShelter.addressCity,
+            note = newShelter.note,
+            personsCount = newShelter.personsCount,
+            enabled = newShelter.enabled,
+            sortOrder = 1,
+            contacts = newShelter.contacts,
+        )
 
         every { service.createShelter(any()) } returns createdShelter
 
@@ -152,7 +182,7 @@ class SheltersControllerTest {
 
     @Test
     fun `reorder shelters`() {
-        val shelter1 = Shelter(
+        val shelter1 = ShelterResponse(
             id = 1,
             name = "Shelter 1",
             addressStreet = "Street",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/CarServiceTest.kt
@@ -3,7 +3,8 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.CarEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.CarRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Car
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.CarResponse
 import at.wrk.tafel.admin.backend.modules.logistics.testCar1
 import at.wrk.tafel.admin.backend.modules.logistics.testCar2
 import io.mockk.every
@@ -34,7 +35,7 @@ class CarServiceTest {
 
         assertThat(cars).hasSize(2)
         assertThat(cars.first()).isEqualTo(
-            Car(
+            CarResponse(
                 id = testCar1.id!!,
                 licensePlate = testCar1.licensePlate!!,
                 name = testCar1.name!!,
@@ -52,7 +53,7 @@ class CarServiceTest {
 
         assertThat(cars).hasSize(2)
         assertThat(cars.first()).isEqualTo(
-            Car(
+            CarResponse(
                 id = testCar1.id!!,
                 licensePlate = testCar1.licensePlate!!,
                 name = testCar1.name!!,
@@ -71,7 +72,7 @@ class CarServiceTest {
             enabled = true
             sortOrder = 1
         }
-        val updated = Car(
+        val updated = CarRequest(
             id = existingEntity.id!!,
             licensePlate = "Updated Plate",
             name = "Updated Car",
@@ -84,7 +85,15 @@ class CarServiceTest {
 
         val result = service.updateCar(existingEntity.id!!, updated)
 
-        assertThat(result).isEqualTo(updated)
+        assertThat(result).isEqualTo(
+            CarResponse(
+                id = updated.id,
+                licensePlate = updated.licensePlate,
+                name = updated.name,
+                enabled = updated.enabled,
+                sortOrder = updated.sortOrder,
+            ),
+        )
     }
 
     @Test
@@ -94,7 +103,7 @@ class CarServiceTest {
         val exception = assertThrows<NotFoundException> {
             service.updateCar(
                 99L,
-                Car(id = 99L, licensePlate = "X", name = "X", enabled = true, sortOrder = 1),
+                CarRequest(id = 99L, licensePlate = "X", name = "X", enabled = true, sortOrder = 1),
             )
         }
         assertThat(exception.body.detail).isEqualTo("Car with id 99 not found")
@@ -102,7 +111,7 @@ class CarServiceTest {
 
     @Test
     fun `create car assigns next sort order after the current max, ignoring the input value`() {
-        val createInput = Car(
+        val createInput = CarRequest(
             id = null,
             licensePlate = "New Plate",
             name = "New Car",
@@ -120,7 +129,7 @@ class CarServiceTest {
         val result = service.createCar(createInput)
 
         assertThat(result).isEqualTo(
-            Car(
+            CarResponse(
                 id = 42L,
                 licensePlate = createInput.licensePlate,
                 name = createInput.name,
@@ -132,7 +141,7 @@ class CarServiceTest {
 
     @Test
     fun `create car assigns sort order 1 when no cars exist yet`() {
-        val createInput = Car(
+        val createInput = CarRequest(
             id = null,
             licensePlate = "New Plate",
             name = "New Car",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCategoryServiceTest.kt
@@ -3,7 +3,8 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.FoodCategoryRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategory
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.FoodCategoryResponse
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory1
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory2
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory3
@@ -39,7 +40,7 @@ class FoodCategoryServiceTest {
 
         assertThat(categories).isEqualTo(
             listOf(
-                FoodCategory(
+                FoodCategoryResponse(
                     id = category3.id,
                     name = category3.name!!,
                     weightPerUnit = category3.weightPerUnit,
@@ -47,7 +48,7 @@ class FoodCategoryServiceTest {
                     sortOrder = category3.sortOrder!!,
                     enabled = category3.enabled!!,
                 ),
-                FoodCategory(
+                FoodCategoryResponse(
                     id = category1.id,
                     name = category1.name!!,
                     weightPerUnit = category1.weightPerUnit,
@@ -55,7 +56,7 @@ class FoodCategoryServiceTest {
                     sortOrder = category1.sortOrder!!,
                     enabled = category1.enabled!!,
                 ),
-                FoodCategory(
+                FoodCategoryResponse(
                     id = category2.id,
                     name = category2.name!!,
                     weightPerUnit = category2.weightPerUnit,
@@ -90,7 +91,7 @@ class FoodCategoryServiceTest {
 
     @Test
     fun `create category assigns next sort order after the current max, ignoring the input value`() {
-        val createInput = FoodCategory(
+        val createInput = FoodCategoryRequest(
             id = null,
             name = "New Category",
             weightPerUnit = BigDecimal("15"),
@@ -111,14 +112,23 @@ class FoodCategoryServiceTest {
         // testFoodCategory2 is a return-item ("Kisten") fixture and must be ignored when
         // computing the next order - only testFoodCategory1 (sortOrder 200) and
         // testFoodCategory3 (sortOrder 100) count, so the next value is 201.
-        assertThat(result).isEqualTo(createInput.copy(id = 42L, sortOrder = 201))
+        assertThat(result).isEqualTo(
+            FoodCategoryResponse(
+                id = 42L,
+                name = createInput.name,
+                weightPerUnit = createInput.weightPerUnit,
+                returnItem = createInput.returnItem,
+                sortOrder = 201,
+                enabled = createInput.enabled,
+            ),
+        )
 
         verify { foodCategoryRepository.save(any()) }
     }
 
     @Test
     fun `create category assigns sort order 1 when no categories exist yet`() {
-        val createInput = FoodCategory(
+        val createInput = FoodCategoryRequest(
             id = null,
             name = "New Category",
             weightPerUnit = BigDecimal("15"),
@@ -149,7 +159,7 @@ class FoodCategoryServiceTest {
             sortOrder = 100
             enabled = true
         }
-        val updated = FoodCategory(
+        val updated = FoodCategoryRequest(
             id = existingEntity.id,
             name = "Updated Category",
             weightPerUnit = BigDecimal("99"),
@@ -163,14 +173,23 @@ class FoodCategoryServiceTest {
 
         val result = service.updateFoodCategory(existingEntity.id!!, updated)
 
-        assertThat(result).isEqualTo(updated)
+        assertThat(result).isEqualTo(
+            FoodCategoryResponse(
+                id = updated.id,
+                name = updated.name,
+                weightPerUnit = updated.weightPerUnit,
+                returnItem = updated.returnItem,
+                sortOrder = updated.sortOrder,
+                enabled = updated.enabled,
+            ),
+        )
     }
 
     @Test
     fun `update category throws exception when not found`() {
         every { foodCategoryRepository.findByIdOrNull(99L) } returns null
 
-        val updated = FoodCategory(
+        val updated = FoodCategoryRequest(
             id = 99L,
             name = "Updated Category",
             weightPerUnit = BigDecimal("99"),

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/FoodCollectionServiceTest.kt
@@ -6,7 +6,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.*
-import at.wrk.tafel.admin.backend.modules.base.employee.Employee
+import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeResponse
 import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee1
 import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee2
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
@@ -80,7 +80,7 @@ class FoodCollectionServiceTest {
 
         assertThat(data.carId).isEqualTo(testFoodCollectionRoute1Entity.car!!.id)
         assertThat(data.driver).isEqualTo(
-            Employee(
+            EmployeeResponse(
                 id = testFoodCollectionRoute1Entity.driver!!.id!!,
                 personnelNumber = testEmployee1.personnelNumber!!,
                 firstname = testEmployee1.firstname!!,
@@ -88,7 +88,7 @@ class FoodCollectionServiceTest {
             ),
         )
         assertThat(data.coDriver).isEqualTo(
-            Employee(
+            EmployeeResponse(
                 id = testFoodCollectionRoute1Entity.coDriver!!.id!!,
                 personnelNumber = testEmployee2.personnelNumber!!,
                 firstname = testEmployee2.firstname!!,
@@ -120,7 +120,7 @@ class FoodCollectionServiceTest {
         val routeId = 123L
         val driverId = 1L
         val coDriverId = 2L
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = testCar1.id!!,
             driverId = driverId,
             coDriverId = coDriverId,
@@ -140,7 +140,7 @@ class FoodCollectionServiceTest {
         val routeId = 123L
         val driverId = 1L
         val coDriverId = 2L
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = testCar1.id!!,
             driverId = driverId,
             coDriverId = coDriverId,
@@ -178,7 +178,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items with invalid route`() {
         val routeId = 123L
-        val data = FoodCollectionItems(
+        val data = FoodCollectionItemsRequest(
             items = emptyList(),
         )
         val activeDistribution = testDistributionEntity.apply { endedAt = null }
@@ -192,7 +192,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items`() {
         val routeId = 123L
-        val data = FoodCollectionItems(
+        val data = FoodCollectionItemsRequest(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = testFoodCategory1.id!!,
@@ -256,7 +256,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items per shop when current data is null`() {
         val routeId = 123L
-        val data = FoodCollectionSaveItemsPerShopData(
+        val data = FoodCollectionSaveItemsPerShopRequest(
             items = listOf(
                 FoodCollectionCategoryAmount(
                     categoryId = testFoodCategory1.id!!,
@@ -333,7 +333,7 @@ class FoodCollectionServiceTest {
         every { shopRepository.findByIdOrNull(testShop1.id!!) } returns testShop1
         every { shopRepository.findByIdOrNull(testShop2.id!!) } returns testShop2
 
-        val newData = FoodCollectionSaveItemsPerShopData(
+        val newData = FoodCollectionSaveItemsPerShopRequest(
             items = listOf(
                 FoodCollectionCategoryAmount(
                     categoryId = testFoodCategory2.id!!,
@@ -397,7 +397,7 @@ class FoodCollectionServiceTest {
         }
         distributionEntity.foodCollections = mutableListOf(existingFoodCollection)
 
-        val newData = FoodCollectionSaveItemsPerShopData(
+        val newData = FoodCollectionSaveItemsPerShopRequest(
             items = listOf(
                 FoodCollectionCategoryAmount(
                     categoryId = testFoodCategory1.id!!,
@@ -519,7 +519,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `patch a single item when current data is null`() {
         val routeId = 123L
-        val data = FoodCollectionItem(
+        val data = FoodCollectionItemRequest(
             categoryId = testFoodCategory1.id!!,
             shopId = testShop1.id!!,
             amount = 44,
@@ -575,7 +575,7 @@ class FoodCollectionServiceTest {
         }
         distributionEntity.foodCollections = mutableListOf(existingFoodCollection)
 
-        val newData = FoodCollectionItem(
+        val newData = FoodCollectionItemRequest(
             categoryId = testFoodCategory2.id!!,
             shopId = testShop2.id!!,
             amount = 22,
@@ -637,7 +637,7 @@ class FoodCollectionServiceTest {
         }
         distributionEntity.foodCollections = mutableListOf(existingFoodCollection)
 
-        val newAmount = FoodCollectionItem(
+        val newAmount = FoodCollectionItemRequest(
             categoryId = testFoodCategory1.id!!,
             shopId = testShop1.id!!,
             amount = 22,
@@ -691,7 +691,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `patch a single item with unknown route throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionItem(
+        val data = FoodCollectionItemRequest(
             categoryId = testFoodCategory1.id!!,
             shopId = testShop1.id!!,
             amount = 1,
@@ -710,7 +710,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `patch a single item with invalid category throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionItem(
+        val data = FoodCollectionItemRequest(
             categoryId = 999L,
             shopId = testShop1.id!!,
             amount = 1,
@@ -730,7 +730,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `patch a single item with invalid shop throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionItem(
+        val data = FoodCollectionItemRequest(
             categoryId = testFoodCategory1.id!!,
             shopId = 999L,
             amount = 1,
@@ -753,7 +753,7 @@ class FoodCollectionServiceTest {
         val routeId = testRoute1.id!!
         val driverId = testEmployee1.id!!
         val coDriverId = testEmployee2.id!!
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = testCar1.id!!,
             driverId = driverId,
             coDriverId = coDriverId,
@@ -790,7 +790,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save route data with invalid car throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = 999L,
             driverId = testEmployee1.id!!,
             coDriverId = testEmployee2.id!!,
@@ -814,7 +814,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save route data with invalid driver throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = testCar1.id!!,
             driverId = 999L,
             coDriverId = testEmployee2.id!!,
@@ -839,7 +839,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save route data with invalid coDriver throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionSaveRouteData(
+        val data = FoodCollectionSaveRouteRequest(
             carId = testCar1.id!!,
             driverId = testEmployee1.id!!,
             coDriverId = 999L,
@@ -865,7 +865,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items reuses the existing food collection for the route`() {
         val routeId = testRoute1.id!!
-        val data = FoodCollectionItems(
+        val data = FoodCollectionItemsRequest(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = testFoodCategory1.id!!,
@@ -903,7 +903,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items with invalid category throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionItems(
+        val data = FoodCollectionItemsRequest(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = 999L,
@@ -927,7 +927,7 @@ class FoodCollectionServiceTest {
     @Test
     fun `save items with invalid shop throws exception`() {
         val routeId = 123L
-        val data = FoodCollectionItems(
+        val data = FoodCollectionItemsRequest(
             items = listOf(
                 FoodCollectionItem(
                     categoryId = testFoodCategory1.id!!,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/RouteServiceTest.kt
@@ -1,7 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
-import at.wrk.tafel.admin.backend.modules.logistics.model.Route
+import at.wrk.tafel.admin.backend.modules.logistics.model.RouteItem
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute1
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute2
 import io.mockk.every
@@ -31,11 +31,11 @@ class RouteServiceTest {
 
         assertThat(routes).isEqualTo(
             listOf(
-                Route(
+                RouteItem(
                     id = route1.id!!,
                     name = route1.name!!,
                 ),
-                Route(
+                RouteItem(
                     id = route2.id!!,
                     name = route2.name!!,
                 ),

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShelterServiceTest.kt
@@ -3,8 +3,9 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.ShelterRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shelter
-import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContact
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterContactItem
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterRequest
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShelterResponse
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter1
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter2
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter3
@@ -37,7 +38,7 @@ class ShelterServiceTest {
 
         assertThat(shelters).hasSize(2)
         assertThat(shelters.first()).isEqualTo(
-            Shelter(
+            ShelterResponse(
                 id = testShelter1.id!!,
                 name = testShelter1.name!!,
                 addressStreet = testShelter1.addressStreet!!,
@@ -63,7 +64,7 @@ class ShelterServiceTest {
 
         assertThat(shelters).hasSize(2)
         assertThat(shelters.first()).isEqualTo(
-            Shelter(
+            ShelterResponse(
                 id = testShelter1.id!!,
                 name = testShelter1.name!!,
                 addressStreet = testShelter1.addressStreet!!,
@@ -83,7 +84,7 @@ class ShelterServiceTest {
 
     @Test
     fun `update shelter`() {
-        val updated = Shelter(
+        val updated = ShelterRequest(
             id = testShelter3.id!!,
             name = "Updated Shelter",
             addressStreet = testShelter3.addressStreet!!,
@@ -104,12 +105,28 @@ class ShelterServiceTest {
 
         val result = service.updateShelter(testShelter3.id!!, updated)
 
-        assertThat(result).isEqualTo(updated)
+        assertThat(result).isEqualTo(
+            ShelterResponse(
+                id = updated.id,
+                name = updated.name,
+                addressStreet = updated.addressStreet,
+                addressHouseNumber = updated.addressHouseNumber,
+                addressStairway = updated.addressStairway,
+                addressPostalCode = updated.addressPostalCode,
+                addressCity = updated.addressCity,
+                addressDoor = updated.addressDoor,
+                note = updated.note,
+                personsCount = updated.personsCount,
+                enabled = updated.enabled,
+                sortOrder = updated.sortOrder,
+                contacts = updated.contacts,
+            ),
+        )
     }
 
     @Test
     fun `create shelter assigns next sort order after the current max, ignoring the input value`() {
-        val createInput = Shelter(
+        val createInput = ShelterRequest(
             id = 0L,
             name = "New Shelter",
             addressStreet = "New Street",
@@ -135,7 +152,7 @@ class ShelterServiceTest {
         val result = service.createShelter(createInput)
 
         assertThat(result).isEqualTo(
-            Shelter(
+            ShelterResponse(
                 id = 42L,
                 name = createInput.name,
                 addressStreet = createInput.addressStreet,
@@ -157,7 +174,7 @@ class ShelterServiceTest {
 
     @Test
     fun `create shelter assigns sort order 1 when no shelters exist yet`() {
-        val createInput = Shelter(
+        val createInput = ShelterRequest(
             id = 0L,
             name = "New Shelter",
             addressStreet = "New Street",
@@ -187,7 +204,7 @@ class ShelterServiceTest {
 
     @Test
     fun `create shelter with contacts`() {
-        val createInput = Shelter(
+        val createInput = ShelterRequest(
             id = 0L,
             name = "New Shelter",
             addressStreet = "New Street",
@@ -201,7 +218,7 @@ class ShelterServiceTest {
             enabled = true,
             sortOrder = 0,
             contacts = listOf(
-                ShelterContact(firstname = "Max", lastname = "Mustermann", phone = "0123456789"),
+                ShelterContactItem(firstname = "Max", lastname = "Mustermann", phone = "0123456789"),
             ),
         )
 
@@ -214,7 +231,7 @@ class ShelterServiceTest {
         val result = service.createShelter(createInput)
 
         assertThat(result.contacts).containsExactly(
-            ShelterContact(firstname = "Max", lastname = "Mustermann", phone = "0123456789"),
+            ShelterContactItem(firstname = "Max", lastname = "Mustermann", phone = "0123456789"),
         )
 
         val savedEntitySlot = slot<ShelterEntity>()
@@ -225,7 +242,7 @@ class ShelterServiceTest {
 
     @Test
     fun `update shelter with contacts`() {
-        val updated = Shelter(
+        val updated = ShelterRequest(
             id = testShelter3.id!!,
             name = "Updated Shelter",
             addressStreet = testShelter3.addressStreet!!,
@@ -239,7 +256,7 @@ class ShelterServiceTest {
             enabled = false,
             sortOrder = 5,
             contacts = listOf(
-                ShelterContact(firstname = "Erika", lastname = "Musterfrau", phone = "0987654321"),
+                ShelterContactItem(firstname = "Erika", lastname = "Musterfrau", phone = "0987654321"),
             ),
         )
 
@@ -248,7 +265,23 @@ class ShelterServiceTest {
 
         val result = service.updateShelter(testShelter3.id!!, updated)
 
-        assertThat(result).isEqualTo(updated)
+        assertThat(result).isEqualTo(
+            ShelterResponse(
+                id = updated.id,
+                name = updated.name,
+                addressStreet = updated.addressStreet,
+                addressHouseNumber = updated.addressHouseNumber,
+                addressStairway = updated.addressStairway,
+                addressPostalCode = updated.addressPostalCode,
+                addressCity = updated.addressCity,
+                addressDoor = updated.addressDoor,
+                note = updated.note,
+                personsCount = updated.personsCount,
+                enabled = updated.enabled,
+                sortOrder = updated.sortOrder,
+                contacts = updated.contacts,
+            ),
+        )
 
         val savedEntitySlot = slot<ShelterEntity>()
         verify { shelterRepository.save(capture(savedEntitySlot)) }
@@ -259,7 +292,7 @@ class ShelterServiceTest {
     fun `update shelter throws exception when not found`() {
         every { shelterRepository.findByIdOrNull(99L) } returns null
 
-        val exception = assertThrows<NotFoundException> { service.updateShelter(99L, testShelter3ShelterModel()) }
+        val exception = assertThrows<NotFoundException> { service.updateShelter(99L, testShelter3ShelterRequest()) }
         assertThat(exception.body.detail).isEqualTo("Shelter with id 99 not found")
     }
 
@@ -299,7 +332,7 @@ class ShelterServiceTest {
         assertThat(exception.body.detail).isEqualTo("Shelter with id 99 not found")
     }
 
-    private fun testShelter3ShelterModel() = Shelter(
+    private fun testShelter3ShelterRequest() = ShelterRequest(
         id = testShelter3.id!!,
         name = testShelter3.name!!,
         addressStreet = testShelter3.addressStreet!!,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/internal/ShopServiceTest.kt
@@ -2,7 +2,7 @@ package at.wrk.tafel.admin.backend.modules.logistics.internal
 
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
-import at.wrk.tafel.admin.backend.modules.logistics.model.Shop
+import at.wrk.tafel.admin.backend.modules.logistics.model.ShopItem
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute1
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -47,7 +47,7 @@ class ShopServiceTest {
                 .sortedBy { it.time }
                 .filter { it.shop != null }
                 .map {
-                    Shop(
+                    ShopItem(
                         id = it.shop!!.id!!,
                         number = it.shop!!.number!!,
                         name = it.shop!!.name!!,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/CarsResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/CarsResponseModelTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test
 class CarsResponseModelTest {
 
     @Test
-    fun `car with blank fields is invalid`() {
-        val car = Car(id = null, licensePlate = "", name = "", enabled = true, sortOrder = 0)
+    fun `car request with blank fields is invalid`() {
+        val car = CarRequest(id = null, licensePlate = "", name = "", enabled = true, sortOrder = 0)
 
         val violations = validator.validate(car)
 
@@ -17,8 +17,8 @@ class CarsResponseModelTest {
     }
 
     @Test
-    fun `car with filled fields is valid`() {
-        val car = Car(id = null, licensePlate = "W-12345", name = "Car", enabled = true, sortOrder = 0)
+    fun `car request with filled fields is valid`() {
+        val car = CarRequest(id = null, licensePlate = "W-12345", name = "Car", enabled = true, sortOrder = 0)
 
         val violations = validator.validate(car)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCategoriesResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCategoriesResponseModelTest.kt
@@ -8,8 +8,8 @@ import java.math.BigDecimal
 class FoodCategoriesResponseModelTest {
 
     @Test
-    fun `food category with blank name and negative weight is invalid`() {
-        val category = FoodCategory(
+    fun `food category request with blank name and negative weight is invalid`() {
+        val category = FoodCategoryRequest(
             id = null,
             name = "",
             weightPerUnit = BigDecimal(-1),
@@ -25,8 +25,8 @@ class FoodCategoriesResponseModelTest {
     }
 
     @Test
-    fun `food category with valid values is valid`() {
-        val category = FoodCategory(
+    fun `food category request with valid values is valid`() {
+        val category = FoodCategoryRequest(
             id = null,
             name = "Category",
             weightPerUnit = BigDecimal.ZERO,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCollectionsModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/FoodCollectionsModelTest.kt
@@ -8,7 +8,7 @@ class FoodCollectionsModelTest {
 
     @Test
     fun `save route data with non-positive and negative values is invalid`() {
-        val data = FoodCollectionSaveRouteData(carId = 0, driverId = 0, coDriverId = 0, kmStart = -1, kmEnd = -1)
+        val data = FoodCollectionSaveRouteRequest(carId = 0, driverId = 0, coDriverId = 0, kmStart = -1, kmEnd = -1)
 
         val violations = validator.validate(data)
 
@@ -18,7 +18,7 @@ class FoodCollectionsModelTest {
 
     @Test
     fun `save route data with valid values is valid`() {
-        val data = FoodCollectionSaveRouteData(carId = 1, driverId = 1, coDriverId = 2, kmStart = 0, kmEnd = 0)
+        val data = FoodCollectionSaveRouteRequest(carId = 1, driverId = 1, coDriverId = 2, kmStart = 0, kmEnd = 0)
 
         val violations = validator.validate(data)
 
@@ -37,7 +37,7 @@ class FoodCollectionsModelTest {
 
     @Test
     fun `food collection items with empty list is invalid`() {
-        val items = FoodCollectionItems(items = emptyList())
+        val items = FoodCollectionItemsRequest(items = emptyList())
 
         val violations = validator.validate(items)
 
@@ -47,7 +47,7 @@ class FoodCollectionsModelTest {
 
     @Test
     fun `food collection items cascades into invalid item`() {
-        val items = FoodCollectionItems(items = listOf(FoodCollectionItem(categoryId = 0, shopId = 1, amount = 1)))
+        val items = FoodCollectionItemsRequest(items = listOf(FoodCollectionItem(categoryId = 0, shopId = 1, amount = 1)))
 
         val violations = validator.validate(items)
 
@@ -67,7 +67,7 @@ class FoodCollectionsModelTest {
 
     @Test
     fun `save items per shop data with empty list is invalid`() {
-        val data = FoodCollectionSaveItemsPerShopData(items = emptyList())
+        val data = FoodCollectionSaveItemsPerShopRequest(items = emptyList())
 
         val violations = validator.validate(data)
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/logistics/model/SheltersResponseModelTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 
 class SheltersResponseModelTest {
 
-    private fun validShelter() = Shelter(
+    private fun validShelterRequest() = ShelterRequest(
         id = null,
         name = "Shelter",
         addressStreet = "Street",
@@ -23,8 +23,8 @@ class SheltersResponseModelTest {
     )
 
     @Test
-    fun `shelter with blank and invalid fields is invalid`() {
-        val shelter = validShelter().copy(
+    fun `shelter request with blank and invalid fields is invalid`() {
+        val shelter = validShelterRequest().copy(
             name = "",
             addressStreet = "",
             addressHouseNumber = "",
@@ -47,9 +47,9 @@ class SheltersResponseModelTest {
     }
 
     @Test
-    fun `shelter cascades into blank contact phone`() {
-        val shelter = validShelter().copy(
-            contacts = listOf(ShelterContact(firstname = "A", lastname = "B", phone = "")),
+    fun `shelter request cascades into blank contact phone`() {
+        val shelter = validShelterRequest().copy(
+            contacts = listOf(ShelterContactItem(firstname = "A", lastname = "B", phone = "")),
         )
 
         val violations = validator.validate(shelter)
@@ -59,8 +59,8 @@ class SheltersResponseModelTest {
     }
 
     @Test
-    fun `shelter with valid values is valid`() {
-        val violations = validator.validate(validShelter())
+    fun `shelter request with valid values is valid`() {
+        val violations = validator.validate(validShelterRequest())
 
         assertThat(violations).isEmpty()
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsControllerTest.kt
@@ -29,7 +29,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `getSettings returns statistics settings from service`() {
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = listOf(2024, 2023, 2022),
             distributions = listOf(
                 StatisticsDistribution(
@@ -59,7 +59,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `getSettings returns empty lists when no distributions exist`() {
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = emptyList(),
             distributions = emptyList(),
         )
@@ -83,7 +83,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `getSettings returns settings with single year`() {
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = listOf(2024),
             distributions = listOf(
                 StatisticsDistribution(
@@ -110,7 +110,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `getSettings returns settings with multiple years`() {
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = listOf(2025, 2024, 2023, 2022, 2021),
             distributions = listOf(
                 StatisticsDistribution(
@@ -151,7 +151,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `getSettings preserves year ordering from service`() {
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = listOf(2024, 2023, 2022),
             distributions = listOf(
                 StatisticsDistribution(
@@ -194,7 +194,7 @@ class StatisticsControllerTest {
             ),
         )
 
-        val expectedSettings = StatisticsSettings(
+        val expectedSettings = StatisticsSettingsResponse(
             availableYears = listOf(2024),
             distributions = expectedDistributions,
         )
@@ -211,7 +211,7 @@ class StatisticsControllerTest {
     fun `get data`() {
         val fromDate = LocalDate.now().minusDays(2)
         val toDate = LocalDate.now()
-        val expectedData = mockk<StatisticsData>()
+        val expectedData = mockk<StatisticsResponse>()
 
         every { service.getData(fromDate, toDate) } returns expectedData
 
@@ -248,7 +248,7 @@ class StatisticsControllerTest {
     @Test
     fun `getSchoolStarterPackageData delegates to service with given age range and page`() {
         val expectedData = PagedResponse(
-            items = listOf(SchoolStarterPackageEntry(householdId = 1L, firstname = "Kind", lastname = "Mustermann", age = 8)),
+            items = listOf(SchoolStarterPackageItem(householdId = 1L, firstname = "Kind", lastname = "Mustermann", age = 8)),
             totalCount = 1L,
             currentPage = 2,
             totalPages = 1,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
@@ -5,10 +5,10 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionReposi
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
 import at.wrk.tafel.admin.backend.database.model.person.PersonRepository
-import at.wrk.tafel.admin.backend.modules.reporting.SchoolStarterPackageEntry
-import at.wrk.tafel.admin.backend.modules.reporting.StatisticsData
-import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDetailData
+import at.wrk.tafel.admin.backend.modules.reporting.SchoolStarterPackageItem
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDetail
 import at.wrk.tafel.admin.backend.modules.reporting.StatisticsDistribution
+import at.wrk.tafel.admin.backend.modules.reporting.StatisticsResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -403,62 +403,62 @@ internal class StatisticsServiceTest {
         val expectedDataPoints: List<Number> = listOf(10L, 20L, 30L)
 
         assertThat(result).isEqualTo(
-            StatisticsData(
-                beneficiaryCustomers = StatisticsDetailData(
+            StatisticsResponse(
+                beneficiaryCustomers = StatisticsDetail(
                     title = "30",
                     subTitle = "Bezugsberechtigte Haushalte",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                beneficiaryPersons = StatisticsDetailData(
+                beneficiaryPersons = StatisticsDetail(
                     title = "30",
                     subTitle = "Bezugsberechtigte Personen",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                beneficiaryCustomersWithChildren = StatisticsDetailData(
+                beneficiaryCustomersWithChildren = StatisticsDetail(
                     title = "30",
                     subTitle = "Bezugsberechtigte Haushalte mit Kindern (Alter <= 15)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                singleParentHouseholds = StatisticsDetailData(
+                singleParentHouseholds = StatisticsDetail(
                     title = "30",
                     subTitle = "Alleinerzieher (Haushalte)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                sheltersCount = StatisticsDetailData(
+                sheltersCount = StatisticsDetail(
                     title = "60",
                     subTitle = "Notschlafstellen (Anzahl)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                sheltersAverage = StatisticsDetailData(
+                sheltersAverage = StatisticsDetail(
                     title = "20,00",
                     subTitle = "Notschlafstellen (Durchschnitt pro Ausgabe)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                sheltersPersonsCount = StatisticsDetailData(
+                sheltersPersonsCount = StatisticsDetail(
                     title = "60",
                     subTitle = "Versorgte Personen (Anzahl)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                shopsCount = StatisticsDetailData(
+                shopsCount = StatisticsDetail(
                     title = "60",
                     subTitle = "Spender (Anzahl)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                shopItemsTotal = StatisticsDetailData(
+                shopItemsTotal = StatisticsDetail(
                     title = "60 kg",
                     subTitle = "Warenmenge (Gesamt)",
                     labels = expectedLabels,
                     dataPoints = expectedDataPoints,
                 ),
-                shopItemsAverage = StatisticsDetailData(
+                shopItemsAverage = StatisticsDetail(
                     title = "20,00 kg",
                     subTitle = "Warenmenge (Durchschnitt pro Spender)",
                     labels = expectedLabels,
@@ -507,7 +507,7 @@ internal class StatisticsServiceTest {
      * The age-range/main-person/valid-household *filtering* itself now happens inside the
      * Specification passed to `personRepository.findAll(...)` (see `StatisticsServiceIT` for that
      * behavior against a real DB) - these unit tests only cover what the service does with
-     * whatever `PersonRepository` hands back: mapping to `SchoolStarterPackageEntry` and
+     * whatever `PersonRepository` hands back: mapping to `SchoolStarterPackageItem` and
      * translating `page` into a zero-based `PageRequest`.
      */
     private fun personEntity(householdId: Long, firstname: String, lastname: String, age: Int): PersonEntity {
@@ -557,7 +557,7 @@ internal class StatisticsServiceTest {
         val result = service.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 1)
 
         assertThat(result.items).containsExactly(
-            SchoolStarterPackageEntry(householdId = 5L, firstname = "A", lastname = "Household5", age = 7),
+            SchoolStarterPackageItem(householdId = 5L, firstname = "A", lastname = "Household5", age = 7),
         )
         assertThat(result.currentPage).isEqualTo(1)
         assertThat(result.totalPages).isEqualTo(1)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/SettingsControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/SettingsControllerTest.kt
@@ -1,8 +1,9 @@
 package at.wrk.tafel.admin.backend.modules.settings
 
 import at.wrk.tafel.admin.backend.modules.settings.internal.SettingsService
-import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
-import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueItem
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -32,7 +33,7 @@ class SettingsControllerTest {
 
     @Test
     fun `update mail recipient settings`() {
-        val settings = MailRecipients(emptyList())
+        val settings = MailRecipientsRequest(emptyList())
         settingsController.updateMailRecipientSettings(settings)
 
         verify(exactly = 1) { settingsService.updateMailRecipients(settings) }
@@ -47,7 +48,7 @@ class SettingsControllerTest {
 
     @Test
     fun `update static value`() {
-        val staticValue = StaticValueItem(
+        val staticValueRequest = StaticValueRequest(
             id = 42L,
             type = "TOLERANCE",
             validFrom = LocalDate.of(2026, 1, 1),
@@ -57,11 +58,21 @@ class SettingsControllerTest {
             countChildren = null,
             age = null,
         )
-        every { settingsService.updateStaticValue(any(), any()) } returns staticValue
+        val staticValueResponse = StaticValueResponse(
+            id = staticValueRequest.id,
+            type = staticValueRequest.type,
+            validFrom = staticValueRequest.validFrom,
+            validTo = staticValueRequest.validTo,
+            amount = staticValueRequest.amount,
+            countAdults = staticValueRequest.countAdults,
+            countChildren = staticValueRequest.countChildren,
+            age = staticValueRequest.age,
+        )
+        every { settingsService.updateStaticValue(any(), any()) } returns staticValueResponse
 
-        val response = settingsController.updateStaticValue(42L, staticValue)
+        val response = settingsController.updateStaticValue(42L, staticValueRequest)
 
-        assertThat(response).isEqualTo(staticValue)
-        verify(exactly = 1) { settingsService.updateStaticValue(42L, staticValue) }
+        assertThat(response).isEqualTo(staticValueResponse)
+        verify(exactly = 1) { settingsService.updateStaticValue(42L, staticValueRequest) }
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceStaticValueCacheIT.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceStaticValueCacheIT.kt
@@ -4,7 +4,7 @@ import at.wrk.tafel.admin.backend.TafelBaseIntegrationTest
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueEntity
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueRepository
 import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueType
-import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueItem
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -56,7 +56,7 @@ class SettingsServiceStaticValueCacheIT : TafelBaseIntegrationTest() {
 
         settingsService.updateStaticValue(
             entity.id!!,
-            StaticValueItem(
+            StaticValueRequest(
                 id = entity.id,
                 type = StaticValueType.TOLERANCE.name,
                 validFrom = today.minusDays(1),

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/internal/SettingsServiceTest.kt
@@ -16,9 +16,11 @@ import at.wrk.tafel.admin.backend.database.model.staticdata.StaticValueType
 import at.wrk.tafel.admin.backend.modules.base.exception.NotFoundException
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientAdresses
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientType
-import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipients
 import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsPerMailType
-import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueItem
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.MailRecipientsResponse
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueRequest
+import at.wrk.tafel.admin.backend.modules.settings.model.StaticValueResponse
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -60,7 +62,7 @@ class SettingsServiceTest {
         val response = service.getMailRecipients()
 
         assertThat(response).isEqualTo(
-            MailRecipients(
+            MailRecipientsResponse(
                 mailRecipients = listOf(
                     MailRecipientsPerMailType(
                         mailType = MailType.DAILY_REPORT.name,
@@ -95,7 +97,7 @@ class SettingsServiceTest {
 
     @Test
     fun `update mail recipients`() {
-        val updatedSettings = MailRecipients(
+        val updatedSettings = MailRecipientsRequest(
             mailRecipients = listOf(
                 MailRecipientsPerMailType(
                     mailType = MailType.DAILY_REPORT.name,
@@ -161,7 +163,7 @@ class SettingsServiceTest {
 
     @Test
     fun `update, filter and sanitize mail recipients`() {
-        val updatedSettings = MailRecipients(
+        val updatedSettings = MailRecipientsRequest(
             mailRecipients = listOf(
                 MailRecipientsPerMailType(
                     mailType = MailType.DAILY_REPORT.name,
@@ -228,7 +230,7 @@ class SettingsServiceTest {
         val response = service.getStaticValues()
 
         assertThat(response.staticValues).containsExactly(
-            StaticValueItem(
+            StaticValueResponse(
                 id = 1,
                 type = "TOLERANCE",
                 validFrom = today.minusDays(10),
@@ -261,7 +263,7 @@ class SettingsServiceTest {
 
         // type/countAdults/countChildren/age differ from the existing row, but must be ignored - only
         // amount is editable, so the new historized row keeps the existing row's own values
-        val requestedChanges = StaticValueItem(
+        val requestedChanges = StaticValueRequest(
             id = 1,
             type = "TOLERANCE",
             validFrom = LocalDate.of(2030, 1, 1),
@@ -276,7 +278,7 @@ class SettingsServiceTest {
 
         assertThat(existing.validTo).isEqualTo(today.minusDays(1))
         assertThat(response).isEqualTo(
-            StaticValueItem(
+            StaticValueResponse(
                 id = 2,
                 type = "INCOME_LIMIT",
                 validFrom = today,
@@ -302,7 +304,7 @@ class SettingsServiceTest {
         every { staticValueRepository.findByIdOrNull(1L) } returns existing
         every { staticValueRepository.save(any()) } answers { firstArg() }
 
-        val requestedChanges = StaticValueItem(
+        val requestedChanges = StaticValueRequest(
             id = 1,
             type = "TOLERANCE",
             validFrom = today,
@@ -317,7 +319,7 @@ class SettingsServiceTest {
 
         verify(exactly = 1) { staticValueRepository.save(any()) }
         assertThat(response).isEqualTo(
-            StaticValueItem(
+            StaticValueResponse(
                 id = 1,
                 type = "TOLERANCE",
                 validFrom = today,
@@ -334,7 +336,7 @@ class SettingsServiceTest {
     fun `update static value fails when id is not found`() {
         every { staticValueRepository.findByIdOrNull(99L) } returns null
 
-        val updated = StaticValueItem(
+        val updated = StaticValueRequest(
             id = 99,
             type = "TOLERANCE",
             validFrom = LocalDate.of(2026, 1, 1),

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/SettingsResponseModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/SettingsResponseModelTest.kt
@@ -17,8 +17,8 @@ class SettingsResponseModelTest {
     }
 
     @Test
-    fun `mail recipients cascades into nested mail type`() {
-        val recipients = MailRecipients(
+    fun `mail recipients request cascades into nested mail type`() {
+        val recipients = MailRecipientsRequest(
             mailRecipients = listOf(MailRecipientsPerMailType(mailType = "", recipients = emptyList())),
         )
 
@@ -29,8 +29,8 @@ class SettingsResponseModelTest {
     }
 
     @Test
-    fun `mail recipients with filled fields is valid`() {
-        val recipients = MailRecipients(
+    fun `mail recipients request with filled fields is valid`() {
+        val recipients = MailRecipientsRequest(
             mailRecipients = listOf(
                 MailRecipientsPerMailType(
                     mailType = "DISTRIBUTION",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/StaticValueSettingsModelTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/settings/model/StaticValueSettingsModelTest.kt
@@ -9,8 +9,8 @@ import java.time.LocalDate
 class StaticValueSettingsModelTest {
 
     @Test
-    fun `static value item with blank type and negative numbers is invalid`() {
-        val item = StaticValueItem(
+    fun `static value request with blank type and negative numbers is invalid`() {
+        val item = StaticValueRequest(
             id = null,
             type = "",
             validFrom = LocalDate.now(),
@@ -28,8 +28,8 @@ class StaticValueSettingsModelTest {
     }
 
     @Test
-    fun `static value item with valid values is valid`() {
-        val item = StaticValueItem(
+    fun `static value request with valid values is valid`() {
+        val item = StaticValueRequest(
             id = null,
             type = "COST_CONTRIBUTION",
             validFrom = LocalDate.now(),

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserControllerTest.kt
@@ -152,7 +152,7 @@ class UserControllerTest {
         val response = controller.getUser(1)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isEqualTo(testUserApiResponse)
+        assertThat(response.body).isEqualTo(testUserResponse)
     }
 
     @Test
@@ -162,7 +162,7 @@ class UserControllerTest {
         val response = controller.getUserByPersonnelNumber(" ${testUser.personnelNumber} ")
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isEqualTo(testUserApiResponse)
+        assertThat(response.body).isEqualTo(testUserResponse)
 
         verify(exactly = 1) { userDetailsManager.loadUserByPersonnelNumber(testUser.personnelNumber) }
     }
@@ -211,7 +211,7 @@ class UserControllerTest {
                 page = page,
             )
 
-        assertThat(response.items).isEqualTo(listOf(testUserApiResponse))
+        assertThat(response.items).isEqualTo(listOf(testUserResponse))
         assertThat(response.totalCount).isEqualTo(userSearchResult.totalCount)
         assertThat(response.currentPage).isEqualTo(userSearchResult.currentPage)
         assertThat(response.totalPages).isEqualTo(userSearchResult.totalPages)
@@ -233,10 +233,10 @@ class UserControllerTest {
         every { userDetailsManager.loadUserByUsername(any()) } throws UsernameNotFoundException("dummy") andThen testUser
         every { userDetailsManager.loadUserByPersonnelNumber(any()) } returns null
 
-        val response = controller.createUser(user = testUserApiResponse)
+        val response = controller.createUser(user = testUserRequest)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        assertThat(response.body).isEqualTo(testUserApiResponse)
+        assertThat(response.body).isEqualTo(testUserResponse)
 
         verify(exactly = 1) { userDetailsManager.createUser(testUser) }
     }
@@ -245,7 +245,7 @@ class UserControllerTest {
     fun `create user exists by username`() {
         every { userDetailsManager.loadUserByUsername(any()) } returns testUser
 
-        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserApiResponse) }
+        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserRequest) }
         assertThat(exception.body.detail).isEqualTo("Benutzer (Benutzername: test-username) existiert bereits!")
     }
 
@@ -254,7 +254,7 @@ class UserControllerTest {
         every { userDetailsManager.loadUserByUsername(any()) } throws UsernameNotFoundException("dummy")
         every { userDetailsManager.loadUserByPersonnelNumber(any()) } returns testUser
 
-        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserApiResponse) }
+        val exception = assertThrows<ConflictException> { controller.createUser(user = testUserRequest) }
         assertThat(exception.body.detail).isEqualTo("Benutzer (Personalnummer: test-personnelnumber) existiert bereits!")
     }
 
@@ -263,7 +263,7 @@ class UserControllerTest {
         every { userDetailsManager.loadUserById(any()) } returns null
 
         val exception =
-            assertThrows<NotFoundException> { controller.updateUser(userId = 123, user = testUserApiResponse) }
+            assertThrows<NotFoundException> { controller.updateUser(userId = 123, user = testUserRequest) }
 
         assertThat(exception.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         assertThat(exception.body.detail).isEqualTo("Benutzer (ID: 123) nicht vorhanden!")
@@ -273,12 +273,12 @@ class UserControllerTest {
     fun `update user found`() {
         every { userDetailsManager.loadUserById(any()) } returns testUser
 
-        val newPermission = UserPermission(
+        val newPermission = UserPermissionItem(
             key = UserPermissions.CHECKIN.key,
             title = UserPermissions.CHECKIN.title,
             category = UserPermissions.CHECKIN.category.title,
         )
-        val updatedUser = User(
+        val updatedUser = UserRequest(
             id = 123,
             username = "updated-username",
             personnelNumber = "updated-personnelnumber",
@@ -292,7 +292,7 @@ class UserControllerTest {
         val updatedUserResponse = controller.updateUser(userId = testUser.id!!, user = updatedUser)
 
         assertThat(updatedUserResponse.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(updatedUserResponse.body).isEqualTo(testUserApiResponse)
+        assertThat(updatedUserResponse.body).isEqualTo(testUserResponse)
 
         val updatedUserDetailsSlot = slot<TafelUser>()
         verify(exactly = 1) { userDetailsManager.updateUser(capture(updatedUserDetailsSlot)) }
@@ -316,11 +316,11 @@ class UserControllerTest {
         val newPassword = "123"
         val updatedUserResponse = controller.updateUser(
             userId = 123,
-            user = testUserApiResponse.copy(password = newPassword, passwordRepeat = newPassword),
+            user = testUserRequest.copy(password = newPassword, passwordRepeat = newPassword),
         )
 
         assertThat(updatedUserResponse.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(updatedUserResponse.body).isEqualTo(testUserApiResponse)
+        assertThat(updatedUserResponse.body).isEqualTo(testUserResponse)
         verify(exactly = 1) { userDetailsManager.updateUser(testUser.copy(password = newPassword)) }
     }
 
@@ -331,7 +331,7 @@ class UserControllerTest {
         val exception = assertThrows<BusinessRuleException> {
             controller.updateUser(
                 userId = 123,
-                user = testUserApiResponse.copy(password = "123", passwordRepeat = "456"),
+                user = testUserRequest.copy(password = "123", passwordRepeat = "456"),
             )
         }
 
@@ -373,7 +373,7 @@ class UserControllerTest {
         val userPermissionEntries = UserPermissions.entries
         assertThat(permissions).hasSize(userPermissionEntries.size)
         assertThat(permissions?.first()).isEqualTo(
-            UserPermission(
+            UserPermissionItem(
                 key = userPermissionEntries.first().key,
                 title = userPermissionEntries.first().title,
                 category = userPermissionEntries.first().category.title,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserTestdata.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/UserTestdata.kt
@@ -1,9 +1,10 @@
 package at.wrk.tafel.admin.backend.security
 
 import at.wrk.tafel.admin.backend.common.auth.model.TafelUser
-import at.wrk.tafel.admin.backend.common.auth.model.User
-import at.wrk.tafel.admin.backend.common.auth.model.UserPermission
+import at.wrk.tafel.admin.backend.common.auth.model.UserPermissionItem
 import at.wrk.tafel.admin.backend.common.auth.model.UserPermissions
+import at.wrk.tafel.admin.backend.common.auth.model.UserRequest
+import at.wrk.tafel.admin.backend.common.auth.model.UserResponse
 import at.wrk.tafel.admin.backend.database.model.auth.UserAuthorityEntity
 import at.wrk.tafel.admin.backend.database.model.auth.UserEntity
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
@@ -44,7 +45,7 @@ val testUser = TafelUser(
     passwordChangeRequired = false,
 )
 
-val testUserApiResponse = User(
+val testUserResponse = UserResponse(
     id = testUserEntity.id!!,
     username = testUserEntity.username!!,
     personnelNumber = testUserEntity.employee?.personnelNumber!!,
@@ -53,6 +54,19 @@ val testUserApiResponse = User(
     enabled = testUserEntity.enabled!!,
     passwordChangeRequired = testUserEntity.passwordChangeRequired!!,
     permissions = testUserPermissions.map {
-        UserPermission(key = it.key, title = it.title, category = it.category.title)
+        UserPermissionItem(key = it.key, title = it.title, category = it.category.title)
+    },
+)
+
+val testUserRequest = UserRequest(
+    id = testUserEntity.id!!,
+    username = testUserEntity.username!!,
+    personnelNumber = testUserEntity.employee?.personnelNumber!!,
+    firstname = testUserEntity.employee?.firstname!!,
+    lastname = testUserEntity.employee?.lastname!!,
+    enabled = testUserEntity.enabled!!,
+    passwordChangeRequired = testUserEntity.passwordChangeRequired!!,
+    permissions = testUserPermissions.map {
+        UserPermissionItem(key = it.key, title = it.title, category = it.category.title)
     },
 )


### PR DESCRIPTION
## Summary

Closes #2877. Standardizes REST request/response DTO naming across the backend, replacing the four+ ad-hoc vocabularies flagged in the issue (`*Response`, `*Request`, bare domain models reused for both directions, `*Item`/`*Entry`, stray `*Data`/`*Result`) with one consistent rule, documented in `AGENTS.md`:

- **`Request`/`Response` split** for any type previously reused bare for both reading and writing: `Car`, `Shelter`, `FoodCategory`, `Household`, `User`, `Employee`, `MailRecipients`, `StaticValueItem`, `FoodCollectionItems`.
- **`Response`** alone for types only ever returned, never a request body (e.g. `StatisticsData` → `StatisticsResponse`, `DistributionCloseValidationResult` → `DistributionCloseResponse`).
- **`Item`** for types that only ever appear as a list element, never independently returned or accepted as a request (e.g. `Route` → `RouteItem`, `Country` → `CountryItem`, `SchoolStarterPackageEntry` → `SchoolStarterPackageItem`).
- Nested-only value objects (`Person`, `HouseholdAddress`, `HouseholdIssuer`) stay bare — no suffix.
- Stray `*Data`/`*Result` suffixes folded into the scheme.

Each module was renamed, compiled, and test-verified in its own commit (15 commits total) before moving to the next, so the history is bisectable per-module.

**Breaking change**: every commit touches the wire-level type names of the REST API (marked `!`). The frontend needs no changes — it has no shared codegen with the backend (hand-written TS interfaces, structurally typed, no reference to backend class names) — but any external API consumer would be affected.

## Test plan
- [x] `:backend:build` (compile + ktlint + full test suite incl. ArchUnit rules) passes on the final commit
- [x] Each module commit individually compiled and passed its own test scope before the next module started
- [ ] Manual smoke test of the running app (not done — pure rename, no behavior change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>