### PR TITLE
fix(ci): stop cleanup workflow from deleting release container images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -50,11 +50,48 @@ jobs:
       # SHA (see pull_request.yml/main_push.yml), so these otherwise accumulate
       # forever. Keep the most recent 2 - the currently deployed dev and test
       # images - and prune the rest; release images ("latest" and semver
-      # version tags) are excluded and kept indefinitely.
+      # version tags) must be kept indefinitely.
+      #
+      # This used to be actions/delete-package-versions with an `ignore-versions`
+      # regex meant to protect "latest"/semver tags. That action tests the regex
+      # against the version's digest (e.g. "sha256:abcd...") rather than its
+      # tags, so the regex never matched anything - it silently kept only the
+      # newest 2 versions overall and deleted every release image in the
+      # process (see #2891). Filtering by tag ourselves instead.
       - name: Delete old commit-SHA-tagged versions of the admin container image
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: admin
-          package-type: container
-          min-versions-to-keep: 2
-          ignore-versions: '^(latest|[0-9]+\.[0-9]+\.[0-9]+)$'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: wrk-tafel
+          PACKAGE: admin
+          KEEP: 2
+        run: |
+          gh api "orgs/${OWNER}/packages/container/${PACKAGE}/versions" --paginate \
+            --jq '.[] | [.id, .created_at, (.metadata.container.tags | join(","))] | @tsv' |
+            sort -t $'\t' -k2,2 -r > /tmp/versions.tsv
+
+          kept=0
+          while IFS=$'\t' read -r id created_at tags; do
+            [ -z "$tags" ] && continue # untagged versions are handled by the previous step
+
+            protected=false
+            IFS=',' read -ra tag_list <<< "$tags"
+            for t in "${tag_list[@]}"; do
+              if [[ "$t" =~ ^(latest|[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+                protected=true
+                break
+              fi
+            done
+            if [ "$protected" = true ]; then
+              echo "Keeping $id (release tag(s): $tags)"
+              continue
+            fi
+
+            kept=$((kept + 1))
+            if [ "$kept" -le "$KEEP" ]; then
+              echo "Keeping $id (recent, tag(s): $tags)"
+              continue
+            fi
+
+            echo "Deleting $id (tag(s): $tags, created $created_at)"
+            gh api -X DELETE "orgs/${OWNER}/packages/container/${PACKAGE}/versions/${id}" || true
+          done < /tmp/versions.tsv


### PR DESCRIPTION
## Summary
- `actions/delete-package-versions`'s `ignore-versions` regex is tested against the package version's digest (`sha256:...`), not its tags, so the regex meant to protect `latest`/semver-tagged images never matched anything. The last scheduled run deleted every release image, keeping only the 2 most recent commit-SHA-tagged versions.
- Replaces that step with a script that filters on the actual `metadata.container.tags`, protecting release-tagged versions permanently and only pruning excess commit-SHA-tagged versions (keeping the 2 newest).
- All 12 previously-deleted release versions (`0.1.0`–`0.5.0`, `latest`) were restored via GitHub's package-version restore API (deleted versions are recoverable for a limited time) — no rebuild was needed.

## Test plan
- [x] Dry-ran the new filtering logic against the live `admin` package data before and after restoring the deleted versions, confirming it now keeps all 12 release-tagged versions and only prunes stale commit-SHA-tagged ones.
- [ ] Confirm the scheduled `cleanup.yml` run behaves as expected in production.

Fixes #2891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rgf9PqkAjAThZUzwLzihkA