### PR TITLE
fix: shrink Support-Anfrage button on phone screens

### DIFF
--- a/frontend/src/main/webapp/src/app/common/views/default-layout/default-header/default-header.component.html
+++ b/frontend/src/main/webapp/src/app/common/views/default-layout/default-header/default-header.component.html
@@ -6,7 +6,7 @@
     </button>
 
     <button (click)="openSupportDialog()" matButton="filled" testid="supportButton" aria-label="Support-Anfrage senden"
-            class="h-9 px-3 flex items-center justify-center rounded-md hover:bg-gray-100 text-sm font-medium">
+            class="h-7 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm flex items-center justify-center rounded-md hover:bg-gray-100 font-medium">
       Support-Anfrage
     </button>
   </div>

--- a/frontend/src/main/webapp/src/app/common/views/default-layout/default-header/default-header.component.html
+++ b/frontend/src/main/webapp/src/app/common/views/default-layout/default-header/default-header.component.html
@@ -6,7 +6,7 @@
     </button>
 
     <button (click)="openSupportDialog()" matButton="filled" testid="supportButton" aria-label="Support-Anfrage senden"
-            class="h-7 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm flex items-center justify-center rounded-md hover:bg-gray-100 font-medium">
+            class="!h-7 !px-2 !text-xs sm:!h-9 sm:!px-3 sm:!text-sm flex items-center justify-center rounded-md hover:bg-gray-100 font-medium">
       Support-Anfrage
     </button>
   </div>


### PR DESCRIPTION
## Summary
- The "Support-Anfrage" button in the header was the same size on all screen sizes, making it feel oversized on phones.
- Reduced its height/padding/font-size below the `sm:` (640px) breakpoint; unchanged at `sm:` and up, matching the codebase's existing phone-vs-tablet/desktop convention.

Closes #2920

## Test plan
- [ ] Deploy and check the button on a phone-width viewport vs. tablet/desktop