### PR TITLE
feat: only count fully recorded routes on dashboard and list them

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/DashboardResponseModel.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/DashboardResponseModel.kt
@@ -28,5 +28,6 @@ data class DashboardStatisticsData(
 data class DashboardLogisticsData(
     val foodCollectionsRecordedCount: Int?,
     val foodCollectionsTotalCount: Int?,
+    val recordedRouteNames: List<String>,
     val foodAmountTotal: BigDecimal?,
 )

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
@@ -4,6 +4,7 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.getCurrentDistribution
+import at.wrk.tafel.admin.backend.database.model.logistics.FoodCollectionEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
 import at.wrk.tafel.admin.backend.modules.dashboard.DashboardData
 import at.wrk.tafel.admin.backend.modules.dashboard.DashboardLogisticsData
@@ -60,12 +61,26 @@ class DashboardService(
             ?.mapNotNull { it.name } ?: emptyList(),
     )
 
-    private fun getLogisticsData(currentDistribution: DistributionEntity): DashboardLogisticsData = DashboardLogisticsData(
-        foodCollectionsRecordedCount = currentDistribution.foodCollections.size,
-        foodCollectionsTotalCount = routeRepository.findAll().size,
-        foodAmountTotal = currentDistribution.foodCollections
-            .flatMap { it.items ?: emptyList() }
-            .map { it.calculateWeight() }
-            .sumOf { it },
-    )
+    private fun getLogisticsData(currentDistribution: DistributionEntity): DashboardLogisticsData {
+        // A route only counts as "recorded" once the whole trip is done: base data (car/driver/
+        // co-driver/mileage) plus the picked-up food items - a FoodCollectionEntity can otherwise
+        // exist with only one of the two (see FoodCollectionService.getOrCreateFoodCollectionEntity).
+        val doneFoodCollections = currentDistribution.foodCollections.filter { it.isFullyRecorded() }
+
+        return DashboardLogisticsData(
+            foodCollectionsRecordedCount = doneFoodCollections.size,
+            foodCollectionsTotalCount = routeRepository.findAll().size,
+            recordedRouteNames = doneFoodCollections
+                .sortedWith(compareBy({ it.route?.number ?: 0.0 }, { it.route?.name ?: "" }))
+                .mapNotNull { it.route?.name },
+            foodAmountTotal = currentDistribution.foodCollections
+                .flatMap { it.items ?: emptyList() }
+                .map { it.calculateWeight() }
+                .sumOf { it },
+        )
+    }
+
+    private fun FoodCollectionEntity.isFullyRecorded(): Boolean =
+        car != null && driver != null && coDriver != null &&
+            kmStart != null && kmEnd != null && !items.isNullOrEmpty()
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardService.kt
@@ -80,7 +80,10 @@ class DashboardService(
         )
     }
 
-    private fun FoodCollectionEntity.isFullyRecorded(): Boolean =
-        car != null && driver != null && coDriver != null &&
-            kmStart != null && kmEnd != null && !items.isNullOrEmpty()
+    private fun FoodCollectionEntity.isFullyRecorded(): Boolean = car != null &&
+        driver != null &&
+        coDriver != null &&
+        kmStart != null &&
+        kmEnd != null &&
+        !items.isNullOrEmpty()
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/DashboardControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/DashboardControllerTest.kt
@@ -41,6 +41,7 @@ internal class DashboardControllerTest {
             logistics = DashboardLogisticsData(
                 foodCollectionsRecordedCount = 1,
                 foodCollectionsTotalCount = 2,
+                recordedRouteNames = listOf("Route 1"),
                 foodAmountTotal = BigDecimal(3),
             ),
             notes = "test-notes",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
@@ -5,15 +5,24 @@ import at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseh
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionStatisticShelterEntity
+import at.wrk.tafel.admin.backend.database.model.logistics.FoodCollectionEntity
+import at.wrk.tafel.admin.backend.database.model.logistics.FoodCollectionItemEntity
 import at.wrk.tafel.admin.backend.database.model.logistics.RouteRepository
+import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee1
+import at.wrk.tafel.admin.backend.modules.base.employee.testEmployee2
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity1
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity2
 import at.wrk.tafel.admin.backend.modules.distribution.internal.testDistributionHouseholdEntity3
+import at.wrk.tafel.admin.backend.modules.logistics.testCar1
+import at.wrk.tafel.admin.backend.modules.logistics.testFoodCategory1
 import at.wrk.tafel.admin.backend.modules.logistics.testFoodCollectionRoute1Entity
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute1
 import at.wrk.tafel.admin.backend.modules.logistics.testRoute2
+import at.wrk.tafel.admin.backend.modules.logistics.testRoute3
+import at.wrk.tafel.admin.backend.modules.logistics.testRoute4
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter1
 import at.wrk.tafel.admin.backend.modules.logistics.testShelter2
+import at.wrk.tafel.admin.backend.modules.logistics.testShop1
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
@@ -149,11 +158,55 @@ internal class DashboardServiceTest {
 
     @Test
     fun `get logistics`() {
+        // base data present, but no food items entered yet -> not fully recorded
+        val notDoneMissingItems = FoodCollectionEntity().apply {
+            route = testRoute2
+            car = testCar1
+            driver = testEmployee1
+            coDriver = testEmployee2
+            kmStart = 100
+            kmEnd = 200
+            items = emptyList()
+        }
+        // food items entered, but base data (car/driver/co-driver) missing -> not fully recorded
+        val notDoneMissingBaseData = FoodCollectionEntity().apply {
+            route = testRoute3
+            kmStart = 10
+            kmEnd = 20
+            items = listOf(
+                FoodCollectionItemEntity().apply {
+                    category = testFoodCategory1
+                    shop = testShop1
+                    amount = 0
+                },
+            )
+        }
+        // fully recorded, same as testFoodCollectionRoute1Entity but for a different/later route -
+        // verifies recordedRouteNames covers more than one route and sorts by route number
+        val doneRoute4 = FoodCollectionEntity().apply {
+            route = testRoute4
+            car = testCar1
+            driver = testEmployee1
+            coDriver = testEmployee2
+            kmStart = 10
+            kmEnd = 20
+            items = listOf(
+                FoodCollectionItemEntity().apply {
+                    category = testFoodCategory1
+                    shop = testShop1
+                    amount = 0
+                },
+            )
+        }
+
         val testDistributionEntity = DistributionEntity().apply {
             id = 123
             endedAt = null
             foodCollections = listOf(
                 testFoodCollectionRoute1Entity,
+                notDoneMissingItems,
+                notDoneMissingBaseData,
+                doneRoute4,
             )
         }
         every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity
@@ -161,12 +214,15 @@ internal class DashboardServiceTest {
         every { routeRepository.findAll() } returns listOf(
             testRoute1,
             testRoute2,
+            testRoute3,
+            testRoute4,
         )
 
         val data = service.getData()
 
-        assertThat(data.logistics!!.foodCollectionsRecordedCount).isEqualTo(1)
-        assertThat(data.logistics.foodCollectionsTotalCount).isEqualTo(2)
+        assertThat(data.logistics!!.foodCollectionsRecordedCount).isEqualTo(2)
+        assertThat(data.logistics.foodCollectionsTotalCount).isEqualTo(4)
+        assertThat(data.logistics.recordedRouteNames).containsExactly("Route 1", "Route 4")
         assertThat(data.logistics.foodAmountTotal).isEqualTo(BigDecimal(100))
     }
 

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/dashboard/internal/DashboardServiceTest.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.modules.dashboard.internal
 
+import at.wrk.tafel.admin.backend.database.model.base.EmployeeEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionEntity
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionHouseholdRepository
 import at.wrk.tafel.admin.backend.database.model.distribution.DistributionRepository
@@ -158,19 +159,13 @@ internal class DashboardServiceTest {
 
     @Test
     fun `get logistics`() {
-        // base data present, but no food items entered yet -> not fully recorded
-        val notDoneMissingItems = FoodCollectionEntity().apply {
-            route = testRoute2
+        // fully recorded, same as testFoodCollectionRoute1Entity but for a different/later route -
+        // verifies recordedRouteNames covers more than one route and sorts by route number
+        val doneRoute4 = FoodCollectionEntity().apply {
+            route = testRoute4
             car = testCar1
             driver = testEmployee1
             coDriver = testEmployee2
-            kmStart = 100
-            kmEnd = 200
-            items = emptyList()
-        }
-        // food items entered, but base data (car/driver/co-driver) missing -> not fully recorded
-        val notDoneMissingBaseData = FoodCollectionEntity().apply {
-            route = testRoute3
             kmStart = 10
             kmEnd = 20
             items = listOf(
@@ -181,10 +176,11 @@ internal class DashboardServiceTest {
                 },
             )
         }
-        // fully recorded, same as testFoodCollectionRoute1Entity but for a different/later route -
-        // verifies recordedRouteNames covers more than one route and sorts by route number
-        val doneRoute4 = FoodCollectionEntity().apply {
-            route = testRoute4
+        // fully recorded but without a route reference (defensive case, route is nullable on the
+        // entity) - must fall back to the default sort key instead of throwing, and must be
+        // dropped from recordedRouteNames (no name to show) while still counting towards the total
+        val doneWithoutRoute = FoodCollectionEntity().apply {
+            route = null
             car = testCar1
             driver = testEmployee1
             coDriver = testEmployee2
@@ -204,9 +200,16 @@ internal class DashboardServiceTest {
             endedAt = null
             foodCollections = listOf(
                 testFoodCollectionRoute1Entity,
-                notDoneMissingItems,
-                notDoneMissingBaseData,
+                // real "getOrCreateFoodCollectionEntity" scenario: base data saved, items field
+                // never touched yet and still at its entity default of null (not an empty list)
+                partiallyRecordedFoodCollection(items = null),
+                partiallyRecordedFoodCollection(items = emptyList()),
+                partiallyRecordedFoodCollection(driver = null),
+                partiallyRecordedFoodCollection(coDriver = null),
+                partiallyRecordedFoodCollection(kmStart = null),
+                partiallyRecordedFoodCollection(kmEnd = null),
                 doneRoute4,
+                doneWithoutRoute,
             )
         }
         every { distributionRepository.findFirstByOrderByIdDesc() } returns testDistributionEntity
@@ -220,10 +223,35 @@ internal class DashboardServiceTest {
 
         val data = service.getData()
 
-        assertThat(data.logistics!!.foodCollectionsRecordedCount).isEqualTo(2)
+        assertThat(data.logistics!!.foodCollectionsRecordedCount).isEqualTo(3)
         assertThat(data.logistics.foodCollectionsTotalCount).isEqualTo(4)
         assertThat(data.logistics.recordedRouteNames).containsExactly("Route 1", "Route 4")
         assertThat(data.logistics.foodAmountTotal).isEqualTo(BigDecimal(100))
+    }
+
+    // Base data is otherwise complete (car/driver/co-driver/mileage) and one food item is present -
+    // each call below nulls out exactly one of those fields, to exercise every individual
+    // "not fully recorded" branch in DashboardService.isFullyRecorded() on its own.
+    private fun partiallyRecordedFoodCollection(
+        driver: EmployeeEntity? = testEmployee1,
+        coDriver: EmployeeEntity? = testEmployee2,
+        kmStart: Int? = 100,
+        kmEnd: Int? = 200,
+        items: List<FoodCollectionItemEntity>? = listOf(
+            FoodCollectionItemEntity().apply {
+                category = testFoodCategory1
+                shop = testShop1
+                amount = 0
+            },
+        ),
+    ): FoodCollectionEntity = FoodCollectionEntity().apply {
+        route = testRoute2
+        car = testCar1
+        this.driver = driver
+        this.coDriver = coDriver
+        this.kmStart = kmStart
+        this.kmEnd = kmEnd
+        this.items = items
     }
 
     @Test

--- a/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
@@ -36,13 +36,6 @@ describe('Food Collection Recording', () => {
       cy.byTestId('save-items-button').click();
       assertSavedToast();
 
-      // Route 2 now has both base data and food items entered, so the dashboard panel should
-      // count it as fully recorded and list it by name - other routes (untouched) must not count.
-      cy.visit('/#/');
-      cy.byTestId('recorded-food-collections-count').should('have.text', '1 / 3');
-      cy.byTestId('recorded-food-collections-route-names').should('have.text', 'Route 2');
-      cy.visit('/#/logistik/warenerfassung');
-
       // check if existing data is filled again
       cy.byTestId('routeInput').click();
       cy.get('mat-option').contains('Route 1').click();
@@ -51,6 +44,12 @@ describe('Food Collection Recording', () => {
       cy.byTestId('category-1-shop-20-input').should('have.value', '12');
 
       assertNoEmployeeModalsOpen();
+
+      // Route 2 now has both base data and food items entered, so the dashboard panel should
+      // count it as fully recorded and list it by name - other routes (untouched) must not count.
+      cy.visit('/#/');
+      cy.byTestId('recorded-food-collections-count').should('have.text', '1 / 3');
+      cy.byTestId('recorded-food-collections-route-names').should('have.text', 'Route 2');
     });
   });
 

--- a/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
@@ -36,6 +36,13 @@ describe('Food Collection Recording', () => {
       cy.byTestId('save-items-button').click();
       assertSavedToast();
 
+      // Route 2 now has both base data and food items entered, so the dashboard panel should
+      // count it as fully recorded and list it by name - other routes (untouched) must not count.
+      cy.visit('/#/');
+      cy.byTestId('recorded-food-collections-count').should('have.text', '1 / 3');
+      cy.byTestId('recorded-food-collections-route-names').should('have.text', 'Route 2');
+      cy.visit('/#/logistik/warenerfassung');
+
       // check if existing data is filled again
       cy.byTestId('routeInput').click();
       cy.get('mat-option').contains('Route 1').click();

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.html
@@ -10,5 +10,8 @@
     } @else {
       <div testid="recorded-food-collections-count" class="text-5xl">-</div>
     }
+    @if (recordedRouteNames() && recordedRouteNames()!.length > 0) {
+      <div testid="recorded-food-collections-route-names" class="text-sm text-white/80 mt-2">{{ recordedRouteNames()!.join(', ') }}</div>
+    }
   </mat-card-content>
 </mat-card>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.spec.ts
@@ -88,4 +88,31 @@ describe('RecordedFoodCollectionsComponent', () => {
     expect(color).toBe('success');
   });
 
+  it('recorded route names rendered when present', () => {
+    globalStateService.getCurrentDistribution.mockReturnValue(signal({id: 123, startedAt: new Date()}).asReadonly());
+
+    const fixture = TestBed.createComponent(RecordedFoodCollectionsComponent);
+    const componentRef = fixture.componentRef;
+    componentRef.setInput('countRecorded', 2);
+    componentRef.setInput('countTotal', 5);
+    componentRef.setInput('recordedRouteNames', ['Route 1', 'Route 3']);
+
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('[testid="recorded-food-collections-route-names"]')).nativeElement.textContent.trim())
+      .toBe('Route 1, Route 3');
+  });
+
+  it('recorded route names not rendered when empty', () => {
+    globalStateService.getCurrentDistribution.mockReturnValue(signal({id: 123, startedAt: new Date()}).asReadonly());
+
+    const fixture = TestBed.createComponent(RecordedFoodCollectionsComponent);
+    const componentRef = fixture.componentRef;
+    componentRef.setInput('countRecorded', 0);
+    componentRef.setInput('countTotal', 5);
+    componentRef.setInput('recordedRouteNames', []);
+
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('[testid="recorded-food-collections-route-names"]'))).toBeNull();
+  });
+
 });

--- a/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/components/recorded-food-collections/recorded-food-collections.component.ts
@@ -16,6 +16,7 @@ import {GlobalStateService} from '../../../../common/state/global-state.service'
 export class RecordedFoodCollectionsComponent {
   countRecorded = input<number | null>(null);
   countTotal = input<number | null>(null);
+  recordedRouteNames = input<string[] | null>(null);
 
   private readonly globalStateService = inject(GlobalStateService);
 

--- a/frontend/src/main/webapp/src/app/modules/dashboard/dashboard.component.html
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/dashboard.component.html
@@ -8,7 +8,8 @@
 <mat-divider class="!m-4"></mat-divider>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-2">
   <tafel-recorded-food-collections [countRecorded]="data()?.logistics?.foodCollectionsRecordedCount ?? null"
-                                   [countTotal]="data()?.logistics?.foodCollectionsTotalCount ?? null">
+                                   [countTotal]="data()?.logistics?.foodCollectionsTotalCount ?? null"
+                                   [recordedRouteNames]="data()?.logistics?.recordedRouteNames ?? null">
   </tafel-recorded-food-collections>
   <tafel-food-amount [amount]="data()?.logistics?.foodAmountTotal ?? null">
   </tafel-food-amount>

--- a/frontend/src/main/webapp/src/app/modules/dashboard/dashboard.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/dashboard/dashboard.component.ts
@@ -66,5 +66,6 @@ export interface DashboardStatisticsData {
 export interface DashboardLogisticsData {
   foodCollectionsRecordedCount?: number;
   foodCollectionsTotalCount?: number;
+  recordedRouteNames?: string[];
   foodAmountTotal?: number;
 }


### PR DESCRIPTION
## Summary
- Fixes #2956: the "Erfasste Routen" dashboard panel counted a route as soon as any partial food-collection record existed (e.g. only mileage/driver saved but no food items yet, or items entered but no base data)
- A route now only counts as recorded once base data (car/driver/co-driver/mileage) **and** food items are both entered
- The panel now also lists which exact routes are already done (sorted by route number)

## Test plan
- [x] Backend unit tests updated (`DashboardServiceTest`, `DashboardControllerTest`) covering partial-vs-fully-recorded routes and the new route name list/sort order
- [x] Frontend unit tests added for `RecordedFoodCollectionsComponent` (renders/hides route name list)
- [x] Cypress e2e (`food-collection-recording.cy.ts`) extended to verify the dashboard panel reflects a fully recorded route by name after saving both base data and items
- [x] `./gradlew :backend:test` and `ng test` pass; `ng lint` clean

https://claude.ai/code/session_01Rbo9cRK5QHchrTnPkFdnfJ