### PR TITLE
Add health check for the scanner-folder network mount

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/ScannerFolderHealthIndicator.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/ScannerFolderHealthIndicator.kt
@@ -1,0 +1,50 @@
+package at.wrk.tafel.admin.backend.modules.household.internal.document
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.stereotype.Component
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Surfaces a dropped scanner-folder NAS/SMB mount via `/actuator/health` (and, through Spring
+ * Boot's per-indicator health-status gauge, `/actuator/prometheus`) instead of it silently looking
+ * like "no documents today" - see issue #2933. This is a separate, direct check rather than reusing
+ * [ScannerFileService.listFiles], which deliberately treats a missing directory as "feature
+ * disabled" (see its own docs) and would otherwise mask exactly the failure this is meant to catch.
+ */
+@Component
+class ScannerFolderHealthIndicator(
+    private val tafelAdminProperties: TafelAdminProperties,
+) : HealthIndicator {
+
+    override fun health(): Health {
+        val scannerPath = tafelAdminProperties.storage.scannerPath
+            ?: return Health.up().withDetail("configured", false).build()
+
+        val scannerDir = Paths.get(scannerPath)
+        return try {
+            if (!Files.isDirectory(scannerDir)) {
+                Health.down()
+                    .withDetail("configured", true)
+                    .withDetail("path", scannerPath)
+                    .withDetail("reason", "not a directory - mount likely not present")
+                    .build()
+            } else {
+                val fileCount = Files.list(scannerDir).use { it.count() }
+                Health.up()
+                    .withDetail("configured", true)
+                    .withDetail("path", scannerPath)
+                    .withDetail("fileCount", fileCount)
+                    .build()
+            }
+        } catch (e: IOException) {
+            Health.down(e)
+                .withDetail("configured", true)
+                .withDetail("path", scannerPath)
+                .build()
+        }
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/ScannerFolderHealthIndicatorTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/ScannerFolderHealthIndicatorTest.kt
@@ -1,0 +1,53 @@
+package at.wrk.tafel.admin.backend.modules.household.internal.document
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminStorageProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.boot.health.contributor.Status
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class ScannerFolderHealthIndicatorTest {
+
+    @TempDir
+    private lateinit var tempDir: Path
+
+    private fun indicatorWithScannerPath(path: String?) = ScannerFolderHealthIndicator(
+        TafelAdminProperties(storage = TafelAdminStorageProperties(scannerPath = path)),
+    )
+
+    @Test
+    fun `reports up with configured=false when scannerPath is not set`() {
+        val indicator = indicatorWithScannerPath(null)
+
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details).containsEntry("configured", false)
+    }
+
+    @Test
+    fun `reports down when the configured path is not a directory - eg a dropped mount`() {
+        val indicator = indicatorWithScannerPath(tempDir.resolve("does-not-exist").toString())
+
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.DOWN)
+        assertThat(health.details).containsEntry("configured", true)
+        assertThat(health.details["reason"]).asString().contains("not a directory")
+    }
+
+    @Test
+    fun `reports up with the file count when the directory is listable`() {
+        Files.writeString(tempDir.resolve("scan1.pdf"), "content1")
+        val indicator = indicatorWithScannerPath(tempDir.toString())
+
+        val health = indicator.health()
+
+        assertThat(health.status).isEqualTo(Status.UP)
+        assertThat(health.details).containsEntry("configured", true)
+        assertThat(health.details).containsEntry("fileCount", 1L)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ScannerFolderHealthIndicator`, a Spring Boot health check that surfaces a dropped scanner-folder NAS/SMB mount instead of it silently looking like "no documents today" (closes #2933).
- Reports `UP` (`configured: false`) when `scannerPath` isn't set, `DOWN` when the path is configured but not a listable directory or listing it throws, `UP` with a `fileCount` detail otherwise.
- Feeds directly into the existing `/actuator/health` uptime alerting from #2930 and the per-indicator status gauge already scraped via `/actuator/prometheus`.

## Test plan
- [x] `ScannerFolderHealthIndicatorTest` (unconfigured / dropped-mount / healthy cases)
- [x] `ModularityTest` (architecture/ArchUnit) still passes
- [x] `ktlintCheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)