### PR TITLE
fix(backend): assign connection field so SseOutboxListenerService shutdown cleanup works

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
@@ -36,17 +36,15 @@ class SseOutboxListenerService(
         const val PG_NOTIFICATION_CHANNEL_NAME = "sse_outbox"
     }
 
-    lateinit var connection: Connection
     lateinit var notificationListenerJob: Job
     val callbacks = ConcurrentHashMap<String, CopyOnWriteArrayList<(String?) -> Unit>>()
 
     @PostConstruct
     fun setupListener() {
         notificationListenerJob = CoroutineScope(Dispatchers.IO).launch {
-            jdbcTemplate.dataSource!!.connection.use { conn ->
-                connection = conn
-                listenOnConnection(conn)
-                val pgConn = conn.unwrap(PGConnection::class.java)
+            jdbcTemplate.dataSource!!.connection.use { connection ->
+                listenOnConnection(connection)
+                val pgConn = connection.unwrap(PGConnection::class.java)
 
                 while (true) {
                     val notifications = pgConn.getNotifications(NOTIFICATIONS_POLL_TIMEOUT)
@@ -74,9 +72,6 @@ class SseOutboxListenerService(
     @PreDestroy
     fun cleanup() {
         notificationListenerJob.cancel()
-        if (!connection.isClosed) {
-            connection.close()
-        }
     }
 
     fun registerCallback(

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerService.kt
@@ -43,9 +43,10 @@ class SseOutboxListenerService(
     @PostConstruct
     fun setupListener() {
         notificationListenerJob = CoroutineScope(Dispatchers.IO).launch {
-            jdbcTemplate.dataSource!!.connection.use { connection ->
-                listenOnConnection(connection)
-                val pgConn = connection.unwrap(PGConnection::class.java)
+            jdbcTemplate.dataSource!!.connection.use { conn ->
+                connection = conn
+                listenOnConnection(conn)
+                val pgConn = conn.unwrap(PGConnection::class.java)
 
                 while (true) {
                     val notifications = pgConn.getNotifications(NOTIFICATIONS_POLL_TIMEOUT)

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerServiceTest.kt
@@ -52,6 +52,8 @@ class SseOutboxListenerServiceTest {
         every { mockConnection.createStatement() } returns mockStatement
         every { mockStatement.execute("LISTEN $PG_NOTIFICATION_CHANNEL_NAME;") } returns true
         every { mockStatement.close() } returns Unit
+        every { mockConnection.isClosed } returns false
+        every { mockConnection.close() } returns Unit
 
         val mockPGConnection: PGConnection = mockk()
         every { mockPGConnection.getNotifications(NOTIFICATIONS_POLL_TIMEOUT) } returns arrayOf(
@@ -82,6 +84,15 @@ class SseOutboxListenerServiceTest {
 
         verify { mockStatement.execute("LISTEN $PG_NOTIFICATION_CHANNEL_NAME;") }
         assertThat(retrievedPayload).isEqualTo(testNotificationEvent.payload)
+        assertThat(service.connection).isNotNull()
+    }
+
+    @Test
+    fun `cleanup after setup listener does not throw`(): Unit = runBlocking {
+        service.setupListener()
+        service.notificationListenerJob.join()
+
+        service.cleanup()
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerServiceTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/database/common/sseoutbox/SseOutboxListenerServiceTest.kt
@@ -52,8 +52,6 @@ class SseOutboxListenerServiceTest {
         every { mockConnection.createStatement() } returns mockStatement
         every { mockStatement.execute("LISTEN $PG_NOTIFICATION_CHANNEL_NAME;") } returns true
         every { mockStatement.close() } returns Unit
-        every { mockConnection.isClosed } returns false
-        every { mockConnection.close() } returns Unit
 
         val mockPGConnection: PGConnection = mockk()
         every { mockPGConnection.getNotifications(NOTIFICATIONS_POLL_TIMEOUT) } returns arrayOf(
@@ -84,48 +82,18 @@ class SseOutboxListenerServiceTest {
 
         verify { mockStatement.execute("LISTEN $PG_NOTIFICATION_CHANNEL_NAME;") }
         assertThat(retrievedPayload).isEqualTo(testNotificationEvent.payload)
-        assertThat(service.connection).isNotNull()
     }
 
     @Test
-    fun `cleanup after setup listener does not throw`(): Unit = runBlocking {
-        service.setupListener()
-        service.notificationListenerJob.join()
-
-        service.cleanup()
-    }
-
-    @Test
-    fun `cleanup with open connection`() {
-        val connection = mockk<Connection>()
-        every { connection.isClosed } returns false
-        every { connection.close() } returns Unit
+    fun `cleanup cancels the notification listener job`() {
         val notificationListenerJob = mockk<Job>()
         every { notificationListenerJob.cancel(null) } returns Unit
 
-        service.connection = connection
         service.notificationListenerJob = notificationListenerJob
 
         service.cleanup()
 
         verify { notificationListenerJob.cancel() }
-        verify { connection.close() }
-    }
-
-    @Test
-    fun `cleanup with closed connection`() {
-        val connection = mockk<Connection>()
-        every { connection.isClosed } returns true
-        every { connection.close() } returns Unit
-        val notificationListenerJob = mockk<Job>()
-        every { notificationListenerJob.cancel(null) } returns Unit
-
-        service.connection = connection
-        service.notificationListenerJob = notificationListenerJob
-
-        service.cleanup()
-
-        verify(exactly = 0) { connection.close() }
     }
 
     @Test


### PR DESCRIPTION
## Summary
`SseOutboxListenerService.setupListener()` opened a JDBC connection via `jdbcTemplate.dataSource!!.connection.use { connection -> ... }`, where the lambda parameter `connection` shadowed the class-level `lateinit var connection` field. The field was therefore never assigned, so `@PreDestroy cleanup()` unconditionally read an uninitialized `lateinit` property and threw `UninitializedPropertyAccessException` on every application shutdown, logged as a WARN by Spring's shutdown hook.

First attempt assigned the opened connection to the field so `cleanup()` could close it explicitly, but that turned out to hang CI: Spring's test-context cache means `cleanup()` only runs once, at final JVM shutdown, by which point the listener coroutine can still be blocked inside `PGConnection.getNotifications()` on that very connection (an effectively infinite poll timeout). Closing the connection from another thread while it's mid-blocking-read is exactly what stalled the `test-backend` CI job (~30-90 min, vs ~3.5 min baseline).

Final fix: drop the dead field entirely and have `cleanup()` just cancel the job — the connection still gets closed by the coroutine's own `.use {}` whenever its loop terminates, with no cross-thread close race.

Closes #2985

## Test plan
- [x] `./gradlew :backend:test --tests SseOutboxListenerServiceTest`
- [x] `./gradlew :backend:ktlintCheck`
- [ ] CI

🤖 Generated with Claude Code