### PR TITLE
fix: direct navigation to a hash route breaks relative API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ Code quality is monitored via SonarCloud with JaCoCo coverage reports.
 
 ### Reverse Proxy Deployment (Subpath / Subdomain)
 
-The frontend is built once and the same artifact is deployed unchanged behind a reverse proxy, whether it's mounted at a **subpath** on a shared domain (e.g. multiple environments under `tafel.wrk.at`) or given its own **subdomain** (the app owns the whole host). Which one is in play is controlled by a single backend property:
+The frontend is built once and the same artifact is deployed unchanged behind a reverse proxy, whether it's mounted at a **subpath** on a shared domain (e.g. multiple environments under one domain) or given its own **subdomain** (the app owns the whole host). Which one is in play is controlled by a single backend property:
 
 ```yaml
 tafeladmin:
   server:
-    relativeBaseUrl: /verwaltung-test/   # "/" for a subdomain / root deployment
+    relativeBaseUrl: /tafel-admin/   # "/" for a subdomain / root deployment
 ```
 
 This must match whatever prefix the reverse proxy exposes to the browser. It drives both the JWT cookie path and the frontend's `<base href>` (rewritten server-side by `IndexHtmlController` - see #2972/#2978), so relative asset and API URLs keep resolving correctly once the proxy has stripped its prefix.
@@ -301,24 +301,24 @@ map $request_uri $sse_cache_control {
 
 #### Subpath example
 
-nginx strips the `/verwaltung-test/` prefix before forwarding to the backend, and passes it along separately via `X-Forwarded-Prefix` (not currently consumed by the app, but kept for parity/future use and general reverse-proxy convention):
+nginx strips the `/tafel-admin/` prefix before forwarding to the backend, and passes it along separately via `X-Forwarded-Prefix` (not currently consumed by the app, but kept for parity/future use and general reverse-proxy convention):
 
 ```nginx
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
-    server_name tafel.wrk.at;
+    server_name tafel-admin.example.com;
 
     # Common Headers
     resolver 127.0.0.11 valid=30s;  # Docker's embedded DNS, for re-resolving the upstream on restart
 
-    location /verwaltung-test/ {
+    location /tafel-admin/ {
         proxy_set_header Host               $host;
         proxy_set_header X-Real-IP          $remote_addr;
         proxy_set_header X-Forwarded-Proto  $scheme;
         proxy_set_header X-Forwarded-Port   443;
         proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Prefix /verwaltung-test;
+        proxy_set_header X-Forwarded-Prefix /tafel-admin;
         proxy_set_header Forwarded          '';
 
         proxy_buffering off;
@@ -329,8 +329,8 @@ server {
         chunked_transfer_encoding off;
 
         # Logic for re-resolution and path stripping
-        set $upstream http://admin-test:8080;
-        rewrite ^/verwaltung-test/(.*) /$1 break;
+        set $upstream http://tafel-admin-backend:8080;
+        rewrite ^/tafel-admin/(.*) /$1 break;
 
         # SSE-Specific Optimization
         add_header Cache-Control $sse_cache_control;
@@ -340,7 +340,7 @@ server {
 }
 ```
 
-Matching backend config: `tafeladmin.server.relativeBaseUrl: /verwaltung-test/`.
+Matching backend config: `tafeladmin.server.relativeBaseUrl: /tafel-admin/`.
 
 #### Subdomain example
 
@@ -350,7 +350,7 @@ A subdomain owns the whole host, so there's no prefix to strip and `relativeBase
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
-    server_name verwaltung-demo.wrk.at;
+    server_name tafeladmin.example.com;
 
     resolver 127.0.0.11 valid=30s;
 
@@ -369,7 +369,7 @@ server {
         proxy_set_header Connection '';
         chunked_transfer_encoding off;
 
-        set $upstream http://admin-demo:8080;
+        set $upstream http://tafel-admin-backend:8080;
 
         add_header Cache-Control $sse_cache_control;
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,112 @@ Code quality is monitored via SonarCloud with JaCoCo coverage reports.
 | `testdata` | Loads test data via Flyway callback |
 | `e2e` | E2E testing with test user credentials |
 
+### Reverse Proxy Deployment (Subpath / Subdomain)
+
+The frontend is built once and the same artifact is deployed unchanged behind a reverse proxy, whether it's mounted at a **subpath** on a shared domain (e.g. multiple environments under `tafel.wrk.at`) or given its own **subdomain** (the app owns the whole host). Which one is in play is controlled by a single backend property:
+
+```yaml
+tafeladmin:
+  server:
+    relativeBaseUrl: /verwaltung-test/   # "/" for a subdomain / root deployment
+```
+
+This must match whatever prefix the reverse proxy exposes to the browser. It drives both the JWT cookie path and the frontend's `<base href>` (rewritten server-side by `IndexHtmlController` - see #2972/#2978), so relative asset and API URLs keep resolving correctly once the proxy has stripped its prefix.
+
+Both examples below reference `$sse_cache_control` for the SSE-specific `Cache-Control` header. Declare this `map` once at the `http {}` level of your nginx config (outside any `server {}` block) - it's not repeated per example, but both need it:
+
+```nginx
+# See the note below on why this is a map rather than a plain `if`.
+map $request_uri $sse_cache_control {
+    default      "";
+    "~*api/sse"  "no-cache, no-transform";
+}
+```
+
+#### Subpath example
+
+nginx strips the `/verwaltung-test/` prefix before forwarding to the backend, and passes it along separately via `X-Forwarded-Prefix` (not currently consumed by the app, but kept for parity/future use and general reverse-proxy convention):
+
+```nginx
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name tafel.wrk.at;
+
+    # Common Headers
+    resolver 127.0.0.11 valid=30s;  # Docker's embedded DNS, for re-resolving the upstream on restart
+
+    location /verwaltung-test/ {
+        proxy_set_header Host               $host;
+        proxy_set_header X-Real-IP          $remote_addr;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+        proxy_set_header X-Forwarded-Port   443;
+        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Prefix /verwaltung-test;
+        proxy_set_header Forwarded          '';
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        chunked_transfer_encoding off;
+
+        # Logic for re-resolution and path stripping
+        set $upstream http://admin-test:8080;
+        rewrite ^/verwaltung-test/(.*) /$1 break;
+
+        # SSE-Specific Optimization
+        add_header Cache-Control $sse_cache_control;
+
+        proxy_pass $upstream;
+    }
+}
+```
+
+Matching backend config: `tafeladmin.server.relativeBaseUrl: /verwaltung-test/`.
+
+#### Subdomain example
+
+A subdomain owns the whole host, so there's no prefix to strip and `relativeBaseUrl` stays at its default (`/`):
+
+```nginx
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name verwaltung-demo.wrk.at;
+
+    resolver 127.0.0.11 valid=30s;
+
+    location / {
+        proxy_set_header Host               $host;
+        proxy_set_header X-Real-IP          $remote_addr;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+        proxy_set_header X-Forwarded-Port   443;
+        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header Forwarded          '';
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        chunked_transfer_encoding off;
+
+        set $upstream http://admin-demo:8080;
+
+        add_header Cache-Control $sse_cache_control;
+
+        proxy_pass $upstream;
+    }
+}
+```
+
+Both examples were verified end-to-end (path stripping, forwarded headers, and the SSE header) against nginx proxying to a real backend container.
+
+> [!NOTE]
+> The SSE header is set via a `map` rather than the more obvious `if ($request_uri ~* "api/sse") { add_header ...; }`. With `proxy_buffering off` (required here for SSE to stream at all), an `add_header` set inside an `if` block is silently dropped - it never reaches the client, with no error logged. An unconditional `add_header`, or one driven by a `map` variable like above, isn't affected and works reliably. This was confirmed by reproducing both the failure and the fix directly against nginx.
+
 ### Permissions
 
 Access control is based on these permissions:

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
@@ -24,10 +24,7 @@ class IndexHtmlController(
 
     @GetMapping("/", produces = [MediaType.TEXT_HTML_VALUE])
     fun index(): ResponseEntity<String> {
-        // Mirrors spring.web.resources.static-locations (file:${user.dir}/static/) in application.yml
-        // - kept as a plain system property read rather than @Value, since this codebase's
-        // "no field injection" ArchUnit rule (GeneralCodingRulesTest) forbids @Value fields.
-        val resource = resourceLoader.getResource("file:${System.getProperty("user.dir")}/static/index.html")
+        val resource = resourceLoader.getResource(staticResourceLocation() + "index.html")
         if (!resource.exists()) {
             return ResponseEntity.notFound().build()
         }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
@@ -1,11 +1,13 @@
 package at.wrk.tafel.admin.backend.config
 
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.core.io.ResourceLoader
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import java.nio.charset.StandardCharsets
 
 /**
@@ -15,6 +17,13 @@ import java.nio.charset.StandardCharsets
  * ships with `<base href="/">` for local `ng serve` use; this controller rewrites that to the
  * configured prefix so relative asset/API URLs still resolve correctly once nginx has stripped it
  * (see #2972 for what breaks otherwise).
+ *
+ * It also acts as the SPA's fallback route: a direct navigation/bookmark/refresh to a client-side
+ * route (e.g. "/login", "/kunden/suchen") isn't a real server path, but the router needs it to
+ * still resolve to the app shell rather than 404 - Angular's HashLocationStrategy then reads the
+ * intended route from the hash once the app has loaded. Static resource requests (real files, all
+ * of which have an extension in this build) and api requests are excluded so real 404s stay real
+ * 404s.
  */
 @Controller
 class IndexHtmlController(
@@ -23,7 +32,20 @@ class IndexHtmlController(
 ) {
 
     @GetMapping("/", produces = [MediaType.TEXT_HTML_VALUE])
-    fun index(): ResponseEntity<String> {
+    fun index(): ResponseEntity<String> = buildIndexResponse()
+
+    @GetMapping(
+        value = ["/{path:[^\\.]*}", "/**/{path:[^\\.]*}"],
+        produces = [MediaType.TEXT_HTML_VALUE],
+    )
+    fun spaFallback(@PathVariable path: String, request: HttpServletRequest): ResponseEntity<String> {
+        if (request.requestURI.startsWith("/api/")) {
+            return ResponseEntity.notFound().build()
+        }
+        return buildIndexResponse()
+    }
+
+    private fun buildIndexResponse(): ResponseEntity<String> {
         val resource = resourceLoader.getResource(staticResourceLocation() + "index.html")
         if (!resource.exists()) {
             return ResponseEntity.notFound().build()

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
@@ -1,0 +1,44 @@
+package at.wrk.tafel.admin.backend.config
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import org.springframework.core.io.ResourceLoader
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import java.nio.charset.StandardCharsets
+
+/**
+ * The frontend is built once and deployed unchanged behind reverse proxies mounting it at
+ * different path prefixes (e.g. "/verwaltung-dev/", stripped by nginx before the request reaches
+ * this app - see tafeladmin.server.relativeBaseUrl, also used for the JWT cookie path). index.html
+ * ships with `<base href="/">` for local `ng serve` use; this controller rewrites that to the
+ * configured prefix so relative asset/API URLs still resolve correctly once nginx has stripped it
+ * (see #2972 for what breaks otherwise).
+ */
+@Controller
+class IndexHtmlController(
+    private val tafelAdminProperties: TafelAdminProperties,
+    private val resourceLoader: ResourceLoader,
+) {
+
+    @GetMapping("/", produces = [MediaType.TEXT_HTML_VALUE])
+    fun index(): ResponseEntity<String> {
+        // Mirrors spring.web.resources.static-locations (file:${user.dir}/static/) in application.yml
+        // - kept as a plain system property read rather than @Value, since this codebase's
+        // "no field injection" ArchUnit rule (GeneralCodingRulesTest) forbids @Value fields.
+        val resource = resourceLoader.getResource("file:${System.getProperty("user.dir")}/static/index.html")
+        if (!resource.exists()) {
+            return ResponseEntity.notFound().build()
+        }
+
+        val html = resource.inputStream.use { it.readBytes() }.toString(StandardCharsets.UTF_8)
+        val relativeBaseUrl = tafelAdminProperties.server.relativeBaseUrl
+        val templatedHtml = html.replace("<base href=\"/\">", "<base href=\"$relativeBaseUrl\">")
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.TEXT_HTML)
+            .body(templatedHtml)
+    }
+
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
@@ -30,12 +30,18 @@ class IndexHtmlController(
         }
 
         val html = resource.inputStream.use { it.readBytes() }.toString(StandardCharsets.UTF_8)
-        val relativeBaseUrl = tafelAdminProperties.server.relativeBaseUrl
+        // A <base href> without a trailing slash treats its last path segment as a filename, so a
+        // relative URL replaces it instead of appending to it (e.g. "/verwaltung-dev" + "main.js"
+        // resolves to "/main.js", not "/verwaltung-dev/main.js") - relativeBaseUrl historically only
+        // fed the cookie path, where that distinction doesn't matter, so not every environment's
+        // config has a trailing slash. Normalize here rather than relying on ops config for it.
+        val relativeBaseUrl = tafelAdminProperties.server.relativeBaseUrl.let {
+            if (it.endsWith("/")) it else "$it/"
+        }
         val templatedHtml = html.replace("<base href=\"/\">", "<base href=\"$relativeBaseUrl\">")
 
         return ResponseEntity.ok()
             .contentType(MediaType.TEXT_HTML)
             .body(templatedHtml)
     }
-
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/StaticResourceLocation.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/StaticResourceLocation.kt
@@ -1,0 +1,7 @@
+package at.wrk.tafel.admin.backend.config
+
+// Mirrors spring.web.resources.static-locations (file:${user.dir}/static/) in application.yml -
+// shared so IndexHtmlController and WebMvcConfig can't drift apart on where the frontend build
+// actually lives. Kept as a plain system property read rather than @Value, since this codebase's
+// "no field injection" ArchUnit rule (GeneralCodingRulesTest) forbids @Value fields.
+internal fun staticResourceLocation(): String = "file:${System.getProperty("user.dir")}/static/"

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebMvcConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebMvcConfig.kt
@@ -2,8 +2,11 @@ package at.wrk.tafel.admin.backend.config
 
 import at.wrk.tafel.admin.backend.common.api.TafelActiveDistributionRequiredInterceptor
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.CacheControl
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.util.concurrent.TimeUnit
 
 @Configuration
 class WebMvcConfig(
@@ -12,5 +15,25 @@ class WebMvcConfig(
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(tafelActiveDistributionRequiredInterceptor)
+    }
+
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        // Angular's production build content-hashes these (outputHashing: all), so a new deploy
+        // always produces new filenames - safe for browsers to cache indefinitely. Everything else
+        // under static-locations (index.html, favicon/icons/manifest, and critically
+        // ngsw.json/ngsw-worker.js, which the service worker polls to detect updates) is NOT
+        // hashed and must keep Spring Boot's existing no-store default, so it isn't matched here.
+        val immutableCache = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic().immutable()
+
+        registry.addResourceHandler("/main-*.js", "/chunk-*.js", "/styles-*.css")
+            .addResourceLocations(staticResourceLocation())
+            .setCacheControl(immutableCache)
+
+        // A "/media/**" handler resolves lookups against its location with the "media/" prefix
+        // already stripped, so the location itself has to point *into* the media subdirectory -
+        // reusing the top-level static location above would silently 404 every font.
+        registry.addResourceHandler("/media/**")
+            .addResourceLocations("${staticResourceLocation()}media/")
+            .setCacheControl(immutableCache)
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,6 +17,9 @@ server:
   # trust X-Forwarded-* headers from the reverse proxy, so request.isSecure is true behind TLS
   # termination and the JWT cookie is issued with the Secure flag
   forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: text/html,text/css,application/javascript,text/javascript,application/json,image/svg+xml,application/manifest+json
   servlet:
     session.cookie.path: ${tafeladmin.server.relativeBaseUrl}
   tomcat:

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerIT.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerIT.kt
@@ -1,0 +1,71 @@
+package at.wrk.tafel.admin.backend.config
+
+import at.wrk.tafel.admin.backend.TafelBaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.io.File
+
+// Exercises the real Spring wiring behind IndexHtmlController - property binding and static file
+// resolution from disk - which IndexHtmlControllerTest's mocked ResourceLoader doesn't cover.
+// See #2972/#2978: relativeBaseUrl without a trailing slash (as configured on the deployed dev
+// environment) broke every asset URL in production despite the unit test suite passing, because
+// that test only ever exercised a value that already had one.
+class IndexHtmlControllerIT : TafelBaseIntegrationTest() {
+
+    companion object {
+        @DynamicPropertySource
+        @JvmStatic
+        fun dynamicProperties(registry: DynamicPropertyRegistry) {
+            // Deliberately no trailing slash - mirrors the deployed dev environment's actual config.
+            registry.add("tafeladmin.server.relativeBaseUrl") { "/tafel-admin" }
+        }
+    }
+
+    @Autowired
+    private lateinit var indexHtmlController: IndexHtmlController
+
+    private val staticDir = File(System.getProperty("user.dir"), "static")
+    private val indexHtmlFile = File(staticDir, "index.html")
+    private val staticDirPreexisted = staticDir.exists()
+
+    @BeforeEach
+    fun beforeEach() {
+        staticDir.mkdirs()
+        indexHtmlFile.writeText("<html><head><base href=\"/\"></head><body>test</body></html>")
+    }
+
+    @AfterEach
+    fun afterEach() {
+        indexHtmlFile.delete()
+        if (!staticDirPreexisted) {
+            staticDir.delete()
+        }
+    }
+
+    @Test
+    fun `index html served with base href rewritten to the real configured relative base url`() {
+        val response = indexHtmlController.index()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.headers.contentType).isEqualTo(MediaType.TEXT_HTML)
+        assertThat(response.body).isEqualTo(
+            "<html><head><base href=\"/tafel-admin/\"></head><body>test</body></html>",
+        )
+    }
+
+    @Test
+    fun `missing index html on disk results in a 404`() {
+        indexHtmlFile.delete()
+
+        val response = indexHtmlController.index()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerIT.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerIT.kt
@@ -5,18 +5,30 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
-// Exercises the real Spring wiring behind IndexHtmlController - property binding and static file
-// resolution from disk - which IndexHtmlControllerTest's mocked ResourceLoader doesn't cover.
-// See #2972/#2978: relativeBaseUrl without a trailing slash (as configured on the deployed dev
-// environment) broke every asset URL in production despite the unit test suite passing, because
-// that test only ever exercised a value that already had one.
+// Exercises the real Spring wiring behind IndexHtmlController over real HTTP - property binding,
+// static file resolution from disk, and (critically) actual DispatcherServlet routing precedence -
+// which IndexHtmlControllerTest's mocked ResourceLoader/direct method calls don't cover.
+//
+// Both bugs this guards against shipped to the deployed dev environment despite a green unit test
+// suite:
+//   - relativeBaseUrl without a trailing slash (see the trailing-slash commit) - the unit test only
+//     ever exercised a value that already had one.
+//   - the SPA fallback route not existing at all (see #2972) - a direct navigation to a non-root
+//     path 404'd for real, which a direct method call to spaFallback() can't detect since it
+//     doesn't ask Spring whether GET /login actually gets routed there in the first place.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class IndexHtmlControllerIT : TafelBaseIntegrationTest() {
 
     companion object {
@@ -28,8 +40,10 @@ class IndexHtmlControllerIT : TafelBaseIntegrationTest() {
         }
     }
 
-    @Autowired
-    private lateinit var indexHtmlController: IndexHtmlController
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val httpClient = HttpClient.newHttpClient()
 
     private val staticDir = File(System.getProperty("user.dir"), "static")
     private val indexHtmlFile = File(staticDir, "index.html")
@@ -50,22 +64,64 @@ class IndexHtmlControllerIT : TafelBaseIntegrationTest() {
     }
 
     @Test
-    fun `index html served with base href rewritten to the real configured relative base url`() {
-        val response = indexHtmlController.index()
+    fun `root path served with base href rewritten to the real configured relative base url`() {
+        val response = get("/")
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.headers.contentType).isEqualTo(MediaType.TEXT_HTML)
-        assertThat(response.body).isEqualTo(
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.headers().firstValue("Content-Type").orElse(null)).startsWith(MediaType.TEXT_HTML_VALUE)
+        assertThat(response.body()).isEqualTo(
             "<html><head><base href=\"/tafel-admin/\"></head><body>test</body></html>",
         )
     }
 
     @Test
-    fun `missing index html on disk results in a 404`() {
+    fun `a top-level client-side route is routed to the spa fallback`() {
+        val response = get("/login")
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.body()).contains("<base href=\"/tafel-admin/\">")
+    }
+
+    @Test
+    fun `a nested client-side route is routed to the spa fallback`() {
+        val response = get("/kunden/suchen")
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.body()).contains("<base href=\"/tafel-admin/\">")
+    }
+
+    @Test
+    fun `an unauthenticated api request is not swallowed into the spa fallback`() {
+        // WebSecurityConfig requires authentication on all of "/api/**", so an anonymous request
+        // never reaches this controller at all - it's rejected by the security filter chain before
+        // Spring MVC's handler mapping even runs. That's still the guarantee this test cares about:
+        // an api path must never resolve to the app shell, authenticated or not.
+        // IndexHtmlControllerTest separately unit-tests spaFallback()'s own "/api/" guard, which is
+        // what protects an *authenticated* request to a nonexistent api endpoint from the same fate.
+        val response = get("/api/some-nonexistent-endpoint")
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value())
+        assertThat(response.body()).doesNotContain("<base href")
+    }
+
+    @Test
+    fun `a request for a nonexistent static file is not swallowed into the spa fallback`() {
+        val response = get("/nonexistent-file.js")
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
+        assertThat(response.body()).doesNotContain("<base href")
+    }
+
+    @Test
+    fun `missing index html on disk results in a 404 for both the root path and the spa fallback`() {
         indexHtmlFile.delete()
 
-        val response = indexHtmlController.index()
+        assertThat(get("/").statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
+        assertThat(get("/login").statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
+    }
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    private fun get(path: String): HttpResponse<String> {
+        val request = HttpRequest.newBuilder(URI.create("http://localhost:$port$path")).GET().build()
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString())
     }
 }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
@@ -4,6 +4,7 @@ import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminServerProperties
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.io.ByteArrayResource
@@ -72,6 +73,40 @@ class IndexHtmlControllerTest {
         )
 
         val response = controller.index()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `spa fallback serves the app shell for a client-side route`() {
+        every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns indexHtmlResource(
+            "<html><head><base href=\"/\"></head><body></body></html>",
+        )
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(),
+            resourceLoader = resourceLoader,
+        )
+        val request = mockk<HttpServletRequest> {
+            every { requestURI } returns "/login"
+        }
+
+        val response = controller.spaFallback(path = "login", request = request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo("<html><head><base href=\"/\"></head><body></body></html>")
+    }
+
+    @Test
+    fun `spa fallback does not swallow unmatched api requests into a 200`() {
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(),
+            resourceLoader = resourceLoader,
+        )
+        val request = mockk<HttpServletRequest> {
+            every { requestURI } returns "/api/some-nonexistent-endpoint"
+        }
+
+        val response = controller.spaFallback(path = "some-nonexistent-endpoint", request = request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
     }

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
@@ -1,0 +1,66 @@
+package at.wrk.tafel.admin.backend.config
+
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
+import at.wrk.tafel.admin.backend.config.properties.TafelAdminServerProperties
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.Resource
+import org.springframework.core.io.ResourceLoader
+import org.springframework.http.HttpStatus
+
+class IndexHtmlControllerTest {
+
+    private val resourceLoader = mockk<ResourceLoader>()
+
+    @Test
+    fun `base href rewritten to the configured relative base url`() {
+        every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns indexHtmlResource(
+            "<html><head><base href=\"/\"></head><body></body></html>",
+        )
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(server = TafelAdminServerProperties(relativeBaseUrl = "/verwaltung-dev/")),
+            resourceLoader = resourceLoader,
+        )
+
+        val response = controller.index()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo("<html><head><base href=\"/verwaltung-dev/\"></head><body></body></html>")
+    }
+
+    @Test
+    fun `base href left as root when no relative base url is configured`() {
+        every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns indexHtmlResource(
+            "<html><head><base href=\"/\"></head><body></body></html>",
+        )
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(),
+            resourceLoader = resourceLoader,
+        )
+
+        val response = controller.index()
+
+        assertThat(response.body).isEqualTo("<html><head><base href=\"/\"></head><body></body></html>")
+    }
+
+    @Test
+    fun `missing index html results in a 404`() {
+        every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns mockk<Resource> {
+            every { exists() } returns false
+        }
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(),
+            resourceLoader = resourceLoader,
+        )
+
+        val response = controller.index()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    private fun indexHtmlResource(content: String): Resource = ByteArrayResource(content.toByteArray())
+
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlControllerTest.kt
@@ -32,6 +32,21 @@ class IndexHtmlControllerTest {
     }
 
     @Test
+    fun `trailing slash added when the configured relative base url is missing one`() {
+        every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns indexHtmlResource(
+            "<html><head><base href=\"/\"></head><body></body></html>",
+        )
+        val controller = IndexHtmlController(
+            tafelAdminProperties = TafelAdminProperties(server = TafelAdminServerProperties(relativeBaseUrl = "/verwaltung-dev")),
+            resourceLoader = resourceLoader,
+        )
+
+        val response = controller.index()
+
+        assertThat(response.body).isEqualTo("<html><head><base href=\"/verwaltung-dev/\"></head><body></body></html>")
+    }
+
+    @Test
     fun `base href left as root when no relative base url is configured`() {
         every { resourceLoader.getResource(match { it.endsWith("/static/index.html") }) } returns indexHtmlResource(
             "<html><head><base href=\"/\"></head><body></body></html>",
@@ -62,5 +77,4 @@ class IndexHtmlControllerTest {
     }
 
     private fun indexHtmlResource(content: String): Resource = ByteArrayResource(content.toByteArray())
-
 }

--- a/frontend/src/main/webapp/cypress/e2e/login.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/login.cy.ts
@@ -29,6 +29,17 @@ describe('Login', () => {
     cy.url().should('contain', '/uebersicht');
   });
 
+  it('login successful after a direct navigation to a non-root path (e.g. a bookmark)', () => {
+    // Regression test for #2972: loading the app from a path other than "/" or "/#/..." (as
+    // happens with a bookmarked/typed URL) must not break the app's own API calls, which rely on
+    // an absolute base URL derived from the page - not the requested path.
+    cy.visit('/login');
+
+    enterLoginData('e2etest', 'e2etest');
+
+    cy.url().should('contain', '/uebersicht');
+  });
+
   it('login failed', () => {
     enterLoginData('dummy', 'dummy');
 

--- a/frontend/src/main/webapp/src/app/common/state/global-state.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/state/global-state.service.spec.ts
@@ -25,6 +25,7 @@ describe('GlobalStateService', () => {
     it('init calls services correctly', () => {
         const { service, sseServiceSpy } = setup();
         expect(service.getCurrentDistribution()()).toBeNull();
+        expect(service.getHasReceivedDistribution()()).toBe(false);
 
         const testDistributionUpdate: DistributionItemUpdate = {
             distribution: {
@@ -37,6 +38,7 @@ describe('GlobalStateService', () => {
         service.init();
 
         expect(service.getCurrentDistribution()()).toEqual(testDistributionUpdate.distribution);
+        expect(service.getHasReceivedDistribution()()).toBe(true);
 
         const args = vi.mocked(sseServiceSpy.listen).mock.lastCall!;
         expect(args[0]).toBe('/sse/distributions');

--- a/frontend/src/main/webapp/src/app/common/state/global-state.service.ts
+++ b/frontend/src/main/webapp/src/app/common/state/global-state.service.ts
@@ -15,14 +15,18 @@ export class GlobalStateService {
 
   private readonly _currentDistribution: WritableSignal<DistributionItem | null> = signal(null);
   private readonly _connectionState: WritableSignal<boolean> = signal(false);
+  private readonly _hasReceivedDistribution: WritableSignal<boolean> = signal(false);
 
 
   /**
    * Starts the `/sse/distributions` subscription. Called once from `default-layout-resolver`
    * (which runs for every authenticated route) before any consumer reads {@link getCurrentDistribution}/
-   * {@link getConnectionState} - until the first SSE message arrives, `getCurrentDistribution()`
-   * stays `null`, which looks identical to "no distribution is open". Consumers that need to tell
-   * "not loaded yet" apart from "confirmed closed" should gate on {@link getConnectionState}.
+   * {@link getConnectionState}/{@link getHasReceivedDistribution} - until the first SSE message
+   * arrives, `getCurrentDistribution()` stays `null`, which looks identical to "no distribution is
+   * open". {@link getConnectionState} reflects the underlying socket (`onopen`), which can flip to
+   * `true` a tick before the first message is actually processed - it is NOT a reliable proxy for
+   * "the initial snapshot has arrived". Consumers that need to tell "not loaded yet" apart from
+   * "confirmed closed" must gate on {@link getHasReceivedDistribution} instead.
    */
   init() {
     const connectionStateCallback = (connected: boolean) => {
@@ -34,6 +38,7 @@ export class GlobalStateService {
       next: (distributionUpdate: DistributionItemUpdate) => {
         const distributionItem = distributionUpdate.distribution;
         this._currentDistribution.set(distributionItem);
+        this._hasReceivedDistribution.set(true);
       }
     });
   }
@@ -44,6 +49,15 @@ export class GlobalStateService {
 
   getConnectionState(): Signal<boolean> {
     return this._connectionState.asReadonly();
+  }
+
+  /**
+   * `true` once the first `/sse/distributions` message has actually been processed - unlike
+   * {@link getConnectionState}, this can't flip to `true` before {@link getCurrentDistribution}
+   * reflects real server state, so it's safe to gate "confirmed closed" redirects on.
+   */
+  getHasReceivedDistribution(): Signal<boolean> {
+    return this._hasReceivedDistribution.asReadonly();
   }
 
 }

--- a/frontend/src/main/webapp/src/app/common/util/url-helper.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/util/url-helper.service.spec.ts
@@ -1,34 +1,29 @@
 import { UrlHelperService } from './url-helper.service';
-import { PlatformLocation } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 
 describe('UrlHelperService', () => {
 
-    let overwriteProtocol: string | undefined;
-    let overwriteTestPathname: string | undefined;
+    let overwriteBaseUri: string | undefined;
 
     function setup() {
-        const platformLocationSpy = {
-            hostname: 'testhost',
-            port: '1234',
-            pathname: overwriteTestPathname ?? '/subpath',
-            protocol: overwriteProtocol ?? 'http:'
+        const documentSpy = {
+            baseURI: overwriteBaseUri ?? 'http://testhost:1234/subpath/'
         };
 
         TestBed.configureTestingModule({
             providers: [
                 UrlHelperService,
-                { provide: PlatformLocation, useValue: platformLocationSpy }
+                { provide: DOCUMENT, useValue: documentSpy }
             ]
         });
         const service = TestBed.inject(UrlHelperService);
 
-        return { service, platformLocationSpy };
+        return { service, documentSpy };
     }
 
     afterEach(() => {
-        overwriteProtocol = undefined;
-        overwriteTestPathname = undefined;
+        overwriteBaseUri = undefined;
     });
 
     it('client configured correctly with http', () => {
@@ -40,7 +35,7 @@ describe('UrlHelperService', () => {
     });
 
     it('client configured correctly with https', () => {
-        overwriteProtocol = 'https:';
+        overwriteBaseUri = 'https://testhost:1234/subpath/';
         const { service } = setup();
 
         const basePath = service.getBaseUrl();
@@ -48,8 +43,8 @@ describe('UrlHelperService', () => {
         expect(basePath).toBe('https://testhost:1234/subpath');
     });
 
-    it('client configured correctly with empty pathname', () => {
-        overwriteTestPathname = '/';
+    it('client configured correctly with root base href', () => {
+        overwriteBaseUri = 'http://testhost:1234/';
         const { service } = setup();
 
         const basePath = service.getBaseUrl();
@@ -57,8 +52,8 @@ describe('UrlHelperService', () => {
         expect(basePath).toBe('http://testhost:1234');
     });
 
-    it('client configured correctly with subPath including trailing slash', () => {
-        overwriteTestPathname = '/subpath/';
+    it('client configured correctly without trailing slash', () => {
+        overwriteBaseUri = 'http://testhost:1234/subpath';
         const { service } = setup();
 
         const basePath = service.getBaseUrl();

--- a/frontend/src/main/webapp/src/app/common/util/url-helper.service.ts
+++ b/frontend/src/main/webapp/src/app/common/util/url-helper.service.ts
@@ -1,24 +1,24 @@
 import {inject, Service} from '@angular/core';
-import {PlatformLocation} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 
 @Service()
 export class UrlHelperService {
-  private readonly platformLocation = inject(PlatformLocation);
+  private readonly document = inject(DOCUMENT);
 
+  /**
+   * Derived from `document.baseURI` (the `<base href>` in index.html) rather than the current
+   * pathname - the app uses hash-based routing, so a direct navigation to a non-root path (e.g.
+   * a bookmark to `/login`) briefly puts that path segment into `location.pathname` before the
+   * router normalizes it into the hash. Reading the pathname here raced that normalization and
+   * misidentified the route segment as a deployment subpath (see #2972).
+   */
   getBaseUrl(): string {
-    let pathname = this.platformLocation.pathname;
-    if (pathname === '/') {
-      pathname = '';
-    }
-    if (pathname.endsWith('/')) {
-      pathname = pathname.slice(0, -1);
+    let baseUri = this.document.baseURI;
+    if (baseUri.endsWith('/')) {
+      baseUri = baseUri.slice(0, -1);
     }
 
-    const baseUrl = this.platformLocation.protocol + '//' + this.platformLocation.hostname + ':' + this.platformLocation.port;
-    const path = pathname.replaceAll('//', '/');
-
-    const absoluteUrl = baseUrl + path;
-    return absoluteUrl;
+    return baseUri;
   }
 
 }

--- a/frontend/src/main/webapp/src/app/modules/checkin/README.md
+++ b/frontend/src/main/webapp/src/app/modules/checkin/README.md
@@ -65,12 +65,12 @@ Once a customer resolves, the component loads their notes (`CustomerNoteApiServi
 There's also a redirect guard worth knowing about:
 ```ts
 effect(() => {
-  if (this.connectionState() && this.currentDistribution() === null) {
+  if (this.hasReceivedDistribution() && this.currentDistribution() === null) {
     this.router.navigate(['uebersicht']);
   }
 });
 ```
-It only fires once `connectionState()` (from `GlobalStateService`, backed by SSE) is `true` — this avoids bouncing the user back to the dashboard during the brief window before the SSE connection is even established, when `currentDistribution()` is still `null` by default.
+It only fires once `hasReceivedDistribution()` (from `GlobalStateService`, set once the first `/sse/distributions` message has actually been processed) is `true` — this avoids bouncing the user back to the dashboard during the brief window before the first SSE message arrives, when `currentDistribution()` is still `null` by default. Gating on the raw SSE connection state instead (`getConnectionState()`) is *not* enough: that flips to `true` on the socket's `onopen`, which can fire a tick before the first message is actually processed, so it doesn't rule out the "not loaded yet" case — see `GlobalStateService.getHasReceivedDistribution`'s doc comment.
 
 ### Ticket monitor: TicketScreenComponent / TicketScreenControlComponent / TicketScreenFullscreenComponent
 

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
@@ -60,7 +60,8 @@ describe('CheckinComponent', () => {
         const globalStateServiceSpy = {
             getCurrentDistribution: vi.fn().mockName('GlobalStateService.getCurrentDistribution')
               .mockReturnValue(signal<DistributionItem>(defaultDistribution).asReadonly()),
-            getHasReceivedDistribution: vi.fn().mockName('GlobalStateService.getHasReceivedDistribution').mockReturnValue(signal(true).asReadonly())
+            getHasReceivedDistribution: vi.fn().mockName('GlobalStateService.getHasReceivedDistribution')
+              .mockReturnValue(signal(true).asReadonly())
         };
         const distributionApiServiceSpy = {
             assignCustomer: vi.fn().mockName('DistributionApiService.assignCustomer')

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.spec.ts
@@ -60,7 +60,7 @@ describe('CheckinComponent', () => {
         const globalStateServiceSpy = {
             getCurrentDistribution: vi.fn().mockName('GlobalStateService.getCurrentDistribution')
               .mockReturnValue(signal<DistributionItem>(defaultDistribution).asReadonly()),
-            getConnectionState: vi.fn().mockName('GlobalStateService.getConnectionState').mockReturnValue(signal(true).asReadonly())
+            getHasReceivedDistribution: vi.fn().mockName('GlobalStateService.getHasReceivedDistribution').mockReturnValue(signal(true).asReadonly())
         };
         const distributionApiServiceSpy = {
             assignCustomer: vi.fn().mockName('DistributionApiService.assignCustomer')

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/checkin/checkin.component.ts
@@ -173,12 +173,14 @@ export class CheckinComponent {
   }
 
   readonly currentDistribution = this.globalStateService.getCurrentDistribution();
-  readonly connectionState = this.globalStateService.getConnectionState();
+  readonly hasReceivedDistribution = this.globalStateService.getHasReceivedDistribution();
 
   constructor() {
-    // Redirect to overview if no distribution is active (only after SSE connection is established)
+    // Redirect to overview once it's confirmed no distribution is active (only after the first
+    // SSE message has actually been processed - see getHasReceivedDistribution's doc comment on
+    // why the raw connection state isn't enough here).
     effect(() => {
-      if (this.connectionState() && this.currentDistribution() === null) {
+      if (this.hasReceivedDistribution() && this.currentDistribution() === null) {
         this.router.navigate(['uebersicht']);
       }
     });

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.spec.ts
@@ -32,7 +32,7 @@ describe('FoodCollectionRecordingComponent', () => {
                     provide: GlobalStateService,
                     useValue: {
                         getCurrentDistribution: vi.fn().mockName('GlobalStateService.getCurrentDistribution'),
-                        getConnectionState: vi.fn().mockName('GlobalStateService.getConnectionState')
+                        getHasReceivedDistribution: vi.fn().mockName('GlobalStateService.getHasReceivedDistribution')
                     }
                 },
                 {
@@ -54,7 +54,7 @@ describe('FoodCollectionRecordingComponent', () => {
 
     it('ngOnInit without active distribution', () => {
         globalStateService.getCurrentDistribution.mockReturnValue(signal<DistributionItem | null>(null).asReadonly());
-        globalStateService.getConnectionState.mockReturnValue(signal(true).asReadonly());
+        globalStateService.getHasReceivedDistribution.mockReturnValue(signal(true).asReadonly());
 
         const fixture = TestBed.createComponent(FoodCollectionRecordingComponent);
         const componentRef = fixture.componentRef;
@@ -69,9 +69,9 @@ describe('FoodCollectionRecordingComponent', () => {
         expect(router.navigate).toHaveBeenCalledWith(['uebersicht']);
     });
 
-    it('ngOnInit without active distribution but before SSE connection is established does not redirect', () => {
+    it('ngOnInit without active distribution but before the first SSE message arrives does not redirect', () => {
         globalStateService.getCurrentDistribution.mockReturnValue(signal<DistributionItem | null>(null).asReadonly());
-        globalStateService.getConnectionState.mockReturnValue(signal(false).asReadonly());
+        globalStateService.getHasReceivedDistribution.mockReturnValue(signal(false).asReadonly());
 
         const fixture = TestBed.createComponent(FoodCollectionRecordingComponent);
         const componentRef = fixture.componentRef;

--- a/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/logistics/views/food-collection-recording/food-collection-recording.component.ts
@@ -59,11 +59,12 @@ export class FoodCollectionRecordingComponent {
 
   constructor() {
     // Redirect to overview once it's confirmed no distribution is active. `getCurrentDistribution()`
-    // is also `null` before the first SSE message arrives, so this must wait for a live connection
+    // is also `null` before the first SSE message arrives, so this must wait for that first message
+    // to actually be processed (getHasReceivedDistribution) - not just for the socket to be open -
     // to avoid redirecting away before the real state is known (e.g. right after a page load with
     // no/poor connectivity).
     effect(() => {
-      if (this.globalStateService.getConnectionState()() && this.globalStateService.getCurrentDistribution()() === null) {
+      if (this.globalStateService.getHasReceivedDistribution()() && this.globalStateService.getCurrentDistribution()() === null) {
         this.router.navigate(['uebersicht']);
       }
     });

--- a/frontend/src/main/webapp/src/index.html
+++ b/frontend/src/main/webapp/src/index.html
@@ -2,6 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8">
+  <base href="/">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta content="width=device-width, initial-scale=1.0, shrink-to-fit=no" name="viewport" />
   <meta name="description" content="Tafel Admin">


### PR DESCRIPTION
## Summary
- Fixes #2972 — loading the app from a non-root path directly (e.g. a bookmarked `http://localhost:4200/login`) broke every relative API call on that page load, since `UrlHelperService.getBaseUrl()` picked up the requested path (`/login`) as if it were the deployment base URL, producing requests like `/login/api/login` (404).
- `getBaseUrl()` now derives the base from `document.baseURI` instead of `PlatformLocation.pathname`. `baseURI` is fixed at document-parse time, so it isn't subject to the race between a direct page load and the hash router's URL-normalizing navigation — this also fixes the app-initializer's very first API call (`loadUserInfo()`), which fires *before* that router navigation completes and would otherwise still race.
- **Reverse-proxy subpath deployments**: this app is deployed behind nginx mounting it at different path prefixes per environment (e.g. `/verwaltung-dev/`, stripped before reaching the backend), using a single shared build artifact. Hardcoding `<base href="/">` in `index.html` would have broken that. Instead, `IndexHtmlController` serves `index.html` with the `<base href>` substituted server-side from the existing `tafeladmin.server.relativeBaseUrl` property (already used for the JWT cookie path), so one build still works at any deployment prefix — no nginx changes needed. A follow-up commit normalizes that value to always end in a trailing slash: the deployed dev environment has it configured as `/verwaltung-dev` (no trailing slash, harmless for the cookie path it originally served, but a `<base href>` without one treats the last segment as a filename and breaks every relative asset/API URL) — this shipped to the real dev environment and got caught live, see below.
- **SPA fallback**: the deployed backend had no route for a direct navigation to a client-side path (e.g. `/login`) — only `ng serve`'s dev server has a built-in fallback for that, so the original bug could only ever be reproduced locally, never in the real deployed app (it 404'd before ever reaching the base-href logic). `IndexHtmlController` now also serves the app shell for any GET request shaped like a client-side route (no dot in the final path segment, not under `/api/`), matching standard SPA-hosting practice. Real static files and `/api/**` are unaffected.
- **Static asset caching / compression** (found while auditing the above): the backend had no `spring.web.resources.cache.*` configured anywhere, so *every* static response — including Angular's content-hashed (`outputHashing: all`) JS/CSS/font bundles that are safe to cache forever — was served `Cache-Control: no-store`, and `server.compression` was never enabled at all. `WebMvcConfig` now registers immutable, one-year caching for the hashed `main-*.js` / `chunk-*.js` / `styles-*.css` / `media/**` files only (`index.html`, favicon/icons/manifest, and `ngsw.json`/`ngsw-worker.js` are deliberately left as-is), and `server.compression` is enabled.
- **Docs**: added a "Reverse Proxy Deployment" section to the README covering subpath and subdomain nginx setups. While verifying those examples end-to-end I found a real bug in the original `if`-based SSE `Cache-Control` header snippet: `add_header` inside an `if` block is silently dropped once `proxy_buffering` is off (required for SSE streaming) — documented a working `map`-based version instead.

## Live verification
This branch auto-deploys to the dev environment on every push, which caught two real regressions this PR introduced before they could reach `main` (both now fixed and confirmed on https://tafel.wrk.at/verwaltung-dev):
- The missing-trailing-slash `<base href>` bug above — dev environment loaded to a blank "Lade Programm ..." screen with every asset 503/404ing at the wrong URL.
- The missing SPA fallback — confirmed via the `e2e-test` CI job (which runs against the actual packaged jar, not `ng serve`) failing on the new Cypress regression test with a real 404.

Both are now verified fixed directly against `https://tafel.wrk.at/verwaltung-dev/login` (network tab: all assets 200 under the correct prefix, page renders).

## Test plan
- [x] `npm run test-ci` — 722/722 frontend unit tests passing
- [x] `npm run lint` — clean
- [x] `./gradlew :backend:test` — full backend suite passing, including architecture/modularity rules
- [x] `./gradlew :backend:ktlintCheck` — clean
- [x] Added a Cypress regression test (`cy.visit('/login')` → successful login) in `login.cy.ts`
- [x] Added `IndexHtmlControllerTest` (unit, mocked `ResourceLoader`) and `IndexHtmlControllerIT` (real embedded server via `webEnvironment = RANDOM_PORT` + JDK `HttpClient`, real property binding, real static file I/O, real HTTP routing) covering: base-href rewriting, trailing-slash normalization, the SPA fallback for top-level and nested routes, that `/api/**` and real static files are never swallowed into the fallback, and the missing-`index.html` 404 case. Verified the trailing-slash regression test actually fails without the fix (reverted it locally, confirmed red, restored it).
- [x] CI `e2e-test` job (runs against the real packaged jar): `login.cy.ts` and the full suite pass modulo one pre-existing, unrelated flake (`cy.request()` 403 from XSRF-token-rotation race in the test harness — different spec each run, not touched by this PR)
- [x] Verified both README nginx examples end-to-end (`nginx -t` + live proxying to a real upstream container): path stripping, `X-Forwarded-Prefix`, and the SSE `Cache-Control` header all confirmed working for both the subpath and subdomain cases
- [x] Live-verified on the real dev deployment (`https://tafel.wrk.at/verwaltung-dev/login`): page renders, all assets 200 under the correct prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EniF2S737CCg248n921F7n