### PR TITLE
fix: retry once on CSRF-token 403 to fix scanner.cy.ts full-suite flake

### DIFF
--- a/frontend/src/main/webapp/src/app/common/http/xsrf-interceptor.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/http/xsrf-interceptor.service.spec.ts
@@ -1,5 +1,5 @@
 import type { MockedObject } from 'vitest';
-import { HttpClient, provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { xsrfInterceptor } from './xsrf-interceptor.service';
@@ -68,6 +68,36 @@ describe('XsrfInterceptor', () => {
 
         const request = httpTestingController.expectOne('/test');
         expect(request.request.headers.has('X-XSRF-TOKEN')).toBe(false);
+    });
+
+    it('retries once with a refreshed token after a 403 if the cookie has since appeared', () => {
+        cookieServiceSpy.get.mockReturnValueOnce('').mockReturnValueOnce('fresh-token');
+
+        let result: unknown;
+        httpClient.post('/test', {}).subscribe({error: (err) => result = err});
+
+        const firstRequest = httpTestingController.expectOne('/test');
+        expect(firstRequest.request.headers.has('X-XSRF-TOKEN')).toBe(false);
+        firstRequest.flush(null, {status: 403, statusText: 'Forbidden'});
+
+        const retriedRequest = httpTestingController.expectOne('/test');
+        expect(retriedRequest.request.headers.get('X-XSRF-TOKEN')).toBe('fresh-token');
+        retriedRequest.flush({});
+
+        expect(result).toBeUndefined();
+    });
+
+    it('does not retry a 403 when the cookie is unchanged', () => {
+        cookieServiceSpy.get.mockReturnValue('token-value');
+
+        let result: unknown;
+        httpClient.post('/test', {}).subscribe({error: (err) => result = err});
+
+        const request = httpTestingController.expectOne('/test');
+        request.flush(null, {status: 403, statusText: 'Forbidden'});
+
+        expect(result).toBeInstanceOf(HttpErrorResponse);
+        expect((result as HttpErrorResponse).status).toBe(403);
     });
 
 });

--- a/frontend/src/main/webapp/src/app/common/http/xsrf-interceptor.service.ts
+++ b/frontend/src/main/webapp/src/app/common/http/xsrf-interceptor.service.ts
@@ -1,6 +1,7 @@
-import {HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest} from '@angular/common/http';
+import {HttpErrorResponse, HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest} from '@angular/common/http';
 import {inject} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, throwError} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 import {CookieService} from 'ngx-cookie-service';
 
 /**
@@ -18,10 +19,28 @@ export const xsrfInterceptor: HttpInterceptorFn = (
     return next(request);
   }
 
-  const token = cookieService.get('XSRF-TOKEN');
-  if (!token) {
-    return next(request);
-  }
+  const send = (token: string | undefined): Observable<HttpEvent<unknown>> =>
+    next(token ? request.clone({headers: request.headers.set('X-XSRF-TOKEN', token)}) : request);
 
-  return next(request.clone({headers: request.headers.set('X-XSRF-TOKEN', token)}));
+  const initialToken = cookieService.get('XSRF-TOKEN');
+
+  return send(initialToken).pipe(
+    catchError((error: unknown) => {
+      if (!(error instanceof HttpErrorResponse) || error.status !== 403) {
+        return throwError(() => error);
+      }
+
+      // The XSRF-TOKEN cookie is only set once some backend response has come back (it can't be
+      // primed by the initial page load, since that's served by the frontend dev server / static
+      // hosting, not the backend). A mutating request fired concurrently with the app's other
+      // bootstrap calls - e.g. the scanner page's registration call right after login - can race
+      // ahead of the response that would have set the cookie and go out with no token at all.
+      // Retry once with whatever the cookie is now before treating this as a genuine failure.
+      const freshToken = cookieService.get('XSRF-TOKEN');
+      if (!freshToken || freshToken === initialToken) {
+        return throwError(() => error);
+      }
+      return send(freshToken);
+    })
+  );
 };


### PR DESCRIPTION
## Summary
Fixes #2967 (the `scanner.cy.ts` half of it — see investigation notes below on `settings-shelters.cy.ts`).

Root cause: a genuine race in the app's CSRF handling, not test flakiness. The `XSRF-TOKEN` cookie is only ever set by a *backend* response — the SPA shell is served by the frontend dev server (and in prod, static hosting), not the backend — so `xsrfInterceptor` can end up sending a mutating request with no cookie yet if it fires before any prior response has set one. The scanner page's registration `POST` fires concurrently with the app-shell's own bootstrap calls right after login, so under the CPU/network load of the full 28-spec local e2e suite it occasionally loses that race and goes out with no `X-XSRF-TOKEN` header at all. The backend's `CsrfFilter` then rejects it with 403 before it ever reaches the controller (confirmed via backend debug logs: no `Mapped to ScannerController#registerScanner` line, straight to a 403 `/error` forward).

- `xsrf-interceptor.service.ts`: retry once with a freshly-read cookie if a mutating request comes back 403 and the cookie value has since appeared/changed — mirrors the same rotation-retry pattern the Cypress test helpers (`cypress/support/commands.ts`) already use for `cy.request()`.
- Added 2 unit tests covering the retry and no-retry paths.

## Investigation notes (`settings-shelters.cy.ts`)
This issue also reported `settings-shelters.cy.ts` → `edits a shelter` flaking in the full suite. I was unable to reproduce it: it passed cleanly across 4 separate full local-suite runs (both before and after this fix). Its failure point is a `GET` request, which doesn't need a CSRF token, so it isn't the same root cause as the scanner issue. Leaving it as an open, separate problem per the issue's own "needs more repro runs" note — will comment on the issue with these findings.

## Test plan
- [x] `ng test` — 6/6 passing in `xsrf-interceptor.service.spec.ts` (4 existing + 2 new)
- [x] Reproduced the original 403 in a full local `npm run cy:run-ci-local` run (backend on `e2e` profile)
- [x] Re-ran the full suite 3 times with the fix in place — all 28 specs / 209 tests passing each time, including `scanner.cy.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)