### PR TITLE
feat: enable Hikari connection-leak detection in prod

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,9 @@ spring:
     driverClassName: org.postgresql.Driver
     hikari:
       maximum-pool-size: 50
+      # logs a warning with a stack trace for any connection held longer than this, so a leak
+      # (e.g. a missed transaction boundary) surfaces well before the pool is exhausted
+      leak-detection-threshold: 60000
   flyway:
     locations: classpath:/db-migration
     group: true


### PR DESCRIPTION
## Summary
- Sets `spring.datasource.hikari.leak-detection-threshold: 60000` in `application.yml` (the base/prod config)
- A connection held longer than 60s now logs a warning with a stack trace, surfacing leaks (e.g. a missed transaction boundary) well before the 50-connection pool is exhausted

Closes #2934, follow-up from #2879

## Test plan
- [ ] Verify app still starts locally with the `local` profile (leak-detection threshold only added to base config, no profile changes needed)
- [ ] Confirm no false-positive leak warnings under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CE82BeuSHAqCdLyGAyjcmk