### PR TITLE
fix(backend): stop SSE stream completion from logging spurious 403s

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
@@ -1,0 +1,61 @@
+package at.wrk.tafel.admin.backend.common.auth.components
+
+import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.web.access.AccessDeniedHandlerImpl
+
+/**
+ * A REQUEST-dispatch denial is a real 403 delivered to a client and worth logging with enough
+ * detail to diagnose (principal + the authorities actually resolved on that token). ASYNC
+ * dispatches are already excluded from authorization in [WebSecurityConfig] (see the
+ * `dispatcherTypeMatchers` comment there for why they'd otherwise be denied on every SSE stream
+ * completion), so a denial reaching here with a committed response is unexpected - log it quietly
+ * rather than delegating to [AccessDeniedHandlerImpl], which would only throw a second, "already
+ * committed" exception on top of it.
+ */
+@ExcludeFromTestCoverage
+class TafelAccessDeniedHandler : AccessDeniedHandler {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(TafelAccessDeniedHandler::class.java)
+    }
+
+    private val delegate = AccessDeniedHandlerImpl()
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException,
+    ) {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal = authentication?.name ?: "anonymous"
+        val authorities = authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none"
+
+        if (request.dispatcherType == DispatcherType.ASYNC || response.isCommitted) {
+            logger.debug(
+                "Access denied on {} dispatch for '{}' {} {} - resolved authorities: [{}]",
+                request.dispatcherType,
+                principal,
+                request.method,
+                request.requestURI,
+                authorities,
+            )
+            return
+        }
+
+        logger.warn(
+            "Access denied for user '{}' on {} {} - resolved authorities: [{}]",
+            principal,
+            request.method,
+            request.requestURI,
+            authorities,
+        )
+        delegate.handle(request, response, accessDeniedException)
+    }
+}

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
@@ -6,6 +6,7 @@ import at.wrk.tafel.admin.backend.config.properties.ApplicationProperties
 import at.wrk.tafel.admin.backend.config.properties.TafelAdminProperties
 import at.wrk.tafel.admin.backend.database.model.auth.UserRepository
 import at.wrk.tafel.admin.backend.database.model.base.EmployeeRepository
+import jakarta.servlet.DispatcherType
 import org.passay.DefaultPasswordValidator
 import org.passay.data.EnglishCharacterData
 import org.passay.data.GermanCharacterData
@@ -106,12 +107,24 @@ class WebSecurityConfig(
             )
             .addFilterAfter(authFilter, TafelLoginFilter::class.java)
             .authorizeHttpRequests { auth ->
+                // SSE endpoints (SseEmitter) keep the request open via request.startAsync(); when
+                // the emitter completes/times out/errors, the container re-enters the filter chain
+                // on an ASYNC dispatch to finish the request. TafelJwtAuthenticationFilter (a
+                // OncePerRequestFilter) skips re-authenticating on that dispatch by default, so
+                // without this, AuthorizationFilter - which runs on every dispatch type, unlike
+                // OncePerRequestFilter - sees no authentication and denies it, even though the
+                // original REQUEST dispatch already authenticated/authorized before the stream
+                // opened.
+                auth.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                 auth.requestMatchers(*publicEndpoints.toTypedArray()).permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().permitAll()
             }
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .exceptionHandling { exceptionHandling ->
+                exceptionHandling.accessDeniedHandler(TafelAccessDeniedHandler())
             }
             .csrf { csrf ->
                 val tokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse()


### PR DESCRIPTION
## Summary
- SSE endpoints (`SseEmitter`) keep the request open via `request.startAsync()`. When the stream completes/times out/errors, the container re-enters the security filter chain on an ASYNC dispatch to finish the request. `TafelJwtAuthenticationFilter` (a `OncePerRequestFilter`) skips re-authenticating on that dispatch by default, so `AuthorizationFilter` — which runs on every dispatch type, not just REQUEST — saw no authentication and denied it, even though the original REQUEST dispatch had already authenticated/authorized before the stream opened.
- Confirmed via a full day of production logs: ~50 occurrences/day, always paired with "response is already committed", never an actual 403 delivered to a client. Fixed by excluding ASYNC dispatches from authorization in `WebSecurityConfig`, matching Spring Security's documented pattern for this exact SSE interaction.
- Also adds `TafelAccessDeniedHandler`, which logs the authenticated principal and their resolved authorities whenever a *synchronous* request is genuinely denied. This is diagnostic tooling for a separate, still-unexplained bug also found while investigating this: a user held the `LOGISTICS` authority continuously in the DB, yet got a real 403 on a `LOGISTICS`-gated endpoint across three sessions (surviving two fresh re-logins and a client-storage wipe). That root cause is not fixed here — every mechanism I could check by static inspection (DB state, app/client caching, cookie extraction, the password-change-required gate, the "no active distribution" interceptor, duplicate usernames, transactional race conditions on authority edits) came back clean, verified against the exact commit that was actually running in prod that day. This handler will capture the resolved authorities directly if/when it recurs.

## Test plan
- [x] `:backend:compileKotlin` passes
- [x] `:backend:ktlintCheck` passes
- [x] `WebSecurityConfigTest` and `GeneralMethodSecurityIT` pass
- [ ] Watch prod logs after deploy to confirm the async-dispatch 403 spam is gone