### PR TITLE
feat(pagination): add selectable page size and stable sort ordering

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/PaginationDefaults.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/api/PaginationDefaults.kt
@@ -1,0 +1,8 @@
+package at.wrk.tafel.admin.backend.common.api
+
+object PaginationDefaults {
+    const val DEFAULT_PAGE_SIZE = 10
+    private val ALLOWED_PAGE_SIZES = setOf(5, 10, 25, 50, 100)
+
+    fun resolvePageSize(pageSize: Int?): Int = pageSize?.takeIf { it in ALLOWED_PAGE_SIZES } ?: DEFAULT_PAGE_SIZE
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/UserController.kt
@@ -104,6 +104,7 @@ class UserController(
         @RequestParam lastname: String? = null,
         @RequestParam enabled: Boolean? = null,
         @RequestParam page: Int? = null,
+        @RequestParam pageSize: Int? = null,
     ): PagedResponse<UserResponse> {
         val userSearchResult = userDetailsManager.loadUsers(
             username = username?.trim(),
@@ -111,6 +112,7 @@ class UserController(
             lastname = lastname?.trim(),
             enabled = enabled,
             page = page,
+            pageSize = pageSize,
         )
         return PagedResponse(
             items = userSearchResult.items.map { mapToResponse(it) },

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelUserDetailsManager.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelUserDetailsManager.kt
@@ -1,6 +1,7 @@
 package at.wrk.tafel.admin.backend.common.auth.components
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
 import at.wrk.tafel.admin.backend.common.auth.model.TafelUser
 import at.wrk.tafel.admin.backend.database.model.auth.UserAuthorityEntity
@@ -57,8 +58,9 @@ class TafelUserDetailsManager(
         lastname: String?,
         enabled: Boolean?,
         page: Int?,
+        pageSize: Int? = null,
     ): UserSearchResult {
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize))
 
         val spec = orderByUpdatedAtDesc(
             where(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/auth/UserEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/auth/UserEntity.kt
@@ -88,7 +88,8 @@ class UserEntity : BaseChangeTrackingEntity() {
             fun orderByUpdatedAtDesc(spec: Specification<UserEntity>): Specification<UserEntity> = Specification { root: Root<UserEntity>, cq: CriteriaQuery<*>?, cb: CriteriaBuilder ->
 
                 val updatedAt: Expression<LocalDateTime> = root["updatedAt"]
-                cq!!.orderBy(cb.desc(updatedAt))
+                val id: Expression<Long> = root["id"]
+                cq!!.orderBy(cb.desc(updatedAt), cb.desc(id))
                 spec.toPredicate(root, cq, cb)
             }
         }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdEntity.kt
@@ -190,8 +190,9 @@ class HouseholdEntity : BaseChangeTrackingEntity() {
 
             fun orderByUpdatedAtDesc(spec: Specification<HouseholdEntity>): Specification<HouseholdEntity> = Specification { root: Root<HouseholdEntity>, cq: CriteriaQuery<*>?, cb: CriteriaBuilder ->
                 val updatedAt: Expression<LocalDate> = root["updatedAt"]
+                val id: Expression<Long> = root["id"]
 
-                cq!!.orderBy(cb.desc(updatedAt))
+                cq!!.orderBy(cb.desc(updatedAt), cb.desc(id))
                 spec.toPredicate(root, cq, cb)
             }
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdNoteRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/HouseholdNoteRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface HouseholdNoteRepository : JpaRepository<HouseholdNoteEntity, Long> {
 
-    fun findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(
+    fun findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(
         householdId: Long,
         pageRequest: PageRequest,
     ): Page<HouseholdNoteEntity>

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/person/PersonEntity.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/person/PersonEntity.kt
@@ -99,8 +99,9 @@ class PersonEntity : BaseChangeTrackingEntity() {
             fun orderByHouseholdId(spec: Specification<PersonEntity>): Specification<PersonEntity> = Specification { root: Root<PersonEntity>, cq: CriteriaQuery<*>?, cb: CriteriaBuilder ->
                 val household: Join<PersonEntity, HouseholdEntity> = root.join("household")
                 val householdId: Expression<Long> = household["householdId"]
+                val id: Expression<Long> = root["id"]
 
-                cq!!.orderBy(cb.asc(householdId))
+                cq!!.orderBy(cb.asc(householdId), cb.desc(id))
                 spec.toPredicate(root, cq, cb)
             }
         }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/EmployeeController.kt
@@ -25,7 +25,8 @@ class EmployeeController(
     fun findEmployees(
         @RequestParam searchInput: String? = null,
         @RequestParam page: Int? = null,
-    ): EmployeeListResponse = employeeService.findEmployees(searchInput, page)
+        @RequestParam pageSize: Int? = null,
+    ): EmployeeListResponse = employeeService.findEmployees(searchInput, page, pageSize)
 
     @PostMapping
     fun saveEmployee(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeService.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.base.employee.internal
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
@@ -18,8 +19,8 @@ class EmployeeService(
     private val employeeRepository: EmployeeRepository,
 ) {
 
-    fun findEmployees(searchInput: String? = null, page: Int? = null): EmployeeListResponse {
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 5, Sort.by("id"))
+    fun findEmployees(searchInput: String? = null, page: Int? = null, pageSize: Int? = null): EmployeeListResponse {
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize), Sort.by("id"))
         val pagedResult = if (searchInput != null) {
             employeeRepository.findBySearchInput(searchInput, pageRequest)
         } else {

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/HouseholdController.kt
@@ -86,6 +86,7 @@ class HouseholdController(
         @RequestParam postProcessing: Boolean? = null,
         @RequestParam costContribution: Boolean? = null,
         @RequestParam valid: Boolean? = null,
+        @RequestParam pageSize: Int? = null,
     ): PagedResponse<HouseholdResponse> {
         val householdSearchResult = householdService.getHouseholds(
             firstname = firstname?.trim(),
@@ -94,6 +95,7 @@ class HouseholdController(
             postProcessing = postProcessing,
             costContribution = costContribution,
             valid = valid,
+            pageSize = pageSize,
         )
         return PagedResponse(
             items = householdSearchResult.items,
@@ -141,8 +143,9 @@ class HouseholdController(
     @PreAuthorize("hasAuthority('CUSTOMERS_ABOVE_LIMIT')")
     fun getHouseholdsAboveLimit(
         @RequestParam page: Int? = null,
+        @RequestParam pageSize: Int? = null,
     ): PagedResponse<HouseholdAboveLimitItem> {
-        val result = householdService.getHouseholdsAboveLimit(page)
+        val result = householdService.getHouseholdsAboveLimit(page, pageSize)
         return PagedResponse(
             items = result.items,
             totalCount = result.totalCount,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdService.kt
@@ -1,6 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.household.internal
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs.Companion.firstnameContains
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity.Specs.Companion.lastnameContains
@@ -24,6 +25,7 @@ import at.wrk.tafel.admin.backend.modules.household.internal.income.IncomeValida
 import at.wrk.tafel.admin.backend.modules.household.internal.masterdata.HouseholdPdfService
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.Specification.where
 import org.springframework.stereotype.Service
@@ -147,8 +149,9 @@ class HouseholdService(
         postProcessing: Boolean?,
         costContribution: Boolean?,
         valid: Boolean?,
+        pageSize: Int? = null,
     ): HouseholdSearchResult {
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize))
 
         val where = where(
             Specification.allOf(
@@ -175,11 +178,11 @@ class HouseholdService(
     }
 
     @Transactional(readOnly = true)
-    fun getHouseholdsAboveLimit(page: Int? = null): HouseholdAboveLimitSearchResult {
+    fun getHouseholdsAboveLimit(page: Int? = null, pageSize: Int? = null): HouseholdAboveLimitSearchResult {
         // households needing post-processing (missing birthDate/gender/country/address/... - see
         // HouseholdEntity.Specs.postProcessingNecessary()) can't be income-validated
         val spec = where(Specification.allOf(listOf(validHousehold(), Specification.not(postProcessingNecessary()))))
-        val households = householdRepository.findAll(spec)
+        val households = householdRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "id"))
             .map { householdConverter.mapEntityToHousehold(it) }
 
         val itemsAboveLimit = households.mapNotNull { household ->
@@ -198,7 +201,7 @@ class HouseholdService(
 
         // the "above limit" filter can't be expressed in SQL (it depends on IncomeValidatorService,
         // not stored columns), so pagination is applied in-memory on the already-computed result
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize))
         val fromIndex = pageRequest.offset.toInt().coerceAtMost(itemsAboveLimit.size)
         val toIndex = (fromIndex + pageRequest.pageSize).coerceAtMost(itemsAboveLimit.size)
         val pagedResult = PageImpl(itemsAboveLimit.subList(fromIndex, toIndex), pageRequest, itemsAboveLimit.size.toLong())

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteController.kt
@@ -24,8 +24,9 @@ class HouseholdNoteController(
     fun getNotes(
         @PathVariable householdId: Long,
         @RequestParam("page") page: Int?,
+        @RequestParam("pageSize") pageSize: Int? = null,
     ): PagedResponse<HouseholdNoteItem> {
-        val searchResult = service.getNotes(householdId = householdId, page = page)
+        val searchResult = service.getNotes(householdId = householdId, page = page, pageSize = pageSize)
         return PagedResponse(
             items = searchResult.items,
             totalCount = searchResult.totalCount,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteService.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.household.internal.note
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdNoteEntity
@@ -16,10 +17,10 @@ class HouseholdNoteService(
     private val userRepository: UserRepository,
 ) {
 
-    fun getNotes(householdId: Long, page: Int?): HouseholdNoteSearchResult {
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 5)
+    fun getNotes(householdId: Long, page: Int?, pageSize: Int? = null): HouseholdNoteSearchResult {
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize))
         val pagedResult =
-            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId, pageRequest)
+            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(householdId, pageRequest)
 
         return HouseholdNoteSearchResult(
             items = pagedResult.map { mapNote(it) }.toList(),

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/StatisticsController.kt
@@ -46,7 +46,8 @@ class StatisticsController(
         @RequestParam ageMin: Int,
         @RequestParam ageMax: Int,
         @RequestParam page: Int? = null,
-    ): PagedResponse<SchoolStarterPackageItem> = statisticsService.getSchoolStarterPackageData(ageMin, ageMax, page)
+        @RequestParam pageSize: Int? = null,
+    ): PagedResponse<SchoolStarterPackageItem> = statisticsService.getSchoolStarterPackageData(ageMin, ageMax, page, pageSize)
 
     @GetMapping("/generate-school-starter-package-csv", produces = [MediaType.TEXT_PLAIN_VALUE])
     fun generateSchoolStarterPackageCsv(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsService.kt
@@ -2,6 +2,7 @@ package at.wrk.tafel.admin.backend.modules.reporting.internal
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import at.wrk.tafel.admin.backend.common.api.PagedResponse
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.csv.CsvUtil
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.person.PersonEntity
@@ -432,9 +433,10 @@ class StatisticsService(
         ageMin: Int,
         ageMax: Int,
         page: Int? = null,
+        pageSize: Int? = null,
     ): PagedResponse<SchoolStarterPackageItem> {
         val today = LocalDate.now()
-        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, 25)
+        val pageRequest = PageRequest.of(page?.minus(1) ?: 0, PaginationDefaults.resolvePageSize(pageSize))
         val pagedResult = personRepository.findAll(schoolStarterPackageSpec(ageMin, ageMax, today), pageRequest)
 
         return PagedResponse(

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/employee/internal/EmployeeServiceTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.base.employee.internal
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
 import at.wrk.tafel.admin.backend.modules.base.employee.EmployeeListResponse
@@ -34,7 +35,7 @@ class EmployeeServiceTest {
 
     @Test
     fun `find employees with searchInput and page`() {
-        val pageRequest = PageRequest.of(0, 5, Sort.by("id"))
+        val pageRequest = PageRequest.of(0, PaginationDefaults.DEFAULT_PAGE_SIZE, Sort.by("id"))
         val searchInput = "test-input"
 
         val employee1 = EmployeeEntity()
@@ -76,7 +77,7 @@ class EmployeeServiceTest {
         employee1.firstname = "first 1"
         employee1.lastname = "last 1"
 
-        val pageRequest = PageRequest.of(0, 5, Sort.by("id"))
+        val pageRequest = PageRequest.of(0, PaginationDefaults.DEFAULT_PAGE_SIZE, Sort.by("id"))
         val pagedResult = PageImpl(listOf(employee1), pageRequest, 123)
         every { employeeRepository.findAll(pageRequest) } returns pagedResult
 
@@ -87,6 +88,26 @@ class EmployeeServiceTest {
                 EmployeeResponse(id = 1, personnelNumber = "00001", firstname = "first 1", lastname = "last 1"),
             ),
         )
+    }
+
+    @Test
+    fun `find employees with explicit valid pageSize`() {
+        val pageRequest = PageRequest.of(0, 25, Sort.by("id"))
+        every { employeeRepository.findAll(pageRequest) } returns PageImpl(emptyList(), pageRequest, 0)
+
+        val response = employeeService.findEmployees(page = 1, pageSize = 25)
+
+        assertThat(response.pageSize).isEqualTo(25)
+    }
+
+    @Test
+    fun `find employees with invalid pageSize falls back to default`() {
+        val pageRequest = PageRequest.of(0, PaginationDefaults.DEFAULT_PAGE_SIZE, Sort.by("id"))
+        every { employeeRepository.findAll(pageRequest) } returns PageImpl(emptyList(), pageRequest, 0)
+
+        val response = employeeService.findEmployees(page = 1, pageSize = 7)
+
+        assertThat(response.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/HouseholdServiceTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.household.internal
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.security.core.context.SecurityContextHolder
 import java.math.BigDecimal
@@ -462,7 +464,7 @@ class HouseholdServiceTest {
         every { householdConverter.mapEntityToHousehold(any()) } returns testHousehold
 
         val selectedPage = 3
-        val pageRequest = PageRequest.of(selectedPage - 1, 25)
+        val pageRequest = PageRequest.of(selectedPage - 1, PaginationDefaults.DEFAULT_PAGE_SIZE)
         val page = PageImpl(listOf(testHouseholdEntity1, testHouseholdEntity2), pageRequest, 123)
         every { householdRepository.findAll(any<Specification<HouseholdEntity>>(), pageRequest) } returns page
 
@@ -470,7 +472,7 @@ class HouseholdServiceTest {
             service.getHouseholds(page = selectedPage, postProcessing = true, costContribution = true, valid = true)
 
         assertThat(searchResult.currentPage).isEqualTo(selectedPage)
-        assertThat(searchResult.totalPages).isEqualTo(5)
+        assertThat(searchResult.totalPages).isEqualTo(page.totalPages)
         assertThat(searchResult.totalCount).isEqualTo(page.totalElements)
         assertThat(searchResult.pageSize).isEqualTo(pageRequest.pageSize)
 
@@ -489,7 +491,7 @@ class HouseholdServiceTest {
         val validHousehold = mockk<HouseholdResponse>(relaxed = true)
         val invalidHousehold = mockk<HouseholdResponse>(relaxed = true)
 
-        every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns listOf(
+        every { householdRepository.findAll(any<Specification<HouseholdEntity>>(), any<Sort>()) } returns listOf(
             testHouseholdEntity1,
             testHouseholdEntity2,
         )
@@ -523,7 +525,7 @@ class HouseholdServiceTest {
         assertThat(result.totalCount).isEqualTo(1)
         assertThat(result.currentPage).isEqualTo(1)
         assertThat(result.totalPages).isEqualTo(1)
-        assertThat(result.pageSize).isEqualTo(25)
+        assertThat(result.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 
     @Test
@@ -531,7 +533,7 @@ class HouseholdServiceTest {
         val testHouseholdEntities = (1..30).map { mockk<HouseholdEntity>(relaxed = true) }
         val invalidHouseholds = (1..30).map { mockk<HouseholdResponse>(relaxed = true) }
 
-        every { householdRepository.findAll(any<Specification<HouseholdEntity>>()) } returns testHouseholdEntities
+        every { householdRepository.findAll(any<Specification<HouseholdEntity>>(), any<Sort>()) } returns testHouseholdEntities
         testHouseholdEntities.forEachIndexed { index, entity ->
             every { householdConverter.mapEntityToHousehold(entity) } returns invalidHouseholds[index]
         }
@@ -544,7 +546,7 @@ class HouseholdServiceTest {
             amountExceededLimit = BigDecimal("500"),
         )
 
-        val firstPage = service.getHouseholdsAboveLimit(page = 1)
+        val firstPage = service.getHouseholdsAboveLimit(page = 1, pageSize = 25)
         assertThat(firstPage.items).hasSize(25)
         assertThat(firstPage.items.first().household).isEqualTo(invalidHouseholds[0])
         assertThat(firstPage.totalCount).isEqualTo(30)
@@ -552,7 +554,7 @@ class HouseholdServiceTest {
         assertThat(firstPage.totalPages).isEqualTo(2)
         assertThat(firstPage.pageSize).isEqualTo(25)
 
-        val secondPage = service.getHouseholdsAboveLimit(page = 2)
+        val secondPage = service.getHouseholdsAboveLimit(page = 2, pageSize = 25)
         assertThat(secondPage.items).hasSize(5)
         assertThat(secondPage.items.first().household).isEqualTo(invalidHouseholds[25])
         assertThat(secondPage.currentPage).isEqualTo(2)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/note/HouseholdNoteServiceTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.household.internal.note
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
@@ -113,10 +114,10 @@ internal class HouseholdNoteServiceTest {
         val householdId = 123L
 
         val selectedPage = 3
-        val pageRequest = PageRequest.of(selectedPage - 1, 5)
+        val pageRequest = PageRequest.of(selectedPage - 1, PaginationDefaults.DEFAULT_PAGE_SIZE)
         val page = PageImpl(emptyList<HouseholdNoteEntity>(), pageRequest, 0)
         every {
-            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId, pageRequest)
+            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(householdId, pageRequest)
         } returns page
 
         val searchResult = service.getNotes(householdId, selectedPage)
@@ -127,7 +128,7 @@ internal class HouseholdNoteServiceTest {
         assertThat(searchResult.totalCount).isEqualTo(page.totalElements)
         assertThat(searchResult.pageSize).isEqualTo(pageRequest.pageSize)
 
-        verify { householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId, pageRequest) }
+        verify { householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(householdId, pageRequest) }
     }
 
     @Test
@@ -160,10 +161,10 @@ internal class HouseholdNoteServiceTest {
         )
 
         val selectedPage = 1
-        val pageRequest = PageRequest.of(selectedPage - 1, 5)
+        val pageRequest = PageRequest.of(selectedPage - 1, PaginationDefaults.DEFAULT_PAGE_SIZE)
         val pagedResult = PageImpl(noteEntities, pageRequest, 2)
         every {
-            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId, pageRequest)
+            householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(householdId, pageRequest)
         } returns pagedResult
 
         val searchResult = service.getNotes(householdId, selectedPage)
@@ -174,7 +175,7 @@ internal class HouseholdNoteServiceTest {
         assertThat(searchResult.totalCount).isEqualTo(pagedResult.totalElements)
         assertThat(searchResult.pageSize).isEqualTo(pageRequest.pageSize)
 
-        verify { householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId, pageRequest) }
+        verify { householdNoteRepository.findAllByHouseholdHouseholdIdOrderByCreatedAtDescIdDesc(householdId, pageRequest) }
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceIT.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceIT.kt
@@ -104,12 +104,12 @@ class StatisticsServiceIT : TafelBaseIntegrationTest() {
         testEntityManager.flush()
         testEntityManager.clear()
 
-        val firstPage = statisticsService.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 1)
+        val firstPage = statisticsService.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 1, pageSize = 25)
         assertThat(firstPage.items).hasSize(25)
         assertThat(firstPage.totalCount).isEqualTo(30L)
         assertThat(firstPage.totalPages).isEqualTo(2)
 
-        val secondPage = statisticsService.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 2)
+        val secondPage = statisticsService.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 2, pageSize = 25)
         assertThat(secondPage.items).hasSize(5)
         assertThat(secondPage.totalCount).isEqualTo(30L)
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/reporting/internal/StatisticsServiceTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.reporting.internal
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.household.HouseholdEntity
@@ -561,7 +562,7 @@ internal class StatisticsServiceTest {
         )
         assertThat(result.currentPage).isEqualTo(1)
         assertThat(result.totalPages).isEqualTo(1)
-        assertThat(result.pageSize).isEqualTo(25)
+        assertThat(result.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 
     @Test
@@ -591,7 +592,7 @@ internal class StatisticsServiceTest {
         service.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 2)
 
         assertThat(pageableSlot.captured.pageNumber).isEqualTo(1)
-        assertThat(pageableSlot.captured.pageSize).isEqualTo(25)
+        assertThat(pageableSlot.captured.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 
     @Test
@@ -605,5 +606,17 @@ internal class StatisticsServiceTest {
 
         assertThat(result.currentPage).isEqualTo(1)
         assertThat(pageableSlot.captured.pageNumber).isEqualTo(0)
+    }
+
+    @Test
+    fun `getSchoolStarterPackageData with invalid pageSize falls back to default`() {
+        val pageableSlot = slot<Pageable>()
+        every {
+            personRepository.findAll(any<Specification<PersonEntity>>(), capture(pageableSlot))
+        } returns PageImpl(emptyList(), PageRequest.of(0, PaginationDefaults.DEFAULT_PAGE_SIZE), 0)
+
+        service.getSchoolStarterPackageData(ageMin = 6, ageMax = 10, page = 1, pageSize = 999)
+
+        assertThat(pageableSlot.captured.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelUserDetailsManagerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/security/components/TafelUserDetailsManagerTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.security.components
 
+import at.wrk.tafel.admin.backend.common.api.PaginationDefaults
 import at.wrk.tafel.admin.backend.common.auth.components.PasswordChangeException
 import at.wrk.tafel.admin.backend.common.auth.components.TafelUserDetailsManager
 import at.wrk.tafel.admin.backend.common.auth.model.TafelJwtAuthentication
@@ -467,7 +468,7 @@ class TafelUserDetailsManagerTest {
         userEntity.passwordChangeRequired = true
 
         val selectedPage = 3
-        val pageRequest = PageRequest.of(selectedPage - 1, 25)
+        val pageRequest = PageRequest.of(selectedPage - 1, PaginationDefaults.DEFAULT_PAGE_SIZE)
         val page = PageImpl(listOf(userEntity), pageRequest, 123)
         every { userRepository.findAll(any<Specification<UserEntity>>(), pageRequest) } returns page
 
@@ -482,7 +483,7 @@ class TafelUserDetailsManagerTest {
         assertThat(searchResult).isNotNull
 
         assertThat(searchResult.currentPage).isEqualTo(selectedPage)
-        assertThat(searchResult.totalPages).isEqualTo(5)
+        assertThat(searchResult.totalPages).isEqualTo(page.totalPages)
         assertThat(searchResult.totalCount).isEqualTo(page.totalElements)
         assertThat(searchResult.pageSize).isEqualTo(pageRequest.pageSize)
 
@@ -494,6 +495,16 @@ class TafelUserDetailsManagerTest {
         assertThat(user.lastname).isEqualTo(userEntity.employee!!.lastname)
 
         verify(exactly = 1) { userRepository.findAll(any<Specification<UserEntity>>(), pageRequest) }
+    }
+
+    @Test
+    fun `loadUsers with invalid pageSize falls back to default`() {
+        val pageRequest = PageRequest.of(0, PaginationDefaults.DEFAULT_PAGE_SIZE)
+        every { userRepository.findAll(any<Specification<UserEntity>>(), pageRequest) } returns PageImpl(emptyList(), pageRequest, 0)
+
+        val searchResult = manager.loadUsers(username = null, firstname = null, lastname = null, enabled = null, page = 1, pageSize = 999)
+
+        assertThat(searchResult.pageSize).isEqualTo(PaginationDefaults.DEFAULT_PAGE_SIZE)
     }
 
     @Test

--- a/frontend/src/main/webapp/src/app/api/customer-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-api.service.ts
@@ -74,7 +74,8 @@ export class CustomerApiService {
     postProcessing?: boolean | null,
     costContribution?: boolean | null,
     valid?: boolean | null,
-    page?: number
+    page?: number,
+    pageSize?: number
   ): Observable<CustomerSearchResult> {
     let queryParams = new HttpParams();
     if (lastname) {
@@ -94,6 +95,9 @@ export class CustomerApiService {
     }
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
     return this.http.get<HouseholdSearchResult>('/households', {params: queryParams}).pipe(
       map(response => ({...response, items: (response?.items ?? []).map(mapHouseholdToCustomer)}))
@@ -116,10 +120,13 @@ export class CustomerApiService {
     );
   }
 
-  getCustomersAboveLimit(page?: number): Observable<CustomerAboveLimitResponse> {
+  getCustomersAboveLimit(page?: number, pageSize?: number): Observable<CustomerAboveLimitResponse> {
     let queryParams = new HttpParams();
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
     return this.http.get<HouseholdAboveLimitResponse>('/households/above-limit', {params: queryParams}).pipe(
       map(response => ({

--- a/frontend/src/main/webapp/src/app/api/customer-note-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/customer-note-api.service.ts
@@ -7,10 +7,13 @@ import {PagedResponse} from '../common/api/paged-response';
 export class CustomerNoteApiService {
   private http = inject(HttpClient);
 
-  getNotesForCustomer(customerId: number, page?: number): Observable<CustomerNotesResponse> {
+  getNotesForCustomer(customerId: number, page?: number, pageSize?: number): Observable<CustomerNotesResponse> {
     let queryParams = new HttpParams();
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
     return this.http.get<CustomerNotesResponse>(`/households/${customerId}/notes`, {params: queryParams});
   }

--- a/frontend/src/main/webapp/src/app/api/employee-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/employee-api.service.ts
@@ -7,13 +7,16 @@ import {PagedResponse} from '../common/api/paged-response';
 export class EmployeeApiService {
   private readonly http = inject(HttpClient);
 
-  findEmployees(searchInput?: string, page?: number): Observable<EmployeeListResponse> {
+  findEmployees(searchInput?: string, page?: number, pageSize?: number): Observable<EmployeeListResponse> {
     let queryParams = new HttpParams();
     if (searchInput) {
       queryParams = queryParams.set('searchInput', searchInput);
     }
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
     return this.http.get<EmployeeListResponse>('/employees', {params: queryParams});
   }

--- a/frontend/src/main/webapp/src/app/api/statistics-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/statistics-api.service.ts
@@ -33,12 +33,17 @@ export class StatisticsApiService {
       });
   }
 
-  getSchoolStarterPackageData(ageMin: number, ageMax: number, page?: number): Observable<SchoolStarterPackageSearchResult> {
+  getSchoolStarterPackageData(
+    ageMin: number, ageMax: number, page?: number, pageSize?: number
+  ): Observable<SchoolStarterPackageSearchResult> {
     let queryParams = new HttpParams();
     queryParams = queryParams.set('ageMin', ageMin);
     queryParams = queryParams.set('ageMax', ageMax);
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
 
     return this.http.get<SchoolStarterPackageSearchResult>('/statistics/school-starter-package', {params: queryParams});

--- a/frontend/src/main/webapp/src/app/api/user-api.service.ts
+++ b/frontend/src/main/webapp/src/app/api/user-api.service.ts
@@ -24,7 +24,8 @@ export class UserApiService {
     enabled?: boolean | null,
     lastname?: string | null,
     firstname?: string | null,
-    page?: number
+    page?: number,
+    pageSize?: number
   ): Observable<UserSearchResult> {
     let queryParams = new HttpParams();
     if (username) {
@@ -41,6 +42,9 @@ export class UserApiService {
     }
     if (page) {
       queryParams = queryParams.set('page', page);
+    }
+    if (pageSize) {
+      queryParams = queryParams.set('pageSize', pageSize);
     }
     return this.http.get<UserSearchResult>('/users', {params: queryParams});
   }

--- a/frontend/src/main/webapp/src/app/common/api/paged-response.ts
+++ b/frontend/src/main/webapp/src/app/common/api/paged-response.ts
@@ -5,3 +5,6 @@ export interface PagedResponse<T> {
   totalPages: number;
   pageSize: number;
 }
+
+export const PAGE_SIZE_OPTIONS = [5, 10, 25, 50, 100];
+export const DEFAULT_PAGE_SIZE = 10;

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.html
@@ -14,8 +14,8 @@
     @if ((customerAboveLimitData()?.items?.length ?? 0) > 0) {
       <div class="mt-4">
         <mat-paginator class="tafel-paginator-responsive" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
-                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
+                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="true"
+                       (page)="getAboveLimit($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
       </div>
 
       <div class="hidden md:block mt-4">
@@ -79,8 +79,8 @@
         </table>
 
         <mat-paginator class="tafel-paginator-responsive mt-4" [length]="customerAboveLimitData()!.totalCount" [pageSize]="customerAboveLimitData()!.pageSize"
-                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                       (page)="getAboveLimit($event.pageIndex + 1)"></mat-paginator>
+                       [pageIndex]="customerAboveLimitData()!.currentPage - 1" [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="true"
+                       (page)="getAboveLimit($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
       </div>
 
       <div class="block md:hidden mt-4">

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.spec.ts
@@ -86,7 +86,7 @@ describe('CustomerAboveLimitComponent', () => {
 
     component.getAboveLimit(page);
 
-    expect(customerApiService.getCustomersAboveLimit).toHaveBeenCalledWith(page);
+    expect(customerApiService.getCustomersAboveLimit).toHaveBeenCalledWith(page, undefined);
     expect(component.customerAboveLimitData()).toEqual(mockCustomerAboveLimitResponse);
   });
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-above-limit/customer-above-limit.component.ts
@@ -9,6 +9,7 @@ import {CommonModule} from '@angular/common';
 import {faSearch, faUser} from '@fortawesome/free-solid-svg-icons';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 @Component({
   selector: 'tafel-customer-above-limit',
@@ -35,8 +36,8 @@ export class CustomerAboveLimitComponent {
   private readonly customerApiService = inject(CustomerApiService);
   private readonly router = inject(Router);
 
-  getAboveLimit(page?: number) {
-    this.customerApiService.getCustomersAboveLimit(page)
+  getAboveLimit(page?: number, pageSize?: number) {
+    this.customerApiService.getCustomersAboveLimit(page, pageSize)
       .subscribe((response: CustomerAboveLimitResponse) => {
         this.customerAboveLimitData.set(response.items.length === 0 ? undefined : response);
       });
@@ -55,4 +56,5 @@ export class CustomerAboveLimitComponent {
 
   protected readonly faUser = faUser;
   protected readonly faSearch = faSearch;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/dialogs/all-notes-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/dialogs/all-notes-dialog.component.html
@@ -1,8 +1,9 @@
 <tafel-dialog type="info" title="Alle Notizen">
   <div tafel-dialog-content>
     <mat-paginator class="tafel-paginator-center" [length]="notesResponse().totalCount" [pageSize]="notesResponse().pageSize"
-                   [pageIndex]="notesResponse().currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                   (page)="getCustomerNotes($event.pageIndex + 1)"></mat-paginator>
+                   [pageSizeOptions]="pageSizeOptions"
+                   [pageIndex]="notesResponse().currentPage - 1" [showFirstLastButtons]="true"
+                   (page)="getCustomerNotes($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
     @for (noteItem of notesResponse().items; track noteItem.timestamp; let i = $index) {
       @if (i > 0) {
         <hr>
@@ -15,8 +16,9 @@
       </div>
     }
     <mat-paginator class="tafel-paginator-center mt-6" [length]="notesResponse().totalCount" [pageSize]="notesResponse().pageSize"
-                   [pageIndex]="notesResponse().currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                   (page)="getCustomerNotes($event.pageIndex + 1)"></mat-paginator>
+                   [pageSizeOptions]="pageSizeOptions"
+                   [pageIndex]="notesResponse().currentPage - 1" [showFirstLastButtons]="true"
+                   (page)="getCustomerNotes($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
   </div>
   <div tafel-dialog-actions>
     <button testid="cancelButton" matButton="filled" (click)="dialogRef.close()">OK</button>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/dialogs/all-notes-dialog.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/dialogs/all-notes-dialog.component.ts
@@ -5,6 +5,7 @@ import {MatPaginatorModule} from '@angular/material/paginator';
 import {CommonModule} from '@angular/common';
 import {CustomerNoteApiService, CustomerNotesResponse} from '../../../../../api/customer-note-api.service';
 import {TafelDialogComponent} from '../../../../../common/components/tafel-dialog/tafel-dialog.component';
+import {PAGE_SIZE_OPTIONS} from '../../../../../common/api/paged-response';
 
 export interface AllNotesDialogData {
   customerId: number;
@@ -22,9 +23,10 @@ export class AllNotesDialogComponent {
   private readonly customerNoteApiService = inject(CustomerNoteApiService);
 
   notesResponse = signal<CustomerNotesResponse>(this.data.initialNotesResponse);
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 
-  getCustomerNotes(page: number) {
-    this.customerNoteApiService.getNotesForCustomer(this.data.customerId, page).subscribe((response) => {
+  getCustomerNotes(page: number, pageSize?: number) {
+    this.customerNoteApiService.getNotesForCustomer(this.data.customerId, page, pageSize).subscribe((response) => {
       this.notesResponse.set(response);
     });
   }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.html
@@ -36,6 +36,7 @@
     @if ((customerDuplicatesData()?.items?.length ?? 0) > 0) {
     <div>
       <mat-paginator class="tafel-paginator-responsive" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
+                     [pageSizeOptions]="pageSizeOptions"
                      [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                      (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
 
@@ -131,6 +132,7 @@
       </div>
 
       <mat-paginator class="tafel-paginator-responsive mt-4" [length]="customerDuplicatesData()!.totalCount" [pageSize]="customerDuplicatesData()!.pageSize"
+                     [pageSizeOptions]="pageSizeOptions"
                      [pageIndex]="customerDuplicatesData()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
                      (page)="getDuplicates($event.pageIndex + 1)"></mat-paginator>
     </div>

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-duplicates/customer-duplicates.component.ts
@@ -10,6 +10,7 @@ import {faCheck, faMagnifyingGlass, faTrashCan} from '@fortawesome/free-solid-sv
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 @Component({
   selector: 'tafel-customer-duplicates',
@@ -102,4 +103,7 @@ export class CustomerDuplicatesComponent {
   protected readonly faCheck = faCheck;
   protected readonly faMagnifyingGlass = faMagnifyingGlass;
   protected readonly faTrashCan = faTrashCan;
+  // Not enabled here (hidePageSize stays true) - page size is fixed at 1 pair per page, which
+  // mergeCustomers() below relies on. Only kept for structural consistency with the other pages.
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.html
@@ -58,8 +58,9 @@
           <div class="mb-6">
             <h5 class="mb-6">Suchergebnis ({{searchResult()!.totalCount}} Kunden)</h5>
             <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
-                           [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                           (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
+                           [pageSizeOptions]="pageSizeOptions"
+                           [pageIndex]="searchResult()!.currentPage - 1" [showFirstLastButtons]="true"
+                           (page)="searchForDetails($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
           </div>
 
           <div class="hidden md:block">

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.spec.ts
@@ -113,7 +113,8 @@ describe('CustomerSearchComponent', () => {
 
         component.searchForDetails();
 
-        expect(apiService.searchCustomer).toHaveBeenCalledWith('lastname', 'firstname', undefined, undefined, undefined, undefined);
+        expect(apiService.searchCustomer)
+            .toHaveBeenCalledWith('lastname', 'firstname', undefined, undefined, undefined, undefined, undefined);
 
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('[testid="searchresult-id-0"]')).nativeElement.textContent).toBe('0');
@@ -132,7 +133,8 @@ describe('CustomerSearchComponent', () => {
 
         component.searchForDetails();
 
-        expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, 'firstname', undefined, undefined, undefined, undefined);
+        expect(apiService.searchCustomer)
+            .toHaveBeenCalledWith(undefined, 'firstname', undefined, undefined, undefined, undefined, undefined);
     });
 
     it('search with firstname no results', () => {
@@ -144,7 +146,8 @@ describe('CustomerSearchComponent', () => {
 
         component.searchForDetails();
 
-        expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, 'firstname', undefined, undefined, undefined, undefined);
+        expect(apiService.searchCustomer)
+            .toHaveBeenCalledWith(undefined, 'firstname', undefined, undefined, undefined, undefined, undefined);
         expect(toastr.info).toHaveBeenCalledWith('Keine Kunden gefunden!');
     });
 
@@ -156,7 +159,8 @@ describe('CustomerSearchComponent', () => {
 
         component.searchForDetails();
 
-        expect(apiService.searchCustomer).toHaveBeenCalledWith('lastname', undefined, undefined, undefined, undefined, undefined);
+        expect(apiService.searchCustomer)
+            .toHaveBeenCalledWith('lastname', undefined, undefined, undefined, undefined, undefined, undefined);
     });
 
     it('search with postProcessing enabled', () => {
@@ -167,7 +171,7 @@ describe('CustomerSearchComponent', () => {
 
         component.searchForDetails();
 
-        expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, true, undefined, undefined, undefined);
+        expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, true, undefined, undefined, undefined, undefined);
     });
 
   it('search with costContribution enabled', () => {
@@ -178,7 +182,7 @@ describe('CustomerSearchComponent', () => {
 
     component.searchForDetails();
 
-    expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, undefined, true, undefined, undefined);
+    expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, undefined, true, undefined, undefined, undefined);
   });
 
   it('search with valid enabled', () => {
@@ -189,7 +193,7 @@ describe('CustomerSearchComponent', () => {
 
     component.searchForDetails();
 
-    expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, undefined, undefined, true, undefined);
+    expect(apiService.searchCustomer).toHaveBeenCalledWith(undefined, undefined, undefined, undefined, true, undefined, undefined);
   });
 
     it('navigate to customer', () => {

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-search/customer-search.component.ts
@@ -17,6 +17,7 @@ import {TafelAutofocusDirective} from '../../../../common/directive/tafel-autofo
 import {FormatCustomerAddressPipe} from '../../../../common/pipes/format-customer-address.pipe';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 @Component({
   selector: 'tafel-customer-search',
@@ -76,14 +77,15 @@ export class CustomerSearchComponent {
     return this.router.navigate(['/kunden/detail', customerId]);
   }
 
-  searchForDetails(page?: number) {
+  searchForDetails(page?: number, pageSize?: number) {
     this.customerApiService.searchCustomer(
       this.lastname.value ?? undefined,
       this.firstname.value ?? undefined,
       this.postProcessing.value ?? undefined,
       this.costContribution.value ?? undefined,
       this.valid.value ?? undefined,
-      page)
+      page,
+      pageSize)
       .subscribe((response: CustomerSearchResult) => {
         if (response.items.length === 0) {
           this.toastr.info('Keine Kunden gefunden!');
@@ -136,4 +138,5 @@ export class CustomerSearchComponent {
   protected readonly faPencil = faPencil;
   protected readonly faUser = faUser;
   protected readonly faSearch = faSearch;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.html
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.html
@@ -1,8 +1,9 @@
 <tafel-dialog [testId]="data.testId" type="info" title="Mitarbeiter auswählen">
   <div tafel-dialog-content>
     <mat-paginator class="tafel-paginator-center" [length]="employeeSearchResponse().totalCount" [pageSize]="employeeSearchResponse().pageSize"
-                   [pageIndex]="employeeSearchResponse().currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                   (page)="triggerSearch($event.pageIndex + 1)"></mat-paginator>
+                   [pageSizeOptions]="pageSizeOptions"
+                   [pageIndex]="employeeSearchResponse().currentPage - 1" [showFirstLastButtons]="true"
+                   (page)="triggerSearch($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
     @for (employee of employeeSearchResponse().items; track employee.id; let i = $index) {
       <mat-card class="mb-2">
         <mat-card-content>

--- a/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/components/dialogs/select-employee-dialog.component.ts
@@ -7,6 +7,7 @@ import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faHandPointer} from '@fortawesome/free-solid-svg-icons';
 import {EmployeeApiService, EmployeeData, EmployeeListResponse} from '../../../../api/employee-api.service';
 import {TafelDialogComponent} from '../../../../common/components/tafel-dialog/tafel-dialog.component';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 export interface SelectEmployeeDialogData {
   initialResponse: EmployeeListResponse;
@@ -30,9 +31,10 @@ export class SelectEmployeeDialogComponent {
   employeeSearchResponse = signal<EmployeeListResponse>(this.data.initialResponse);
 
   protected readonly faHandPointer = faHandPointer;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 
-  triggerSearch(page: number) {
-    this.employeeApiService.findEmployees(this.data.searchInput, page).subscribe((response) => {
+  triggerSearch(page: number, pageSize?: number) {
+    this.employeeApiService.findEmployees(this.data.searchInput, page, pageSize).subscribe((response) => {
       this.employeeSearchResponse.set(response);
     });
   }

--- a/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.html
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.html
@@ -90,8 +90,9 @@
     @if (employees()) {
       <mat-paginator class="tafel-paginator-responsive mt-4" testid="employees-paginator"
                      [length]="employees()!.totalCount" [pageSize]="employees()!.pageSize"
-                     [pageIndex]="employees()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                     (page)="loadEmployees($event.pageIndex + 1)"></mat-paginator>
+                     [pageSizeOptions]="pageSizeOptions"
+                     [pageIndex]="employees()!.currentPage - 1" [showFirstLastButtons]="true"
+                     (page)="loadEmployees($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
     }
   </mat-card-content>
 </mat-card>

--- a/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.spec.ts
@@ -71,7 +71,7 @@ describe('SettingsEmployeesComponent', () => {
     const component = fixture.componentInstance;
     expect(component['employees']()).toBeDefined();
     expect(component['employees']()?.items.length).toBe(2);
-    expect(employeeApiMock.findEmployees).toHaveBeenCalledWith(undefined, undefined);
+    expect(employeeApiMock.findEmployees).toHaveBeenCalledWith(undefined, undefined, undefined);
   });
 
   it('search() reloads from page 1 with the search input', () => {
@@ -82,7 +82,7 @@ describe('SettingsEmployeesComponent', () => {
     component['searchControl'].setValue('00001');
     component['search']();
 
-    expect(employeeApiMock.findEmployees).toHaveBeenCalledWith('00001', 1);
+    expect(employeeApiMock.findEmployees).toHaveBeenCalledWith('00001', 1, listResponse.pageSize);
   });
 
   it('startEdit() enters edit mode for the given row and prefills the fields', () => {

--- a/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/settings/views/employees/settings-employees.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/material/table';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {CreateEmployeeRequest, EmployeeApiService, EmployeeData, EmployeeListResponse} from '../../../../api/employee-api.service';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {MatButton} from '@angular/material/button';
 import {faCheck, faMagnifyingGlass, faPencil, faPlus, faXmark} from '@fortawesome/free-solid-svg-icons';
@@ -74,11 +75,11 @@ export class SettingsEmployeesComponent {
   }
 
   protected search() {
-    this.loadEmployees(1);
+    this.loadEmployees(1, this.employees()?.pageSize);
   }
 
-  protected loadEmployees(page?: number) {
-    this.employeeApiService.findEmployees(this.searchControl.value || undefined, page).subscribe({
+  protected loadEmployees(page?: number, pageSize?: number) {
+    this.employeeApiService.findEmployees(this.searchControl.value || undefined, page, pageSize).subscribe({
       next: data => this._employees.set(data),
       error: () => this.toastr.error('Fehler beim Laden der Mitarbeiter', 'Fehler')
     });
@@ -106,7 +107,7 @@ export class SettingsEmployeesComponent {
       next: () => {
         this.toastr.success('Mitarbeiter gespeichert', 'Erfolgreich');
         this.editingId.set(null);
-        this.loadEmployees(this.employees()?.currentPage);
+        this.loadEmployees(this.employees()?.currentPage, this.employees()?.pageSize);
       },
       error: () => this.toastr.error('Speichern fehlgeschlagen', 'Fehler')
     });
@@ -122,7 +123,7 @@ export class SettingsEmployeesComponent {
         this.employeeApiService.saveEmployee(created).subscribe({
           next: () => {
             this.toastr.success('Mitarbeiter erstellt', 'Erfolgreich');
-            this.loadEmployees(this.employees()?.currentPage);
+            this.loadEmployees(this.employees()?.currentPage, this.employees()?.pageSize);
           },
           error: () => this.toastr.error('Erstellen fehlgeschlagen', 'Fehler')
         });
@@ -135,4 +136,5 @@ export class SettingsEmployeesComponent {
   protected readonly faCheck = faCheck;
   protected readonly faXmark = faXmark;
   protected readonly faMagnifyingGlass = faMagnifyingGlass;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.html
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.html
@@ -32,7 +32,7 @@
         <h5 class="mb-4">{{ schoolStarterPackageData()!.totalCount }} Schulstartpakete benötigt</h5>
         <mat-paginator class="tafel-paginator-responsive" [length]="schoolStarterPackageData()!.totalCount"
                        [pageSize]="schoolStarterPackageData()!.pageSize" [pageIndex]="schoolStarterPackageData()!.currentPage - 1"
-                       [hidePageSize]="true" [showFirstLastButtons]="true" (page)="onPageChange($event)"></mat-paginator>
+                       [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="true" (page)="onPageChange($event)"></mat-paginator>
 
         <table mat-table [dataSource]="schoolStarterPackageData()!.items" class="w-full mt-4"
                testid="school-starter-package-table">
@@ -58,7 +58,7 @@
 
         <mat-paginator class="tafel-paginator-responsive mt-4" [length]="schoolStarterPackageData()!.totalCount"
                        [pageSize]="schoolStarterPackageData()!.pageSize" [pageIndex]="schoolStarterPackageData()!.currentPage - 1"
-                       [hidePageSize]="true" [showFirstLastButtons]="true" (page)="onPageChange($event)"></mat-paginator>
+                       [pageSizeOptions]="pageSizeOptions" [showFirstLastButtons]="true" (page)="onPageChange($event)"></mat-paginator>
       </div>
     }
   </mat-card-content>

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.spec.ts
@@ -49,7 +49,7 @@ describe('StatisticsSchoolStarterPackagesComponent', () => {
     const component = fixture.componentInstance;
     fixture.detectChanges();
 
-    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(6, 10, undefined);
+    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(6, 10, undefined, undefined);
     expect(component.schoolStarterPackageData()).toEqual(mockResult);
   });
 
@@ -61,12 +61,12 @@ describe('StatisticsSchoolStarterPackagesComponent', () => {
     component.onAgeMinChange(0);
 
     expect(component.schoolStarterPackageAgeMin()).toBe(0);
-    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(0, 10, undefined);
+    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(0, 10, undefined, undefined);
 
     component.onAgeMaxChange(3);
 
     expect(component.schoolStarterPackageAgeMax()).toBe(3);
-    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(0, 3, undefined);
+    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(0, 3, undefined, undefined);
   });
 
   it('loads the requested page on paginator page change', () => {
@@ -76,7 +76,7 @@ describe('StatisticsSchoolStarterPackagesComponent', () => {
 
     component.onPageChange({pageIndex: 1, pageSize: 25, length: 30});
 
-    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(6, 10, 2);
+    expect(statisticsApiService.getSchoolStarterPackageData).toHaveBeenCalledWith(6, 10, 2, 25);
   });
 
 });

--- a/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/statistics/views/school-starter-packages/statistics-school-starter-packages.component.ts
@@ -22,6 +22,7 @@ import {SchoolStarterPackageSearchResult, StatisticsApiService} from '../../../.
 import {FileHelperService} from '../../../../common/util/file-helper.service';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faSave} from '@fortawesome/free-solid-svg-icons';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 @Component({
   selector: 'tafel-statistics-school-starter-packages',
@@ -79,14 +80,15 @@ export class StatisticsSchoolStarterPackagesComponent {
   }
 
   onPageChange(event: PageEvent) {
-    this.loadSchoolStarterPackageData(event.pageIndex + 1);
+    this.loadSchoolStarterPackageData(event.pageIndex + 1, event.pageSize);
   }
 
-  private loadSchoolStarterPackageData(page?: number) {
+  private loadSchoolStarterPackageData(page?: number, pageSize?: number) {
     this.statisticsApiService.getSchoolStarterPackageData(
       this.schoolStarterPackageAgeMin(),
       this.schoolStarterPackageAgeMax(),
-      page
+      page,
+      pageSize
     ).subscribe((response) => this.schoolStarterPackageData.set(response));
   }
 
@@ -104,4 +106,5 @@ export class StatisticsSchoolStarterPackagesComponent {
   }
 
   protected readonly faSave = faSave;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.html
@@ -63,8 +63,9 @@
           <div class="mb-6">
             <h5 class="mb-6">Suchergebnis ({{this.searchResult()?.totalCount}} gefunden)</h5>
             <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
-                           [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                           (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
+                           [pageSizeOptions]="pageSizeOptions"
+                           [pageIndex]="searchResult()!.currentPage - 1" [showFirstLastButtons]="true"
+                           (page)="searchForDetails($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
           </div>
 
           <div class="hidden md:block">
@@ -121,8 +122,9 @@
 
             <div class="mt-6">
               <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
-                             [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                             (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
+                             [pageSizeOptions]="pageSizeOptions"
+                             [pageIndex]="searchResult()!.currentPage - 1" [showFirstLastButtons]="true"
+                             (page)="searchForDetails($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
             </div>
           </div>
 
@@ -152,8 +154,9 @@
             </div>
             <div class="mt-2">
               <mat-paginator class="tafel-paginator-responsive" [length]="searchResult()!.totalCount" [pageSize]="searchResult()!.pageSize"
-                             [pageIndex]="searchResult()!.currentPage - 1" [hidePageSize]="true" [showFirstLastButtons]="true"
-                             (page)="searchForDetails($event.pageIndex + 1)"></mat-paginator>
+                             [pageSizeOptions]="pageSizeOptions"
+                             [pageIndex]="searchResult()!.currentPage - 1" [showFirstLastButtons]="true"
+                             (page)="searchForDetails($event.pageIndex + 1, $event.pageSize)"></mat-paginator>
             </div>
           </div>
         </div>

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.spec.ts
@@ -129,7 +129,7 @@ describe('UserSearchComponent', () => {
 
     component.searchForDetails();
 
-    expect(apiService.searchUser).toHaveBeenCalledWith('username', true, 'lastname', 'firstname', undefined);
+    expect(apiService.searchUser).toHaveBeenCalledWith('username', true, 'lastname', 'firstname', undefined, undefined);
 
     fixture.detectChanges();
     // mat-table renders rows; query by attribute selector on nativeElement
@@ -157,7 +157,7 @@ describe('UserSearchComponent', () => {
 
     component.searchForDetails();
 
-    expect(apiService.searchUser).toHaveBeenCalledWith('', false, '', 'firstname', undefined);
+    expect(apiService.searchUser).toHaveBeenCalledWith('', false, '', 'firstname', undefined, undefined);
   });
 
   it('search with firstname no results', () => {
@@ -176,7 +176,7 @@ describe('UserSearchComponent', () => {
 
     component.searchForDetails();
 
-    expect(apiService.searchUser).toHaveBeenCalledWith('', false, '', 'firstname', undefined);
+    expect(apiService.searchUser).toHaveBeenCalledWith('', false, '', 'firstname', undefined, undefined);
     expect(toastr.info).toHaveBeenCalledWith('Keine Benutzer gefunden!');
   });
 

--- a/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/user/views/user-search/user-search.component.ts
@@ -19,6 +19,7 @@ import {form, FormField} from '@angular/forms/signals';
 import {MatDividerModule} from '@angular/material/divider';
 import {TafelToastrService} from '../../../../common/components/tafel-toastr/tafel-toastr.service';
 import {SUPPRESS_ERROR_TOAST_CONTEXT} from '../../../../common/http/suppress-error-toast.token';
+import {PAGE_SIZE_OPTIONS} from '../../../../common/api/paged-response';
 
 @Component({
   selector: 'tafel-user-search',
@@ -82,13 +83,13 @@ export class UserSearchComponent {
     return this.router.navigate(['/benutzer/detail', userId]);
   }
 
-  searchForDetails(page?: number) {
+  searchForDetails(page?: number, pageSize?: number) {
     const username = this.searchForm.username().value();
     const enabled = this.searchForm.enabled().value();
     const lastname = this.searchForm.lastname().value();
     const firstname = this.searchForm.firstname().value();
 
-    this.userApiService.searchUser(username, enabled, lastname, firstname, page)
+    this.userApiService.searchUser(username, enabled, lastname, firstname, page, pageSize)
       .subscribe((response: UserSearchResult) => {
         if (response.items.length === 0) {
           this.toastr.info('Keine Benutzer gefunden!');
@@ -106,4 +107,5 @@ export class UserSearchComponent {
   protected readonly faSearch = faSearch;
   protected readonly faPencil = faPencil;
   protected readonly faUser = faUser;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
 }


### PR DESCRIPTION
## Summary
- Every paginated page (Settings→Employees, employee-select dialog, User search, Customer search, Customer above-limit, Statistics school-starter-packages, all-notes dialog) now offers a page-size selector via Angular Material's paginator: `5, 10, 25, 50, 100`, default `10`.
- Backend controllers/services accept an optional `pageSize` query param, resolved via a new shared `PaginationDefaults.resolvePageSize()` helper (invalid/missing values fall back to the default).
- Customer duplicates intentionally keeps the same paginator wiring for consistency but the size selector stays disabled and page size fixed at 1, since its merge logic depends on exactly one duplicate pair per page.
- Added a stable `id`-descending tiebreaker (newest rows first) to queries that previously had no unique ordering, so pagination results no longer shift between requests: user search, customer search, customer above-limit, statistics school-starter-packages, and the notes dialog.

Closes #2907

## Test plan
- [x] Backend: `./gradlew :backend:test` — 591 tests passing
- [x] Backend: `./gradlew :backend:ktlintCheck` — clean
- [x] Frontend: `ng test` — 652 tests passing
- [x] Frontend: `ng lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)