### PR TITLE
fix: bound XSRF-TOKEN retries in cy.request() instead of a single retry

### DIFF
--- a/frontend/src/main/webapp/cypress/support/commands.ts
+++ b/frontend/src/main/webapp/cypress/support/commands.ts
@@ -80,23 +80,37 @@ Cypress.Commands.overwrite('request', (originalFn, ...args: any[]): Cypress.Chai
   // the retries rather than assuming a single retry always lands on a stable value. Only retry
   // when the cookie actually changed though - if it's the same as what we just sent, this 403
   // isn't a rotation race and retrying won't help.
+  //
+  // Each recursive call must return a *bare* command from the `cy.getCookie().then()` callback
+  // that invokes it, with the response handling living in a separate, sibling `.then()` rather
+  // than being folded into the recursion itself - returning a value that already has its own
+  // `.then()` chained onto it, from within an outer `.then()` callback here, makes Cypress lose
+  // track of the command queue and throw "returned a promise from a command while also invoking
+  // one or more cy commands in that promise" even on the plain non-retry path.
   const MAX_ATTEMPTS = 4;
 
-  const attemptWithToken = (tokenValue: string | undefined, attemptsLeft: number): Cypress.Chainable<Cypress.Response<any>> =>
-    send(tokenValue).then((response): Cypress.Chainable<Cypress.Response<any>> => {
-      if (response.status !== 403 || attemptsLeft <= 1) {
-        return cy.wrap(response, {log: false});
-      }
-      return cy.getCookie('XSRF-TOKEN').then((freshCookie): Cypress.Chainable<Cypress.Response<any>> => {
-        if (!freshCookie || freshCookie.value === tokenValue) {
+  const requestWithRetry = (attemptsLeft: number): Cypress.Chainable<Cypress.Response<any>> => {
+    let tokenValue: string | undefined;
+
+    return cy.getCookie('XSRF-TOKEN')
+      .then(cookie => {
+        tokenValue = cookie?.value;
+        return send(tokenValue);
+      })
+      .then((response): Cypress.Chainable<Cypress.Response<any>> => {
+        if (response.status !== 403 || attemptsLeft <= 1) {
           return cy.wrap(response, {log: false});
         }
-        return attemptWithToken(freshCookie.value, attemptsLeft - 1);
+        return cy.getCookie('XSRF-TOKEN').then((freshCookie): Cypress.Chainable<Cypress.Response<any>> => {
+          if (!freshCookie || freshCookie.value === tokenValue) {
+            return cy.wrap(response, {log: false});
+          }
+          return requestWithRetry(attemptsLeft - 1);
+        });
       });
-    });
+  };
 
-  return cy.getCookie('XSRF-TOKEN')
-    .then(cookie => attemptWithToken(cookie?.value, MAX_ATTEMPTS))
+  return requestWithRetry(MAX_ATTEMPTS)
     .then((response): Cypress.Chainable<Cypress.Response<any>> => {
       if (failOnStatusCode && (response.status < 200 || response.status >= 400)) {
         throw new Error(

--- a/frontend/src/main/webapp/cypress/support/commands.ts
+++ b/frontend/src/main/webapp/cypress/support/commands.ts
@@ -74,28 +74,29 @@ Cypress.Commands.overwrite('request', (originalFn, ...args: any[]): Cypress.Chai
     return originalFn({...options, headers, failOnStatusCode: false} as Cypress.RequestOptions);
   };
 
-  let initialTokenValue: string | undefined;
+  // The XSRF-TOKEN cookie can rotate concurrently (e.g. a background request completing) between
+  // reading it and this request reaching the server, so the header we sent no longer matches the
+  // cookie Cypress auto-attached, causing a 403. It can keep rotating out from under us, so bound
+  // the retries rather than assuming a single retry always lands on a stable value. Only retry
+  // when the cookie actually changed though - if it's the same as what we just sent, this 403
+  // isn't a rotation race and retrying won't help.
+  const MAX_ATTEMPTS = 4;
 
-  return cy.getCookie('XSRF-TOKEN')
-    .then(cookie => {
-      initialTokenValue = cookie?.value;
-      return send(initialTokenValue);
-    })
-    .then((response): Cypress.Chainable<Cypress.Response<any>> => {
-      if (response.status !== 403) {
+  const attemptWithToken = (tokenValue: string | undefined, attemptsLeft: number): Cypress.Chainable<Cypress.Response<any>> =>
+    send(tokenValue).then((response): Cypress.Chainable<Cypress.Response<any>> => {
+      if (response.status !== 403 || attemptsLeft <= 1) {
         return cy.wrap(response, {log: false});
       }
-      // The XSRF-TOKEN cookie can rotate concurrently (e.g. a background request completing)
-      // between reading it above and this request reaching the server, so the header we sent
-      // no longer matches the cookie Cypress auto-attached. Retry once with whatever the
-      // cookie is now before treating this as a genuine failure.
       return cy.getCookie('XSRF-TOKEN').then((freshCookie): Cypress.Chainable<Cypress.Response<any>> => {
-        if (!freshCookie || freshCookie.value === initialTokenValue) {
+        if (!freshCookie || freshCookie.value === tokenValue) {
           return cy.wrap(response, {log: false});
         }
-        return send(freshCookie.value);
+        return attemptWithToken(freshCookie.value, attemptsLeft - 1);
       });
-    })
+    });
+
+  return cy.getCookie('XSRF-TOKEN')
+    .then(cookie => attemptWithToken(cookie?.value, MAX_ATTEMPTS))
     .then((response): Cypress.Chainable<Cypress.Response<any>> => {
       if (failOnStatusCode && (response.status < 200 || response.status >= 400)) {
         throw new Error(


### PR DESCRIPTION
## Summary
- The `cy.request()` override in `commands.ts` retried an XSRF-TOKEN-rotation-caused 403 exactly once. If the cookie rotated again during that retry, the request failed for good, surfacing as intermittent 403s on unrelated specs/endpoints in CI.
- Turns the one-shot retry into a bounded loop (up to 4 total attempts) that keeps retrying with the freshest cookie value as long as it keeps changing, and still fails fast (no retry) when the cookie is unchanged - i.e. when the 403 isn't a rotation race.

Closes #2980

## Test plan
- [x] `npx tsc --noEmit -p cypress/tsconfig.json` passes
- [x] `npx ng lint` passes
- [ ] Watch next few CI runs for recurrence of the flaky 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EniF2S737CCg248n921F7n