### PR TITLE
fix: make getAnyRandomNumber effectively unique to stop e2e username collisions

### DIFF
--- a/frontend/src/main/webapp/cypress/support/commands.ts
+++ b/frontend/src/main/webapp/cypress/support/commands.ts
@@ -372,7 +372,12 @@ Cypress.Commands.add('getRandomNumber', (min: number, max: number): Chainable<nu
   return cy.wrap(Math.floor(Math.random() * (maxFloor - minCeil + 1)) + minCeil);
 });
 
-Cypress.Commands.add('getAnyRandomNumber', (): Chainable<number> => cy.getRandomNumber(50000, 100000));
+Cypress.Commands.add('getAnyRandomNumber', (): Chainable<number> =>
+  // Timestamp (mod 1e8, i.e. ~27.7h) + a random suffix keeps the result unique across every spec
+  // in an e2e run (which takes minutes, not hours) while staying short enough for narrow columns
+  // like license_plate (varchar(20)) that get it appended to a fixed prefix.
+  cy.getRandomNumber(0, 999).then(randomSuffix => (Date.now() % 100_000_000) * 1000 + randomSuffix)
+);
 
 
 export interface AddCustomerToDistributionRequest {

--- a/frontend/src/main/webapp/cypress/support/index.ts
+++ b/frontend/src/main/webapp/cypress/support/index.ts
@@ -125,7 +125,9 @@ declare global {
       getRandomNumber(min: number, max: number): Chainable<number>;
 
       /**
-       * Custom command to generate any random number in a fixed range of 50_000 to 100_000.
+       * Custom command to generate an ~11-digit number that's effectively unique across the whole
+       * e2e run (derived from the current timestamp plus a random suffix), for test data (e.g.
+       * usernames) that must not collide with data created by other specs in the same run.
        * @example cy.getAnyRandomNumber();
        */
       getAnyRandomNumber(): Chainable<number>;


### PR DESCRIPTION
## Summary
- `cy.getAnyRandomNumber()` only drew from a 50,000-value pool (`getRandomNumber(50000, 100000)`), so across the ~30 specs run sequentially against the same DB in an e2e run, a birthday-paradox collision was expected — this caused the flaky `409 CONFLICT` in `passwordchange.cy.ts` when creating a test user with a colliding `username-<n>`.
- Changed `getAnyRandomNumber()` to derive its value from the current timestamp (mod ~27.7h) plus a small random suffix, giving an ~11-digit result that's effectively unique for the duration of a CI run, while staying short enough to still fit into narrow columns that also consume it (e.g. `cars.license_plate varchar(20)` via `'W-NEW-' + randomId` in `settings-cars.cy.ts`).

Fixes #2977

## Test plan
- [x] `npx tsc --noEmit` on the cypress support files — no type errors
- [x] `npx eslint` on the changed files — clean
- [ ] Full e2e suite run in CI to confirm `passwordchange.cy.ts` and other specs using `getAnyRandomNumber()` (user-create, user-detail, settings-cars, settings-employees, settings-food-categories, settings-shelters, login, food-collection-recording, customer-duplicates, statistics-school-starter-packages) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EniF2S737CCg248n921F7n