### PR TITLE
fix(ci): install Graphviz for module diagram regeneration

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -43,6 +43,11 @@ jobs:
           distribution: 'corretto'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - name: Install Graphviz
+        # PlantUML needs the `dot` binary to lay out the component diagram; without it,
+        # ModularityTest.createModuleDocumentation() writes an SVG containing a "Cannot
+        # find Graphviz" error graphic instead of the actual diagram (see #2906).
+        run: sudo apt-get update && sudo apt-get install -y graphviz
       - name: Regenerate module structure diagram
         run: ./gradlew :backend:test --tests "at.wrk.tafel.admin.backend.architecture.ModularityTest"
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Summary
- The `update-module-diagram` job's runner didn't have Graphviz (`dot`) installed, so PlantUML wrote a "Cannot find Graphviz" error graphic into `docs/module-structure.svg` instead of the real diagram — see the broken image in #2906.
- Because that broken output always differs from the correct diagram checked into `main`, the job opened a new PR on essentially every push to `main`, regardless of whether the module structure actually changed (#2900, #2906). `create-pull-request` already skips opening a PR when there's no file diff, so installing Graphviz fixes both problems: the diagram renders correctly again, and PRs are only opened for genuine structural changes.

## Test plan
- [ ] After merge, push to `main` and confirm `update-module-diagram` renders a correct diagram (no "Cannot find Graphviz" text) and does not open a PR when the module structure hasn't changed.
- [ ] Close #2906 and #2900-derived branch cleanup (broken, superseded by this fix) once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)