### PR TITLE
fix(logistics): wait for SSE connection before redirecting off warenerfassung

### DIFF
--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.spec.ts
@@ -31,7 +31,8 @@ describe('FoodCollectionRecordingComponent', () => {
                 {
                     provide: GlobalStateService,
                     useValue: {
-                        getCurrentDistribution: vi.fn().mockName('GlobalStateService.getCurrentDistribution')
+                        getCurrentDistribution: vi.fn().mockName('GlobalStateService.getCurrentDistribution'),
+                        getConnectionState: vi.fn().mockName('GlobalStateService.getConnectionState')
                     }
                 },
                 {
@@ -53,6 +54,7 @@ describe('FoodCollectionRecordingComponent', () => {
 
     it('ngOnInit without active distribution', () => {
         globalStateService.getCurrentDistribution.mockReturnValue(signal<DistributionItem | null>(null).asReadonly());
+        globalStateService.getConnectionState.mockReturnValue(signal(true).asReadonly());
 
         const fixture = TestBed.createComponent(FoodCollectionRecordingComponent);
         const componentRef = fixture.componentRef;
@@ -65,6 +67,23 @@ describe('FoodCollectionRecordingComponent', () => {
         fixture.detectChanges();
 
         expect(router.navigate).toHaveBeenCalledWith(['uebersicht']);
+    });
+
+    it('ngOnInit without active distribution but before SSE connection is established does not redirect', () => {
+        globalStateService.getCurrentDistribution.mockReturnValue(signal<DistributionItem | null>(null).asReadonly());
+        globalStateService.getConnectionState.mockReturnValue(signal(false).asReadonly());
+
+        const fixture = TestBed.createComponent(FoodCollectionRecordingComponent);
+        const componentRef = fixture.componentRef;
+
+        // Provide required model inputs before detectChanges
+        componentRef.setInput('routeList', { routes: [] });
+        componentRef.setInput('carList', { cars: [] });
+        componentRef.setInput('foodCategories', []);
+
+        fixture.detectChanges();
+
+        expect(router.navigate).not.toHaveBeenCalled();
     });
 
 });

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.ts
@@ -58,9 +58,12 @@ export class FoodCollectionRecordingComponent {
   private readonly router = inject(Router);
 
   constructor() {
-    // Redirect to overview if no distribution is active
+    // Redirect to overview once it's confirmed no distribution is active. `getCurrentDistribution()`
+    // is also `null` before the first SSE message arrives, so this must wait for a live connection
+    // to avoid redirecting away before the real state is known (e.g. right after a page load with
+    // no/poor connectivity).
     effect(() => {
-      if (this.globalStateService.getCurrentDistribution()() === null) {
+      if (this.globalStateService.getConnectionState()() && this.globalStateService.getCurrentDistribution()() === null) {
         this.router.navigate(['uebersicht']);
       }
     });


### PR DESCRIPTION
## Summary
- `FoodCollectionRecordingComponent` redirected to the overview page whenever `getCurrentDistribution()` was `null`, but `null` also means "SSE hasn't delivered its first message yet" (per `GlobalStateService`'s own doc-comment)
- Now waits for `getConnectionState()` to be `true` before treating a `null` distribution as confirmed-closed, so a cold start with no/poor connectivity no longer boots the codriver out of the Warenerfassung recording screen before the real state is known

## Test plan
- [x] Added a spec case covering "no active distribution but before SSE connection is established" → no redirect
- [x] Existing "no active distribution" (connected) case still redirects
- [x] `npm test` / `npm run lint` / `npm run typecheck:app` all pass

Closes #2897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rgf9PqkAjAThZUzwLzihkA