### PR TITLE
fix: make search-by-cost-contribution e2e test independent of suite-wide debt state

### DIFF
--- a/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
@@ -47,8 +47,22 @@ describe('Customer Search', () => {
   });
 
   it('search by cost contribution', () => {
-    cy.byTestId('costContributionInput').click();
-    clickSearchAndOpenFirstResult(100);
+    cy.createDummyCustomer().then((response) => {
+      const customer = response.body.data;
+      const customerId = customer.id!;
+      cy.accrueCostContributionDebt(customerId);
+
+      // Filter by lastname too - asserting on the cost-contribution filter alone would depend on
+      // this being the only customer with pending debt suite-wide, which broke repeatedly when
+      // other specs left dummy customers with leftover debt behind (see #2966). The randomized
+      // dummy lastname combined with the cost-contribution filter narrows to just this customer
+      // regardless of what other specs have accrued.
+      cy.byTestId('lastnameText').type(customer.lastname);
+      cy.byTestId('costContributionInput').click();
+      clickSearchAndOpenFirstResult(customerId);
+
+      cy.request('PUT', `/api/households/${customerId}/cost-contribution`, {amount: 0});
+    });
   });
 
   it('search result renders as a card list on phone and search still works', () => {


### PR DESCRIPTION
## Summary
- `customer-search.cy.ts`'s "search by cost contribution" test asserted a suite-wide result count of exactly 1, assuming customer #100 was the only household with pending debt. Any other spec transiently leaving a dummy customer with debt behind (before its own cleanup step runs) breaks that assumption when the full suite runs together.
- The test now creates and accrues debt on its own dummy customer via `cy.accrueCostContributionDebt`, filters by lastname + cost-contribution together (backend ANDs the filters, and the dummy lastname is randomized so there's no collision risk), and cleans its own debt back to zero afterward.

Fixes #2966 (the immediate cross-spec pollution was already patched in #2963 at the individual leak sites; this closes the underlying fragility that issue was intentionally left open for).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `cypress run` for `customer-search.cy.ts` alone - all 7 tests pass
- [x] `cypress run` for `customer-search.cy.ts` + `customer-detail.cy.ts` + `ticket-screen.cy.ts` together (the specs that leave/clean up cost-contribution debt) - all 48 tests pass

https://claude.ai/code/session_01Rbo9cRK5QHchrTnPkFdnfJ