### PR TITLE
chore(backend): remove duplicate UserDetailsService bean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ This is a food bank (Tafel) administration system built with a Spring Boot/Kotli
 
 ## Build and Development Commands
 
+**The Gradle wrapper (`gradlew`/`gradlew.bat`) lives at the repo root, not in `backend/`.** Always
+invoke it as `./gradlew :backend:...` from the repo root (or with an explicit path to the root
+wrapper) — there is no wrapper inside `backend/`, so running it from that directory fails with
+"not recognized"/"No such file or directory".
+
 ### Full Application Build
 Backend and frontend build independently - there's no Gradle cross-dependency between them.
 ```bash

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/WebSecurityConfig.kt
@@ -25,7 +25,6 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.security.provisioning.UserDetailsManager
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher
@@ -167,16 +166,13 @@ class WebSecurityConfig(
     }
 
     @Bean
-    fun userDetailsManager(): UserDetailsManager = tafelUserDetailsManager()
-
-    @Bean
     fun tafelUserDetailsManager(): TafelUserDetailsManager = TafelUserDetailsManager(userRepository, employeeRepository, passwordEncoder(), passwordValidator)
 
     @Bean
     fun authenticationManager(): AuthenticationManager = ProviderManager(tafelLoginProvider(), tafelJwtAuthProvider())
 
     @Bean
-    fun tafelLoginProvider(): TafelLoginProvider = TafelLoginProvider(userDetailsManager(), passwordEncoder(), loginAttemptService)
+    fun tafelLoginProvider(): TafelLoginProvider = TafelLoginProvider(tafelUserDetailsManager(), passwordEncoder(), loginAttemptService)
 
     @Bean
     fun tafelJwtAuthProvider(): TafelJwtAuthProvider = TafelJwtAuthProvider(jwtTokenService, userRepository)


### PR DESCRIPTION
## Summary
- `WebSecurityConfig` defined two Spring beans implementing `UserDetailsService` (`userDetailsManager` and `tafelUserDetailsManager`), where the former just delegated to the latter — triggering Spring Security's "Found 2 UserDetailsService beans" WARN on every startup.
- Removed the redundant `userDetailsManager()` bean; `tafelLoginProvider()` now wires `tafelUserDetailsManager()` directly.
- Noted in AGENTS.md that the Gradle wrapper lives at the repo root, not `backend/`.

Closes #2988. (The Flyway `createSchema` deprecation WARN from the same issue needs no code change — it resolves itself on a future Flyway upgrade, per the issue.)

## Test plan
- [x] `./gradlew :backend:compileKotlin`
- [x] `./gradlew :backend:test --tests "*WebSecurityConfigTest*" --tests "*TafelUserDetailsManagerTest*" --tests "*TafelLoginProviderTest*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)