### PR TITLE
feat: clean up orphaned document files not referenced in the DB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,11 @@ PR_TITLE` in the repo settings, so the title is what `release.yml` actually sees
 individual commits).
 
 When committing on this repo's behalf, write commit messages and PR titles in this format
-without being asked.
+without being asked. This has been missed in practice more than once (e.g. a PR left titled
+"Remove combined customer PDF (idcard + masterdata)" with no type prefix, failing
+`pr-title-lint`), so treat it as a hard checklist item: before opening or editing a PR, and
+whenever a CI failure turns out to be `pr-title-lint`/`commitlint`, check the PR title and commit
+subjects against these rules yourself rather than waiting for CI to flag it.
 
 ## API Structure
 

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/DocumentRepository.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/model/household/DocumentRepository.kt
@@ -1,10 +1,19 @@
 package at.wrk.tafel.admin.backend.database.model.household
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface DocumentRepository : JpaRepository<DocumentEntity, Long> {
 
     fun findAllByHouseholdHouseholdIdOrderByCreatedAtDesc(householdId: Long): List<DocumentEntity>
 
     fun findByIdAndHouseholdHouseholdId(id: Long, householdId: Long): DocumentEntity?
+
+    /**
+     * Used by [at.wrk.tafel.admin.backend.modules.household.internal.document.DocumentStorageCleanupService]
+     * to find files on disk that no longer have a DB row - a plain column projection instead of
+     * loading full entities since only the path is needed.
+     */
+    @Query("select d.storagePath from Document d")
+    fun findAllStoragePaths(): List<String>
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupService.kt
@@ -1,0 +1,65 @@
+package at.wrk.tafel.admin.backend.modules.household.internal.document
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.database.model.household.DocumentRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Deletes document files left behind on disk once their DB row is gone.
+ *
+ * Normal deletion paths (`HouseholdDocumentService.deleteDocument`,
+ * `HouseholdService.deleteHouseholdByHouseholdId`) already remove the file itself, but anything
+ * that drops `household_documents` rows without going through that code - most notably resetting
+ * a dev/test database, which never touches the documents mount - leaves the file behind on disk
+ * indefinitely. This periodically reconciles the documents folder against the DB and removes
+ * whatever is no longer referenced.
+ */
+@Service
+class DocumentStorageCleanupService(
+    private val documentRepository: DocumentRepository,
+    private val tafelAdminProperties: TafelAdminProperties,
+) {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DocumentStorageCleanupService::class.java)
+
+        // A file is written to disk (DocumentStorageService.store) before its DB row is committed
+        // (HouseholdDocumentService.uploadDocument/importFromScannerFile) - skipping anything newer
+        // than this avoids deleting a just-uploaded file out from under a request still in flight.
+        private const val MIN_AGE_MINUTES = 60L
+    }
+
+    @Scheduled(cron = "0 0 23 * * *")
+    fun cleanupOrphanedFiles() {
+        val documentsRoot = Paths.get(tafelAdminProperties.storage.documentsPath)
+        if (!Files.isDirectory(documentsRoot)) {
+            return
+        }
+
+        val knownPaths = documentRepository.findAllStoragePaths().toSet()
+        val cutoff = Instant.now().minus(MIN_AGE_MINUTES, ChronoUnit.MINUTES)
+
+        val orphanedFiles = Files.walk(documentsRoot).use { stream ->
+            stream
+                .filter { Files.isRegularFile(it) }
+                .filter { it.toAbsolutePath().toString() !in knownPaths }
+                .filter { Files.getLastModifiedTime(it).toInstant().isBefore(cutoff) }
+                .toList()
+        }
+
+        orphanedFiles.forEach { deleteOrphanedFile(it) }
+    }
+
+    private fun deleteOrphanedFile(file: Path) {
+        Files.deleteIfExists(file)
+        logger.info("Deleted orphaned document file: {}", file)
+    }
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupService.kt
@@ -47,7 +47,7 @@ class DocumentStorageCleanupService(
         val knownPaths = documentRepository.findAllStoragePaths().toSet()
         val cutoff = Instant.now().minus(MIN_AGE_MINUTES, ChronoUnit.MINUTES)
 
-        val orphanedFiles = Files.walk(documentsRoot).use { stream ->
+        val orphanedFiles: List<Path> = Files.walk(documentsRoot).use { stream ->
             stream
                 .filter { Files.isRegularFile(it) }
                 .filter { it.toAbsolutePath().toString() !in knownPaths }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/household/internal/document/DocumentStorageCleanupServiceTest.kt
@@ -1,0 +1,98 @@
+package at.wrk.tafel.admin.backend.modules.household.internal.document
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminStorageProperties
+import at.wrk.tafel.admin.backend.database.model.household.DocumentRepository
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileTime
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@ExtendWith(MockKExtension::class)
+internal class DocumentStorageCleanupServiceTest {
+
+    @TempDir
+    private lateinit var tempDir: Path
+
+    @RelaxedMockK
+    private lateinit var documentRepository: DocumentRepository
+
+    private lateinit var service: DocumentStorageCleanupService
+
+    @BeforeEach
+    fun beforeEach() {
+        service = DocumentStorageCleanupService(
+            documentRepository = documentRepository,
+            tafelAdminProperties = TafelAdminProperties(storage = TafelAdminStorageProperties(documentsPath = tempDir.toString())),
+        )
+    }
+
+    private fun writeFile(relativePath: String, ageInHours: Long = 2): Path {
+        val file = tempDir.resolve(relativePath)
+        Files.createDirectories(file.parent)
+        Files.writeString(file, "content")
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now().minus(ageInHours, ChronoUnit.HOURS)))
+        return file
+    }
+
+    @Test
+    fun `deletes an old file that is no longer referenced in the DB`() {
+        val orphanedFile = writeFile("100/uuid_proof.pdf")
+        every { documentRepository.findAllStoragePaths() } returns emptyList()
+
+        service.cleanupOrphanedFiles()
+
+        assertThat(orphanedFile).doesNotExist()
+    }
+
+    @Test
+    fun `keeps a file still referenced in the DB`() {
+        val referencedFile = writeFile("100/uuid_proof.pdf")
+        every { documentRepository.findAllStoragePaths() } returns listOf(referencedFile.toAbsolutePath().toString())
+
+        service.cleanupOrphanedFiles()
+
+        assertThat(referencedFile).exists()
+    }
+
+    @Test
+    fun `keeps an unreferenced file that was written too recently`() {
+        val recentFile = writeFile("100/uuid_proof.pdf", ageInHours = 0)
+        every { documentRepository.findAllStoragePaths() } returns emptyList()
+
+        service.cleanupOrphanedFiles()
+
+        assertThat(recentFile).exists()
+    }
+
+    @Test
+    fun `is a no-op when the documents directory doesn't exist`() {
+        service = DocumentStorageCleanupService(
+            documentRepository = documentRepository,
+            tafelAdminProperties = TafelAdminProperties(
+                storage = TafelAdminStorageProperties(documentsPath = tempDir.resolve("does-not-exist").toString()),
+            ),
+        )
+
+        service.cleanupOrphanedFiles()
+    }
+
+    @Test
+    fun `leaves the now-empty household directory in place`() {
+        writeFile("100/uuid_proof.pdf")
+        every { documentRepository.findAllStoragePaths() } returns emptyList()
+
+        service.cleanupOrphanedFiles()
+
+        assertThat(tempDir.resolve("100")).exists()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a nightly job (`DocumentStorageCleanupService`, `@Scheduled(cron = "0 0 23 * * *")`) that reconciles the documents folder against `household_documents` and deletes files no longer referenced in the DB
- Only deletes unreferenced files older than 60 minutes, to avoid racing a file that's on disk but whose DB row hasn't committed yet
- Normal deletion paths (`HouseholdDocumentService.deleteDocument`, `HouseholdService.deleteHouseholdByHouseholdId`) already remove files immediately; this job only cleans up files orphaned by other means - most notably the dev DB reset, which never touches the documents mount

Closes #2952

## Test plan
- [x] `DocumentStorageCleanupServiceTest` covers: deletes old orphaned file, keeps DB-referenced file, keeps recently-written unreferenced file, no-op when documents dir missing, leaves now-empty directories alone
- [x] `:backend:test`, `:backend:ktlintCheck`, `:backend:jacocoTestCoverageVerification` all pass