### PR TITLE
fix(backend): stop AsyncRequestNotUsableException from logging as ERROR

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -68,15 +68,25 @@ class GenericExceptionHandler(
      * mid-stream) - it's an IOException, so Spring's own SSE completion handling
      * (`DefaultSseEmitterHandler.complete()`) catches it internally and resurfaces it as a deferred
      * result error rather than throwing it back to the calling code, which is why callers like
-     * `SseOutboxService.sendEvent()` can never catch it themselves. Without this handler it falls
+     * `SseOutboxService.sendEvent()` can never catch it themselves. Without overriding this it falls
      * through to [handleGenericException] and gets logged as a full ERROR stack trace for what's a
-     * routine disconnect. A `Unit` return here tells Spring the exception is fully handled with
-     * nothing to write, since attempting to render a body onto an already-unusable response would
-     * just fail again.
+     * routine disconnect.
+     *
+     * This overrides the protected hook [ResponseEntityExceptionHandler.handleAsyncRequestNotUsableException]
+     * rather than adding a new `@ExceptionHandler(AsyncRequestNotUsableException::class)` method: the
+     * superclass's own `handleException` already declares that exact exception type in its
+     * `@ExceptionHandler` list (since Spring Framework 6.2) and dispatches to this hook internally -
+     * a second method independently claiming the same type is an "Ambiguous @ExceptionHandler method"
+     * error at context startup, not a silent override. Returning `null` (the default) tells Spring the
+     * exception is fully handled with nothing to write, since attempting to render a body onto an
+     * already-unusable response would just fail again.
      */
-    @ExceptionHandler(AsyncRequestNotUsableException::class)
-    fun handleAsyncRequestNotUsableException(exception: AsyncRequestNotUsableException) {
-        log.debug("Async request/response no longer usable, client likely disconnected", exception)
+    public override fun handleAsyncRequestNotUsableException(
+        ex: AsyncRequestNotUsableException,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        log.debug("Async request/response no longer usable, client likely disconnected", ex)
+        return null
     }
 
     @ExceptionHandler(Exception::class)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import tools.jackson.databind.json.JsonMapper
 
@@ -60,6 +61,22 @@ class GenericExceptionHandler(
             ex.bindingResult.fieldErrors.map { FieldErrorItem(field = it.field, message = it.defaultMessage) },
         )
         return handleExceptionInternal(ex, problemDetail, headers, status, request)
+    }
+
+    /**
+     * [AsyncRequestNotUsableException] means the response is already unusable (client disconnected
+     * mid-stream) - it's an IOException, so Spring's own SSE completion handling
+     * (`DefaultSseEmitterHandler.complete()`) catches it internally and resurfaces it as a deferred
+     * result error rather than throwing it back to the calling code, which is why callers like
+     * `SseOutboxService.sendEvent()` can never catch it themselves. Without this handler it falls
+     * through to [handleGenericException] and gets logged as a full ERROR stack trace for what's a
+     * routine disconnect. A `Unit` return here tells Spring the exception is fully handled with
+     * nothing to write, since attempting to render a body onto an already-unusable response would
+     * just fail again.
+     */
+    @ExceptionHandler(AsyncRequestNotUsableException::class)
+    fun handleAsyncRequestNotUsableException(exception: AsyncRequestNotUsableException) {
+        log.debug("Async request/response no longer usable, client likely disconnected", exception)
     }
 
     @ExceptionHandler(Exception::class)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -18,6 +18,7 @@ import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import tools.jackson.databind.json.JsonMapper
 import java.util.*
 
@@ -145,6 +146,13 @@ internal class GenericExceptionHandlerTest {
         assertThat(errorBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
         assertThat(errorBody.detail).isEqualTo("test-msg")
+    }
+
+    @Test
+    fun `handles AsyncRequestNotUsableException without throwing`() {
+        val exception = AsyncRequestNotUsableException("response no longer usable")
+
+        exceptionHandler.handleAsyncRequestNotUsableException(exception)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -149,10 +149,12 @@ internal class GenericExceptionHandlerTest {
     }
 
     @Test
-    fun `handles AsyncRequestNotUsableException without throwing`() {
+    fun `handles AsyncRequestNotUsableException without throwing and returns no body`() {
         val exception = AsyncRequestNotUsableException("response no longer usable")
 
-        exceptionHandler.handleAsyncRequestNotUsableException(exception)
+        val response = exceptionHandler.handleAsyncRequestNotUsableException(exception, request)
+
+        assertThat(response).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a specific `@ExceptionHandler(AsyncRequestNotUsableException::class)` to `GenericExceptionHandler` that logs at DEBUG and does nothing else, instead of falling through to the generic `Exception` handler which logged a full ERROR stack trace.
- `AsyncRequestNotUsableException` extends `IOException`, and Spring's own `DefaultSseEmitterHandler.complete()` catches that internally and resurfaces it via `DeferredResult.setErrorResult()` rather than throwing it back to the caller — which is why `SseOutboxService.sendEvent()`'s own try/catch around `sseEmitter.complete()` could never catch it. The fix needed to live in the exception-handling layer, not the SSE service.

Fixes #2986

## Test plan
- [x] `./gradlew :backend:compileKotlin :backend:compileTestKotlin`
- [x] `./gradlew :backend:test --tests "*GenericExceptionHandlerTest*"` — added a test asserting the new handler doesn't throw
- [x] `./gradlew :backend:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)