### PR TITLE
perf: bake an AppCDS archive into the docker image for faster startup

### DIFF
--- a/_build/Dockerfile
+++ b/_build/Dockerfile
@@ -4,6 +4,40 @@ COPY ./artifact/admin-backend.jar app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
 RUN find extracted -exec touch -d @0 {} \+
 
+# Trains an AppCDS archive by running the app through a real startup (migrations, EntityManagerFactory
+# build, security config, ...) against a throwaway local Postgres, then dumping the JVM's loaded-class
+# set on exit. Baking that archive into the final image lets every deployed container skip re-parsing/
+# re-verifying those classes, which measured ~20-25% faster starts with zero behavior change (see issue
+# #2881). The trainer must launch the app the exact same way the final ENTRYPOINT does (JarLauncher over
+# the extracted layered jar, not a plain `java -jar`) - CDS is classpath-layout sensitive, and a mismatch
+# here would silently produce a dead archive that never gets used at runtime.
+FROM amazoncorretto:26-alpine AS cds-trainer
+# fuzzystrmatch (used by household duplicate detection, see R__00031) lives in postgresql-contrib, not
+# the base package.
+RUN apk add --no-cache postgresql17 postgresql17-contrib
+ENV PGDATA=/var/lib/postgresql/data
+RUN mkdir -p "$PGDATA" /run/postgresql && chown -R postgres:postgres /var/lib/postgresql /run/postgresql \
+    && su postgres -c "initdb -D '$PGDATA' --auth=trust --no-sync" \
+    && su postgres -c "pg_ctl -D '$PGDATA' -o \"-c listen_addresses=localhost\" -w start" \
+    && su postgres -c "createuser tafeladmin -s" \
+    && su postgres -c "createdb tafeladmin -O tafeladmin" \
+    && su postgres -c "pg_ctl -D '$PGDATA' -w stop"
+
+WORKDIR /app
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+# The local profile supplies the JWT/mail/support properties SecurityProperties/TafelAdminProperties
+# require; mail/scanner-folder targets are never dialed during startup, so no mail server needs to
+# exist here.
+RUN mkdir documents scanner-inbox logs
+RUN su postgres -c "pg_ctl -D '$PGDATA' -o \"-c listen_addresses=localhost\" -w start" \
+    && java -Dspring.context.exit=onRefresh \
+         -XX:ArchiveClassesAtExit=/app-cds.jsa \
+         org.springframework.boot.loader.launch.JarLauncher --spring.profiles.active=local \
+    && su postgres -c "pg_ctl -D '$PGDATA' -w stop"
+
 FROM amazoncorretto:26-alpine
 ARG VERSION=dev
 ARG BUILD_TIME=unknown
@@ -25,6 +59,7 @@ COPY --from=builder /builder/extracted/dependencies/ ./
 COPY --from=builder /builder/extracted/spring-boot-loader/ ./
 COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
 COPY --from=builder /builder/extracted/application/ ./
+COPY --from=cds-trainer /app-cds.jsa ./app-cds.jsa
 COPY ./frontend-dist/ ./static/
 
-ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Duser.language=de","-Duser.country=DE","-Dspring.config.additional-location=file:/app/config/config.yml","org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java","-Duser.timezone=Europe/Vienna","-Duser.language=de","-Duser.country=DE","-XX:SharedArchiveFile=/app/app-cds.jsa","-Dspring.config.additional-location=file:/app/config/config.yml","org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## Summary

- Analyzed backend startup time for #2881: measured a full local run with real Postgres, breaking down the ~6-7s (or ~15s in a container) into phases (Hibernate EMF build, Spring Security filter chain setup, JPA repo proxy creation, etc.)
- The one change that gave a real, measured improvement: bake a Class Data Sharing (CDS) archive into the Docker image at build time, instead of every JVM re-parsing/re-verifying the same classes on every container start
- Tried the commonly-recommended `hibernate.temp.use_jdbc_metadata_defaults=false` tweak first - measured no actual difference locally, so did not include it

## What changed

- `_build/Dockerfile` gets a new `cds-trainer` stage: spins up a throwaway local Postgres (needs `postgresql17-contrib` for the `fuzzystrmatch` extension used by household duplicate detection), runs the app through a real startup (all 81 Flyway migrations, EntityManagerFactory build, security config) via the *same* `JarLauncher` mechanism the production entrypoint uses (CDS is classpath-layout sensitive - training via a plain `java -jar` would silently produce a dead archive), then dumps the resulting CDS archive on exit
- The final image copies that archive in; entrypoint adds `-XX:SharedArchiveFile=/app/app-cds.jsa` (default `auto` mode - if the archive were ever invalid, the JVM silently falls back to normal class loading, so this can't break a deploy)

## Verified results

Built and ran the real image repeatedly against docker-compose Postgres:
- Without archive: ~14.9s to `Started AdminBackendApplicationKt`
- With archive: ~11.4-11.8s
- **~22-25% faster**, confirmed genuinely active (not silently skipped) via a `-Xshare:on` run, which hard-fails on any archive mismatch instead of silently falling back

Adds ~15-20s one-time to CI image build; saves that percentage on every deployed container start going forward.

## Test plan

- [x] Built the full multi-stage image locally (`docker build -f _build/Dockerfile .`) and confirmed all 81 migrations apply cleanly in the trainer stage
- [x] Ran the built image against the project's docker-compose Postgres/network and compared timings against an equivalent image without the CDS archive
- [x] Verified the archive is genuinely used at runtime (`-Xshare:on`, which hard-fails on mismatch instead of silently ignoring it)
- [ ] CI build (`subflow_docker_image.yml`) succeeds on a real GitHub Actions runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CE82BeuSHAqCdLyGAyjcmk