### PR TITLE
fix(frontend): redirect to login on navigation when session expired

### DIFF
--- a/frontend/src/main/webapp/cypress/e2e/login.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/login.cy.ts
@@ -130,6 +130,22 @@ describe('Login', () => {
     cy.byTestId('errorMessage').should('exist').and('contain.text', 'Sitzung abgelaufen');
   });
 
+  it('an invalidated session redirects to login even via a route with no data-fetch of its own', () => {
+    enterLoginData('e2etest', 'e2etest');
+    cy.url().should('contain', '/uebersicht');
+
+    cy.clearCookie('tafel-admin-jwt');
+
+    // "Passwort ändern" has no resolver and its component fires no HTTP request on mount - before
+    // this fix, AuthGuardService only ever checked a stale in-memory flag, so a click like this
+    // one was silently ignored instead of redirecting (see #2976).
+    cy.byTestId('usermenu').click();
+    cy.byTestId('usermenu-changepassword').click();
+
+    cy.url().should('contain', '/login/abgelaufen');
+    cy.byTestId('errorMessage').should('exist').and('contain.text', 'Sitzung abgelaufen');
+  });
+
   it('accessing a module without the required permission shows access denied', () => {
     createTestUser([{key: 'CHECKIN', title: 'Anmeldung'}]).then(({user, testUser}) => {
       cy.visit('/#/login');

--- a/frontend/src/main/webapp/src/app/common/security/authguard.service.spec.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authguard.service.spec.ts
@@ -13,6 +13,7 @@ describe('AuthGuardService', () => {
     function setup() {
         const authServiceSpy = {
             isAuthenticated: vi.fn().mockName('AuthenticationService.isAuthenticated'),
+            loadUserInfo: vi.fn().mockName('AuthenticationService.loadUserInfo'),
             hasAnyPermission: vi.fn().mockName('AuthenticationService.hasAnyPermission'),
             hasAnyPermissionOf: vi.fn().mockName('AuthenticationService.hasAnyPermissionOf'),
             redirectToLogin: vi.fn().mockName('AuthenticationService.redirectToLogin')
@@ -41,6 +42,7 @@ describe('AuthGuardService', () => {
     it('canActivate when authenticated', async () => {
         const { service, authServiceSpy } = setup();
         authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue({ username: 'user', permissions: ['PERM1'] });
         authServiceSpy.hasAnyPermission.mockReturnValue(true);
 
         const activatedRoute = <ActivatedRouteSnapshot>{ data: {} };
@@ -52,6 +54,7 @@ describe('AuthGuardService', () => {
     it('canActivate when authenticated without permissions', async () => {
         const { service, authServiceSpy } = setup();
         authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue({ username: 'user', permissions: [] });
 
         const activatedRoute = <ActivatedRouteSnapshot><AuthGuardData>{ data: {} };
         const canActivate = await service.canActivate(activatedRoute);
@@ -63,6 +66,7 @@ describe('AuthGuardService', () => {
     it('canActivate when authenticated without permissions but anyPermission is necessary', async () => {
         const { service, authServiceSpy } = setup();
         authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue({ username: 'user', permissions: [] });
         authServiceSpy.hasAnyPermission.mockReturnValue(false);
 
         const activatedRoute = <ActivatedRouteSnapshot><AuthGuardData>{ data: { anyPermission: true } };
@@ -75,6 +79,7 @@ describe('AuthGuardService', () => {
     it('canActivate when authenticated with wrong permission', async () => {
         const { service, authServiceSpy } = setup();
         authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue({ username: 'user', permissions: ['PERM2'] });
         authServiceSpy.hasAnyPermission.mockReturnValue(true);
         authServiceSpy.hasAnyPermissionOf.mockReturnValue(false);
 
@@ -85,16 +90,31 @@ describe('AuthGuardService', () => {
         expect(authServiceSpy.redirectToLogin).toHaveBeenCalledWith('fehlgeschlagen');
     });
 
-    it('canActivate when authenticated with correct permission', () => {
+    it('canActivate when authenticated with correct permission', async () => {
         const { service, authServiceSpy } = setup();
         authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue({ username: 'user', permissions: ['PERM1'] });
         authServiceSpy.hasAnyPermission.mockReturnValue(true);
         authServiceSpy.hasAnyPermissionOf.mockReturnValue(true);
 
         const activatedRoute = <ActivatedRouteSnapshot><AuthGuardData>{ data: { anyPermissionOf: ['PERM1'] } };
-        const canActivate = service.canActivate(activatedRoute);
+        const canActivate = await service.canActivate(activatedRoute);
 
         expect(canActivate).toBeTruthy();
+        expect(authServiceSpy.redirectToLogin).not.toHaveBeenCalled();
+    });
+
+    it('canActivate when the cached session looks valid but the server says it has expired revalidates and blocks navigation', async () => {
+        const { service, authServiceSpy } = setup();
+        authServiceSpy.isAuthenticated.mockReturnValue(true);
+        authServiceSpy.loadUserInfo.mockResolvedValue(null);
+
+        const activatedRoute = <ActivatedRouteSnapshot><AuthGuardData>{ data: {} };
+        const canActivate = await service.canActivate(activatedRoute);
+
+        expect(canActivate).toBe(false);
+        // errorHandlerInterceptor already redirects with 'abgelaufen' as a side effect of the
+        // loadUserInfo() request's 401 - the guard must not also redirect (would double-navigate).
         expect(authServiceSpy.redirectToLogin).not.toHaveBeenCalled();
     });
 
@@ -128,6 +148,7 @@ describe('AuthGuardService with real router navigation (route data inheritance)'
     function mockAuthService(hasAnyPermissionOf: boolean) {
         return {
             isAuthenticated: vi.fn().mockReturnValue(true),
+            loadUserInfo: vi.fn().mockResolvedValue({ username: 'user', permissions: ['CUSTOMER'] }),
             hasAnyPermission: vi.fn().mockReturnValue(true),
             hasAnyPermissionOf: vi.fn().mockReturnValue(hasAnyPermissionOf),
             redirectToLogin: vi.fn()

--- a/frontend/src/main/webapp/src/app/common/security/authguard.service.ts
+++ b/frontend/src/main/webapp/src/app/common/security/authguard.service.ts
@@ -17,13 +17,23 @@ export class AuthGuardService {
    * not the same as being logged in but lacking a permission - the former sends the user to a
    * plain login page, the latter shows the "access denied" message via the `fehlgeschlagen`
    * error key so it isn't misreported as a real authorization failure.
+   *
+   * A cached "authenticated" flag alone can't tell a live session from one that expired
+   * server-side without any HTTP request happening yet (e.g. a menu click to a route with no
+   * resolver/data call of its own) - so whenever we still believe we're authenticated, this
+   * revalidates against the server first. If that revalidation itself 401s, the
+   * errorHandlerInterceptor's auth-error handling already redirects with the `abgelaufen`
+   * message as a side effect of the failed request, so this only needs to stop the navigation.
    */
   async canActivate(childRoute: ActivatedRouteSnapshot): Promise<boolean> {
     const routeData: AuthGuardData = childRoute.data;
 
-    const authenticated = this.authenticationService.isAuthenticated();
-    if (!authenticated) {
-      this.authenticationService.redirectToLogin();
+    const wasAuthenticated = this.authenticationService.isAuthenticated();
+    const userInfo = wasAuthenticated ? await this.authenticationService.loadUserInfo() : null;
+    if (userInfo === null) {
+      if (!wasAuthenticated) {
+        this.authenticationService.redirectToLogin();
+      }
       return false;
     }
 


### PR DESCRIPTION
## Summary
- Fixes the "click anywhere is ignored while the session is expired" bug reported in #2976 (page reload correctly redirected to login, but client-side navigation via the menu did nothing).
- `AuthGuardService.canActivate` previously trusted a cached, never-invalidated `isAuthenticated()` signal. Routes with no resolver/HTTP call of their own (e.g. "Passwort ändern") could be activated even after the server-side session died.
- The guard now revalidates against the server (`GET /users/info`) before activating a route whenever it still believes the session is live. If that revalidation itself 401s, the existing `errorHandlerInterceptor` auth-error handling performs the redirect to `/login/abgelaufen` as a side effect — no duplicated redirect logic needed.

Closes #2976

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test-ci` (723 tests passing)
- [x] `cypress/e2e/login.cy.ts` run locally against `e2e` profile backend (15/15 passing), including a new case that logs in, invalidates the session cookie, then clicks through the user menu to a resolver-free route and asserts the redirect to `/login/abgelaufen`
- [ ] CI

🤖 Generated with Claude Code