### PR TITLE
ci: block prod deploys during the Saturday event window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,30 @@ jobs:
       sshKey: ${{ secrets.SSH_PRIVATE_KEY }}
       sshKnownHosts: ${{ secrets.SSH_KNOWN_HOSTS }}
       sshDeployCommand: ${{ secrets.SSH_DEPLOY_COMMAND }}
+  check-deploy-window:
+    runs-on: ubuntu-latest
+    outputs:
+      blocked: ${{ steps.check.outputs.blocked }}
+    steps:
+      - name: Check for the Saturday event window
+        id: check
+        env:
+          TZ: Europe/Vienna
+        # The app is used live Sat ~12:00-24:00 and must not restart (Flyway migrations run on
+        # boot) during that window - see issue #2931. Block the whole Saturday to be safe.
+        run: |
+          day=$(date +%u) # ISO weekday, 6 = Saturday
+          if [ "$day" -eq 6 ]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "### :no_entry: Prod deploy blocked" >> "$GITHUB_STEP_SUMMARY"
+            echo "Current day in Europe/Vienna is $(date '+%A %H:%M'). Prod deploys are blocked all day Saturday. Skipping deploy-prod." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
   deploy-prod:
     uses: ./.github/workflows/subflow_deploy.yml
-    needs: [version, github-release]
+    needs: [version, github-release, check-deploy-window]
+    if: needs.check-deploy-window.outputs.blocked != 'true'
     with:
       environment: prod
       version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Summary
- Add a `check-deploy-window` job to `release.yml` that computes the current weekday in `Europe/Vienna`.
- `deploy-prod` is now skipped (not failed) whenever that day is Saturday, via `if: needs.check-deploy-window.outputs.blocked != 'true'`.
- `deploy-test` and `github-release` are unaffected — releases/tags still get cut normally on Saturdays, only the prod restart is held back.

Closes #2931

## Test plan
- [x] Validated YAML with `yaml.safe_load`
- [x] Manually verified the weekday boundary logic (`date +%u`, 6 = Saturday) across Fri 23:59 → Sat 00:00 → Sat 23:59 → Sun 00:00
- [ ] Confirm on a real Saturday run (or via `workflow_dispatch` with a temporarily forced date) that `deploy-prod` shows as skipped with the explanatory job summary