### PR TITLE
fix: center upload panel and drop empty-state text on Documents tab

### DIFF
--- a/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
@@ -257,15 +257,12 @@ describe('Customer Detail', () => {
         cy.visit('/#/kunden/detail/' + customerId);
 
         cy.byTestId('documents-tab-label').click();
-        cy.byTestId('nodocuments-label').should('be.visible');
-
         cy.byTestId('upload-document-panel').should('be.visible');
         cy.byTestId('documentTypeInput').click();
         cy.byTestId('documentTypeInput-option-PROOF_OF_INCOME').click();
         cy.byTestId('documentFileInput').selectFile('cypress/fixtures/documents/test-document.pdf', {force: true});
         cy.byTestId('okButton').click();
 
-        cy.byTestId('nodocuments-label').should('not.exist');
         cy.byTestId('document-0-fileNameText').should('have.text', 'test-document.pdf');
 
         const downloadsFolder = Cypress.config('downloadsFolder');
@@ -280,7 +277,7 @@ describe('Customer Detail', () => {
           cy.byTestId('okButton').click();
         });
 
-        cy.byTestId('nodocuments-label').should('be.visible');
+        cy.byTestId('upload-document-panel').should('be.visible');
       });
     });
 

--- a/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
+++ b/frontend/src/main/webapp/src/app/modules/customer/views/customer-detail/customer-detail.component.html
@@ -311,12 +311,11 @@
           <span testid="documents-tab-label">Dokumente ({{ customerDocuments()?.length }})</span>
         </ng-template>
         <div>
-          <div class="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-4">
-            <div>
-              @if (customerDocuments()?.length === 0) {
-                <h6 testid="nodocuments-label">Keine Dokumente vorhanden</h6>
-              }
-              @if ((customerDocuments()?.length ?? 0) > 0) {
+          <div [class]="(customerDocuments()?.length ?? 0) === 0
+            ? 'flex justify-center'
+            : 'grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-4'">
+            @if ((customerDocuments()?.length ?? 0) > 0) {
+              <div>
                 <div class="grid grid-cols-1 gap-2">
                   @for (doc of customerDocuments(); track doc.id; let i = $index) {
                     <mat-card>
@@ -343,9 +342,9 @@
                     </mat-card>
                   }
                 </div>
-              }
-            </div>
-            <div>
+              </div>
+            }
+            <div [class]="(customerDocuments()?.length ?? 0) === 0 ? 'w-full lg:max-w-md' : ''">
               <tafel-upload-document-panel (upload)="onDocumentUpload($event)"></tafel-upload-document-panel>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Removes the "Keine Dokumente vorhanden" placeholder on the customer's Documents tab
- Centers the upload panel (capped at `lg:max-w-md`) when there are no documents yet; once documents exist, the layout is unchanged (2-column grid)
- Keeps `tafel-upload-document-panel` mounted at a single, stable template location instead of toggling it via `@if`/`@else` — the previous structure destroyed/recreated the component on the 0→1 document transition, resetting its internal state (scanner source tab, scanner file list, SSE subscription), which broke the scanner-import e2e flow

Closes #2962

## Test plan
- [x] `ng build --configuration production` succeeds
- [x] Full `customer-detail.cy.ts` Cypress spec passes (28/28) against a freshly restarted `e2e`-profile backend, including the scanner-import flow that exercises the empty→non-empty document transition