### PR TITLE
feat(frontend): switch angular routing from HashLocationStrategy to PathLocationStrategy

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/IndexHtmlController.kt
@@ -20,10 +20,10 @@ import java.nio.charset.StandardCharsets
  *
  * It also acts as the SPA's fallback route: a direct navigation/bookmark/refresh to a client-side
  * route (e.g. "/login", "/kunden/suchen") isn't a real server path, but the router needs it to
- * still resolve to the app shell rather than 404 - Angular's HashLocationStrategy then reads the
- * intended route from the hash once the app has loaded. Static resource requests (real files, all
- * of which have an extension in this build) and api requests are excluded so real 404s stay real
- * 404s.
+ * still resolve to the app shell rather than 404 - Angular's PathLocationStrategy then picks the
+ * intended route back up from the URL itself once the app has loaded. Static resource requests
+ * (real files, all of which have an extension in this build) and api requests are excluded so real
+ * 404s stay real 404s.
  */
 @Controller
 class IndexHtmlController(

--- a/frontend/src/main/webapp/cypress/e2e/checkin.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/checkin.cy.ts
@@ -5,7 +5,7 @@ describe('CheckIn', () => {
   beforeEach(() => {
     cy.loginDefault();
     cy.createDistribution();
-    cy.visit('/#/anmeldung/annahme');
+    cy.visit('/anmeldung/annahme');
   });
 
   afterEach(() => {
@@ -21,7 +21,7 @@ describe('CheckIn', () => {
 
     assertDashboardCustomerCount(1);
 
-    cy.visit('/#/anmeldung/annahme');
+    cy.visit('/anmeldung/annahme');
     searchCustomer(100);
 
     cy.byTestId('ticketNumberInput').should('have.value', '10');
@@ -82,7 +82,7 @@ describe('CheckIn', () => {
 
     assertDashboardCustomerCount(1);
 
-    cy.visit('/#/anmeldung/annahme');
+    cy.visit('/anmeldung/annahme');
     searchCustomer(100);
 
     cy.byTestId('ticketNumberInput').should('have.value', '10');
@@ -132,6 +132,6 @@ function assertFormReset() {
 }
 
 function assertDashboardCustomerCount(count: number) {
-  cy.visit('/#/uebersicht');
+  cy.visit('/uebersicht');
   cy.byTestId('customers-count').should('have.text', count.toString());
 }

--- a/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-above-limit.cy.ts
@@ -10,7 +10,7 @@ describe('Customer Above Limit', () => {
     cy.createDummyCustomer(50000, true).then((response) => {
       const customer = response.body.data;
 
-      cy.visit('/#/kunden/ueber-limit');
+      cy.visit('/kunden/ueber-limit');
 
       cy.contains('[testid^="abovelimit-id-"]', customer.id!.toString())
         .closest('tr')
@@ -40,7 +40,7 @@ describe('Customer Above Limit', () => {
     cy.createDummyCustomer(50000, true).then((response) => {
       const customer = response.body.data;
 
-      cy.visit('/#/kunden/ueber-limit');
+      cy.visit('/kunden/ueber-limit');
 
       // below md: the table is hidden and the card list is shown instead
       cy.get('[testid^="abovelimit-id-"]').should('exist').and('not.be.visible');
@@ -64,7 +64,7 @@ describe('Customer Above Limit', () => {
     cy.createDummyCustomer(50000, true).then((response) => {
       const customer = response.body.data;
 
-      cy.visit('/#/kunden/ueber-limit');
+      cy.visit('/kunden/ueber-limit');
 
       cy.contains('[testid^="abovelimit-id-"]', customer.id!.toString())
         .closest('tr')

--- a/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-create.cy.ts
@@ -6,7 +6,7 @@ describe('Customer Creation', () => {
 
   beforeEach(() => {
     cy.loginE2ETest2();
-    cy.visit('/#/kunden/anlegen');
+    cy.visit('/kunden/anlegen');
   });
 
   it('create new qualified customer', () => {
@@ -60,7 +60,7 @@ describe('Customer Creation', () => {
 
     beforeEach(() => {
       cy.loginDefault();
-      cy.visit('/#/kunden/anlegen');
+      cy.visit('/kunden/anlegen');
     });
 
     it('supervisor should be able to create qualified customer', () => {

--- a/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-detail.cy.ts
@@ -12,22 +12,22 @@ describe('Customer Detail', () => {
   });
 
   it('customerId correct', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
     cy.byTestId('customerIdText').should('have.text', '101');
   });
 
   it('generate pdf and opens for download', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
     generateAndDownloadPdf('stammdaten-101-musterfrau-eva.pdf');
   });
 
   it('generate pdf and opens for download with less data from customer', () => {
-    cy.visit('/#/kunden/detail/100');
+    cy.visit('/kunden/detail/100');
     generateAndDownloadPdf('stammdaten-100-mustermann-max-single.pdf');
   });
 
   it('edit customer', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
 
     cy.byTestId('editCustomerButton').click();
 
@@ -36,7 +36,7 @@ describe('Customer Detail', () => {
 
   it('delete customer', () => {
     cy.createDummyCustomer().then((response) => {
-      cy.visit('/#/kunden/detail/' + response.body.data.id);
+      cy.visit('/kunden/detail/' + response.body.data.id);
 
       openEditMenu();
       cy.byTestId('deleteCustomerButton').click();
@@ -60,7 +60,7 @@ describe('Customer Detail', () => {
   });
 
   it('prolong customer', () => {
-    cy.visit('/#/kunden/detail/100');
+    cy.visit('/kunden/detail/100');
 
     let validDateString;
     cy.byTestId('validUntilText').then(($value) => {
@@ -75,7 +75,7 @@ describe('Customer Detail', () => {
   });
 
   it('invalidate customer', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
 
     openEditMenu();
     cy.byTestId('invalidateCustomerButton').click();
@@ -84,7 +84,7 @@ describe('Customer Detail', () => {
   });
 
   it('lock and unlock customer', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
 
     cy.byTestId('lock-info-banner').should('not.exist');
 
@@ -104,14 +104,14 @@ describe('Customer Detail', () => {
   });
 
   it('customer note shown', () => {
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
 
     cy.byTestId('latest-customer-note').should('be.visible');
     cy.byTestId('latest-customer-note-none').should('not.exist');
   });
 
   it('customer note not shown', () => {
-    cy.visit('/#/kunden/detail/100');
+    cy.visit('/kunden/detail/100');
 
     cy.byTestId('latest-customer-note').should('not.exist');
     cy.byTestId('latest-customer-note-none').should('be.visible');
@@ -119,7 +119,7 @@ describe('Customer Detail', () => {
 
   it('renders responsively on phone (content before actions) and still allows locking/unlocking', () => {
     cy.viewport(PHONE_VIEWPORT);
-    cy.visit('/#/kunden/detail/101');
+    cy.visit('/kunden/detail/101');
 
     cy.byTestId('customerIdText').should('be.visible');
     cy.byTestId('latest-customer-note').scrollIntoView().should('be.visible');
@@ -153,7 +153,7 @@ describe('Customer Detail', () => {
 
   it('renders correctly at tablet breakpoint and still allows prolonging', () => {
     cy.viewport(TABLET_VIEWPORT);
-    cy.visit('/#/kunden/detail/100');
+    cy.visit('/kunden/detail/100');
 
     cy.byTestId('customerIdText').should('be.visible');
     cy.byTestId('latest-customer-note-none').should('be.visible');
@@ -171,7 +171,7 @@ describe('Customer Detail', () => {
   });
 
   it('ticket section not visible when no distribution is active', () => {
-    cy.visit('/#/kunden/detail/100');
+    cy.visit('/kunden/detail/100');
 
     cy.byTestId('ticket-number-input').should('not.exist');
     cy.byTestId('ticket-number-display').should('not.exist');
@@ -187,14 +187,14 @@ describe('Customer Detail', () => {
     });
 
     it('ticket section visible when distribution is active', () => {
-      cy.visit('/#/kunden/detail/100');
+      cy.visit('/kunden/detail/100');
 
       cy.byTestId('ticket-number-input').should('be.visible');
       cy.byTestId('assign-ticket-button').should('be.visible');
     });
 
     it('assign ticket to customer', () => {
-      cy.visit('/#/kunden/detail/100');
+      cy.visit('/kunden/detail/100');
 
       cy.byTestId('ticket-number-input').type('15');
       cy.byTestId('assign-ticket-button').should('not.be.disabled');
@@ -207,7 +207,7 @@ describe('Customer Detail', () => {
 
     it('delete assigned ticket from customer', () => {
       cy.addCustomerToDistribution({customerId: 100, ticketNumber: 25});
-      cy.visit('/#/kunden/detail/100');
+      cy.visit('/kunden/detail/100');
 
       cy.byTestId('ticket-number-display').should('contain.text', '25');
       cy.byTestId('delete-ticket-button').click();
@@ -217,7 +217,7 @@ describe('Customer Detail', () => {
     });
 
     it('assign ticket button disabled when input is empty', () => {
-      cy.visit('/#/kunden/detail/100');
+      cy.visit('/kunden/detail/100');
 
       cy.byTestId('assign-ticket-button').should('be.disabled');
     });
@@ -254,7 +254,7 @@ describe('Customer Detail', () => {
     it('upload, download and delete a document', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('documents-tab-label').click();
         cy.byTestId('upload-document-panel').should('be.visible');
@@ -284,7 +284,7 @@ describe('Customer Detail', () => {
     it('moves document actions below the filename on phone, keeps them alongside it on tablet/desktop', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('documents-tab-label').click();
         cy.byTestId('upload-document-panel').should('be.visible');
@@ -354,7 +354,7 @@ describe('Customer Detail', () => {
 
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('documents-tab-label').click();
         cy.byTestId('upload-document-panel').should('be.visible');
@@ -386,7 +386,7 @@ describe('Customer Detail', () => {
 
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('documents-tab-label').click();
         cy.byTestId('upload-document-panel').should('be.visible');
@@ -416,7 +416,7 @@ describe('Customer Detail', () => {
         const customerId = response.body.data.id!;
         cy.accrueCostContributionDebt(customerId);
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('pendingCostContributionText').should(($el) => {
           expect(parseCurrencyText($el.text())).to.be.greaterThan(0);
@@ -447,7 +447,7 @@ describe('Customer Detail', () => {
         const customerId = response.body.data.id!;
         cy.accrueCostContributionDebt(customerId);
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('pendingCostContributionText').invoke('text').then(parseCurrencyText).then((initialAmount) => {
           cy.byTestId('costContributionButton').scrollIntoView().click();
@@ -477,7 +477,7 @@ describe('Customer Detail', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('pendingCostContributionText').should(($el) => {
           expect(parseCurrencyText($el.text())).to.equal(0);
@@ -510,7 +510,7 @@ describe('Customer Detail', () => {
     it('prolong customer with invalid income triggers confirm dialog when supervisor', () => {
       cy.createDummyCustomer(10000, true).then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
 
         cy.byTestId('prolongButton').click();
         cy.byTestId('prolongThreeMonthsButton').click();
@@ -541,7 +541,7 @@ describe('Customer Detail', () => {
           }
         });
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
         cy.byTestId('editCustomerButton').click();
 
         cy.byTestId('save-button').click();
@@ -558,7 +558,7 @@ describe('Customer Detail', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
         cy.byTestId('editCustomerButton').click();
 
         const incomeInput = cy.byTestId('incomeInput');
@@ -591,7 +591,7 @@ describe('Customer Detail', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
 
-        cy.visit('/#/kunden/detail/' + customerId);
+        cy.visit('/kunden/detail/' + customerId);
         cy.byTestId('editCustomerButton').click();
 
         const incomeInput = cy.byTestId('incomeInput');

--- a/frontend/src/main/webapp/cypress/e2e/customer-duplicates.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-duplicates.cy.ts
@@ -13,7 +13,7 @@ describe('Customer Duplicates', () => {
       const customer1 = first.body.data;
       const customer2 = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
 
       cy.byTestId('duplicate-customer-' + customer1.id).within(() => {
         cy.byTestId('duplicate-customer-name-' + customer1.id)
@@ -35,7 +35,7 @@ describe('Customer Duplicates', () => {
     createDuplicatePair().then(({first}) => {
       const customer1 = first.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-detail-button-' + customer1.id).click();
 
       cy.url().should('include', '/kunden/detail/' + customer1.id);
@@ -46,7 +46,7 @@ describe('Customer Duplicates', () => {
     createDuplicatePair().then(({second}) => {
       const customer2 = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-delete-button-' + customer2.id).click();
 
       cy.byTestId('deletecustomer-dialog').should('be.visible');
@@ -72,7 +72,7 @@ describe('Customer Duplicates', () => {
       const customer1 = first.body.data;
       const customer2 = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + customer1.id).click();
 
       cy.url().should('include', `/kunden/zusammenfuehren/${customer1.id}`);
@@ -87,7 +87,7 @@ describe('Customer Duplicates', () => {
       const customer1 = first.body.data;
       const customer2 = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
 
       cy.byTestId('duplicate-customer-' + customer1.id).scrollIntoView().should('be.visible');
       cy.byTestId('duplicate-customer-' + customer2.id).scrollIntoView().should('be.visible');
@@ -119,7 +119,7 @@ describe('Customer Duplicates', () => {
       const customer1 = first.body.data;
       const customer2 = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
 
       // at md: (768px) the pair grid becomes 2 columns, so both cards start at the same row position
       cy.byTestId('duplicate-customer-' + customer1.id).then(($first) => {
@@ -148,7 +148,7 @@ describe('Customer Merge', () => {
       const target = first.body.data;
       const source = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
 
       cy.url().should('include', `/kunden/zusammenfuehren/${target.id}`);
@@ -177,7 +177,7 @@ describe('Customer Merge', () => {
     }).then(({first}) => {
       const target = first.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
       cy.byTestId('merge-confirm-button').click();
 
@@ -207,7 +207,7 @@ describe('Customer Merge', () => {
     ).then(({first}) => {
       const target = first.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
       cy.byTestId('merge-confirm-button').click();
 
@@ -226,7 +226,7 @@ describe('Customer Merge', () => {
 
       cy.createCustomerNote(source.id!, 'note from the merged-away source');
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
       cy.byTestId('merge-confirm-button').click();
 
@@ -246,7 +246,7 @@ describe('Customer Merge', () => {
       cy.addCustomerToDistribution({customerId: target.id!, ticketNumber: 11});
       cy.addCustomerToDistribution({customerId: source.id!, ticketNumber: 22});
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
 
       cy.contains('22').should('be.visible');
@@ -264,7 +264,7 @@ describe('Customer Merge', () => {
       const target = first.body.data;
       const source = second.body.data;
 
-      cy.visit('/#/kunden/duplikate');
+      cy.visit('/kunden/duplikate');
       cy.byTestId('duplicate-merge-button-' + target.id).click();
       cy.byTestId('merge-cancel-button').click();
 

--- a/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-edit.cy.ts
@@ -9,7 +9,7 @@ describe('Customer Edit', () => {
   it('customer updated', () => {
     cy.createDummyCustomer().then((response) => {
       const customerId = response.body.data.id;
-      cy.visit('/#/kunden/bearbeiten/' + customerId);
+      cy.visit('/kunden/bearbeiten/' + customerId);
 
       cy.byTestId('save-button').should('be.enabled');
 
@@ -65,7 +65,7 @@ describe('Customer Edit', () => {
   it('customer invalid and saved but invalid', () => {
     cy.createDummyCustomer().then((response) => {
       const customerId = response.body.data.id;
-      cy.visit('/#/kunden/bearbeiten/' + customerId);
+      cy.visit('/kunden/bearbeiten/' + customerId);
 
       cy.byTestId('save-button').should('be.enabled');
 
@@ -99,7 +99,7 @@ describe('Customer Edit', () => {
 
       [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
         cy.viewport(viewport);
-        cy.visit('/#/kunden/bearbeiten/' + customerId);
+        cy.visit('/kunden/bearbeiten/' + customerId);
 
         cy.byTestId('lastnameInput').should('be.visible');
         cy.byTestId('save-button').should('be.enabled');
@@ -116,7 +116,7 @@ describe('Customer Edit', () => {
     it('supervisor should be able to force update customer', () => {
       cy.createDummyCustomer().then((response) => {
         const customerId = response.body.data.id;
-        cy.visit('/#/kunden/bearbeiten/' + customerId);
+        cy.visit('/kunden/bearbeiten/' + customerId);
 
         // Set income within limits
         const incomeInput = cy.byTestId('incomeInput');

--- a/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/customer-search.cy.ts
@@ -4,7 +4,7 @@ describe('Customer Search', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/kunden/suchen');
+    cy.visit('/kunden/suchen');
   });
 
   it('search by customerId', () => {

--- a/frontend/src/main/webapp/cypress/e2e/dashboard.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/dashboard.cy.ts
@@ -6,7 +6,7 @@ describe('Dashboard', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/');
+    cy.visit('/');
   });
 
   it('create and stop distribution', () => {

--- a/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/food-collection-recording.cy.ts
@@ -5,7 +5,7 @@ describe('Food Collection Recording', () => {
   beforeEach(() => {
     cy.loginDefault();
     cy.createDistribution();
-    cy.visit('/#/logistik/warenerfassung');
+    cy.visit('/logistik/warenerfassung');
   });
 
   afterEach(() => {
@@ -47,7 +47,7 @@ describe('Food Collection Recording', () => {
 
       // Route 2 now has both base data and food items entered, so the dashboard panel should
       // count it as fully recorded and list it by name - other routes (untouched) must not count.
-      cy.visit('/#/');
+      cy.visit('/');
       cy.byTestId('recorded-food-collections-count').should('have.text', '1 / 3');
       cy.byTestId('recorded-route-names').should('have.text', 'Route 2');
     });

--- a/frontend/src/main/webapp/cypress/e2e/general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/general.cy.ts
@@ -3,7 +3,7 @@ import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 describe('General', () => {
 
   beforeEach(() => {
-    cy.visit('/#/');
+    cy.visit('/');
   });
 
   it('window title correct', () => {
@@ -15,7 +15,7 @@ describe('General', () => {
   });
 
   it('status 404 page visible', () => {
-    cy.visit('/#/invalidpath');
+    cy.visit('/invalidpath');
 
     cy.byTestId('status').should('have.text', '404');
     cy.byTestId('title').should('have.text', 'Seite nicht gefunden');
@@ -25,7 +25,7 @@ describe('General', () => {
   });
 
   it('status 500 page visible', () => {
-    cy.visit('/#/500');
+    cy.visit('/500');
 
     cy.byTestId('status').should('have.text', '500');
     cy.byTestId('title').should('have.text', 'Houston, wir haben ein Problem!');
@@ -37,7 +37,7 @@ describe('General', () => {
   it('remains usable on mobile viewports', () => {
     [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
       cy.viewport(viewport);
-      cy.visit('/#/invalidpath');
+      cy.visit('/invalidpath');
 
       cy.byTestId('status').should('be.visible').and('have.text', '404');
       cy.byTestId('title').should('be.visible').and('have.text', 'Seite nicht gefunden');
@@ -50,7 +50,7 @@ describe('Navigation Progress Bar', () => {
 
   it('shows a top-level loading bar while a resolver-gated page is loading, and hides it once loaded', () => {
     cy.loginDefault();
-    cy.visit('/#/uebersicht');
+    cy.visit('/uebersicht');
 
     // navigate once first so the app is fully settled before triggering the navigation under test
     cy.contains('Kunden suchen').click();

--- a/frontend/src/main/webapp/cypress/e2e/login.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/login.cy.ts
@@ -4,7 +4,7 @@ import {PHONE_VIEWPORT, TABLET_VIEWPORT} from '../support/viewports';
 describe('Login', () => {
 
   beforeEach(() => {
-    cy.visit('/#/login');
+    cy.visit('/login');
   });
 
   it('login button disabled by default', () => {
@@ -29,17 +29,6 @@ describe('Login', () => {
     cy.url().should('contain', '/uebersicht');
   });
 
-  it('login successful after a direct navigation to a non-root path (e.g. a bookmark)', () => {
-    // Regression test for #2972: loading the app from a path other than "/" or "/#/..." (as
-    // happens with a bookmarked/typed URL) must not break the app's own API calls, which rely on
-    // an absolute base URL derived from the page - not the requested path.
-    cy.visit('/login');
-
-    enterLoginData('e2etest', 'e2etest');
-
-    cy.url().should('contain', '/uebersicht');
-  });
-
   it('login failed', () => {
     enterLoginData('dummy', 'dummy');
 
@@ -49,12 +38,12 @@ describe('Login', () => {
 
   it('login with required password change cannot access the dashboard', () => {
     createTestUserRequiringPasswordChange().then(({user, testUser}) => {
-      cy.visit('/#/login');
+      cy.visit('/login');
 
       enterLoginData(user.username, testUser.password!);
       cy.url().should('contain', '/login/passwortaendern');
 
-      cy.visit('/#/uebersicht');
+      cy.visit('/uebersicht');
       cy.url().should('contain', '/login');
       cy.byTestId('errorMessage').should('exist');
     });
@@ -71,7 +60,7 @@ describe('Login', () => {
 
       // Cancelling must actually end the still-live session (not just navigate away from
       // it) - otherwise a stale session would let this "cancelled" login back into the app.
-      cy.visit('/#/uebersicht');
+      cy.visit('/uebersicht');
       cy.url().should('contain', '/login');
       cy.byTestId('errorMessage').should('not.exist');
     });
@@ -79,7 +68,7 @@ describe('Login', () => {
 
   it('login with required password change and password changed', () => {
     createTestUserRequiringPasswordChange([{key: 'CHECKIN', title: 'Anmeldung'}]).then(({user, testUser}) => {
-      cy.visit('/#/login');
+      cy.visit('/login');
 
       enterLoginData(user.username, testUser.password!);
       cy.url().should('contain', '/login/passwortaendern');
@@ -102,7 +91,7 @@ describe('Login', () => {
         cy.createLoginRequest(user.username, 'wrong-' + testUser.password, false);
       }
 
-      cy.visit('/#/login');
+      cy.visit('/login');
       enterLoginData(user.username, testUser.password!);
 
       cy.url().should('contain', '/login');
@@ -148,14 +137,14 @@ describe('Login', () => {
 
   it('accessing a module without the required permission shows access denied', () => {
     createTestUser([{key: 'CHECKIN', title: 'Anmeldung'}]).then(({user, testUser}) => {
-      cy.visit('/#/login');
+      cy.visit('/login');
       enterLoginData(user.username, testUser.password!);
 
       // CHECKIN is enough to pass uebersicht's generic anyPermission check...
       cy.url().should('contain', '/uebersicht');
 
       // ...but kunden specifically requires CUSTOMER, which this user was never given.
-      cy.visit('/#/kunden/suchen');
+      cy.visit('/kunden/suchen');
 
       cy.url().should('contain', '/login/fehlgeschlagen');
       cy.byTestId('errorMessage').should('exist').and('contain.text', 'Zugriff nicht erlaubt');
@@ -164,7 +153,7 @@ describe('Login', () => {
 
   it('remains usable on a phone viewport', () => {
     cy.viewport(PHONE_VIEWPORT);
-    cy.visit('/#/login');
+    cy.visit('/login');
 
     cy.byTestId('username').should('be.visible').type('e2etest');
     cy.byTestId('password').should('be.visible').type('e2etest');
@@ -175,7 +164,7 @@ describe('Login', () => {
 
   it('remains usable on a tablet viewport', () => {
     cy.viewport(TABLET_VIEWPORT);
-    cy.visit('/#/login');
+    cy.visit('/login');
 
     cy.byTestId('username').should('be.visible').type('e2etest');
     cy.byTestId('password').should('be.visible').type('e2etest');

--- a/frontend/src/main/webapp/cypress/e2e/passwordchange.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/passwordchange.cy.ts
@@ -6,7 +6,7 @@ describe('PasswordChange', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#');
+    cy.visit('/');
   });
 
   it('password mismatch validation', () => {
@@ -70,14 +70,17 @@ describe('PasswordChange', () => {
         password: 'dummy-' + randomNumber,
         passwordRepeat: 'dummy-' + randomNumber,
         passwordChangeRequired: false,
-        permissions: []
+        // Needs at least one permission to pass the dashboard's anyPermission guard - the cy.visit
+        // below is a real page reload (not just an in-app navigation), so the guard genuinely runs
+        // for this freshly-logged-in user rather than reusing an already-authenticated session.
+        permissions: [{key: 'CHECKIN', title: 'Anmeldung'}]
       };
 
       cy.createUser(testUser).then(response => {
         const user = response.body;
 
         cy.login(user.username, testUser.password!);
-        cy.visit('/#');
+        cy.visit('/');
 
         cy.byTestId('usermenu').click();
         cy.byTestId('usermenu-changepassword').click();
@@ -116,9 +119,9 @@ describe('PasswordChange', () => {
         cy.url().should('contain', '/login');
 
         cy.login(user.username, '4wtouCcWWqDJsP');
-        cy.visit('/#');
+        cy.visit('/');
 
-        cy.url().should('contain', '/#');
+        cy.url().should('contain', '/uebersicht');
 
         // expect error for invalid password
         cy.createLoginRequest(user.username, currentPassword, false).then((resp) => {

--- a/frontend/src/main/webapp/cypress/e2e/scanner.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/scanner.cy.ts
@@ -8,7 +8,7 @@ describe('Scanner', () => {
   });
 
   it('connection and webcam initialized successfully', () => {
-    cy.visit('/#/anmeldung/scanner');
+    cy.visit('/anmeldung/scanner');
 
     // Check that the scanner ID is displayed
     cy.byTestId('scanner-id').should('be.visible').invoke('text').then((text) => {
@@ -24,7 +24,7 @@ describe('Scanner', () => {
   it('QR code scanned from webcam is decoded and sent to the backend', () => {
     cy.intercept('POST', '/api/scanners/*/results*').as('scanResult');
 
-    cy.visit('/#/anmeldung/scanner');
+    cy.visit('/anmeldung/scanner');
     cy.byTestId('state-camera', {timeout: 20000}).should('have.text', 'Bereit');
 
     // The fake webcam feed (cypress.config.ts) shows a QR code encoding '12345' -
@@ -39,7 +39,7 @@ describe('Scanner', () => {
   it('remains usable on mobile viewports', () => {
     [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
       cy.viewport(viewport);
-      cy.visit('/#/anmeldung/scanner');
+      cy.visit('/anmeldung/scanner');
 
       cy.byTestId('scanner-id').should('be.visible');
       cy.byTestId('state-camera', {timeout: 20000}).should('have.text', 'Bereit');

--- a/frontend/src/main/webapp/cypress/e2e/settings-cars.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-cars.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Cars', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/fahrzeuge');
+    cy.visit('/einstellungen/fahrzeuge');
   });
 
   it('lists cars', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-employees.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-employees.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Employees', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/mitarbeiter');
+    cy.visit('/einstellungen/mitarbeiter');
   });
 
   it('lists employees', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-food-categories.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-food-categories.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Food Categories', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/lebensmittelkategorien');
+    cy.visit('/einstellungen/lebensmittelkategorien');
   });
 
   it('lists food categories', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-login-attempts.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-login-attempts.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Anmelde-Versuche', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/anmelde-versuche');
+    cy.visit('/einstellungen/anmelde-versuche');
   });
 
   it('lists login attempts', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-mail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-mail.cy.ts
@@ -4,7 +4,7 @@ describe('Dashboard', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/email');
+    cy.visit('/einstellungen/email');
   });
 
   it('change email recipients', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-shelters.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-shelters.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Shelters', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/notschlafstellen');
+    cy.visit('/einstellungen/notschlafstellen');
   });
 
   it('lists shelters', () => {

--- a/frontend/src/main/webapp/cypress/e2e/settings-static-values.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/settings-static-values.cy.ts
@@ -4,7 +4,7 @@ describe('Settings - Static Values', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/einstellungen/statische-werte');
+    cy.visit('/einstellungen/statische-werte');
   });
 
   it('lists static values', () => {

--- a/frontend/src/main/webapp/cypress/e2e/statistics-general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/statistics-general.cy.ts
@@ -6,7 +6,7 @@ describe('Statistics General', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/statistiken/allgemein');
+    cy.visit('/statistiken/allgemein');
   });
 
   it('defaults to the current year and shows the aggregated data', () => {

--- a/frontend/src/main/webapp/cypress/e2e/statistics-school-starter-packages.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/statistics-school-starter-packages.cy.ts
@@ -14,7 +14,7 @@ describe('Statistics School Starter Packages', () => {
       const customer = response.body.data;
       const child = customer.additionalPersons![0];
 
-      cy.visit('/#/statistiken/schulstartpakete');
+      cy.visit('/statistiken/schulstartpakete');
 
       cy.byTestId('schoolStarterPackageAgeMinInput').should('have.value', '6');
       cy.byTestId('schoolStarterPackageAgeMaxInput').should('have.value', '10');
@@ -34,7 +34,7 @@ describe('Statistics School Starter Packages', () => {
     createCustomerWithChildAge(20).then((response) => {
       const child = response.body.data.additionalPersons![0];
 
-      cy.visit('/#/statistiken/schulstartpakete');
+      cy.visit('/statistiken/schulstartpakete');
 
       cy.contains(child.lastname).should('not.exist');
     });
@@ -44,7 +44,7 @@ describe('Statistics School Starter Packages', () => {
     createCustomerWithChildAge(15).then((response) => {
       const child = response.body.data.additionalPersons![0];
 
-      cy.visit('/#/statistiken/schulstartpakete');
+      cy.visit('/statistiken/schulstartpakete');
       cy.contains(child.lastname).should('not.exist');
 
       cy.byTestId('schoolStarterPackageAgeMinInput').clear().type('11');
@@ -55,7 +55,7 @@ describe('Statistics School Starter Packages', () => {
   });
 
   it('exports the school starter package report as csv', () => {
-    cy.visit('/#/statistiken/schulstartpakete');
+    cy.visit('/statistiken/schulstartpakete');
 
     cy.contains('CSV-Export').click();
 
@@ -73,7 +73,7 @@ describe('Statistics School Starter Packages', () => {
     createCustomerWithChildAge(8).then((response) => {
       const child = response.body.data.additionalPersons![0];
 
-      cy.visit('/#/statistiken/schulstartpakete');
+      cy.visit('/statistiken/schulstartpakete');
 
       cy.byTestId('schoolStarterPackageAgeMinInput').should('be.visible');
       cy.byTestId('school-starter-package-table').should('not.be.visible');
@@ -87,7 +87,7 @@ describe('Statistics School Starter Packages', () => {
     cy.viewport(TABLET_VIEWPORT);
 
     createCustomerWithChildAge(8).then(() => {
-      cy.visit('/#/statistiken/schulstartpakete');
+      cy.visit('/statistiken/schulstartpakete');
 
       cy.byTestId('schoolStarterPackageAgeMinInput').should('be.visible');
       cy.byTestId('school-starter-package-table').should('be.visible');

--- a/frontend/src/main/webapp/cypress/e2e/ticket-screen.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/ticket-screen.cy.ts
@@ -7,7 +7,7 @@ describe('TicketScreen', () => {
   });
 
   it('start time set and shown correctly', () => {
-    cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+    cy.visit('/anmeldung/ticketmonitor-steuerung');
 
     cy.byTestId('starttime-input').type('12:34');
     cy.byTestId('show-starttime-button').click();
@@ -17,19 +17,21 @@ describe('TicketScreen', () => {
   });
 
   it('monitor opened correctly', () => {
+    // Stubbed without a fake implementation that redirects the current window: the target URL is
+    // now a real path rather than a hash fragment, so setting location.href to it (as this test
+    // used to, to simulate "opening" the monitor without a real new tab) triggers a genuine page
+    // reload - which wipes the stub before Cypress can assert it was called. Asserting on the call
+    // itself is enough; that the target URL actually renders the ticket monitor is already covered
+    // by the tests below that visit it directly.
     cy.on('window:before:load', (win) => {
-      cy.stub(win, 'open').as('open').callsFake(url => {
-        win.location.href = url;
-      });
+      cy.stub(win, 'open').as('open');
     });
 
-    cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+    cy.visit('/anmeldung/ticketmonitor-steuerung');
 
     cy.byTestId('open-screen-button').click();
 
-    cy.get('@open').should('be.called');
-    cy.byTestId('title').should('have.text', 'Ticket');
-    cy.url().should('eq', Cypress.config().baseUrl + '#/anmeldung/ticketmonitor');
+    cy.get('@open').should('have.been.calledWith', Cypress.config().baseUrl + 'anmeldung/ticketmonitor', '_blank');
   });
 
   it('fullscreen kiosk display still loads at phone and tablet sizes', () => {
@@ -37,7 +39,7 @@ describe('TicketScreen', () => {
     // the smaller viewports rather than exercising its layout in detail.
     for (const viewport of [PHONE_VIEWPORT, TABLET_VIEWPORT]) {
       cy.viewport(viewport);
-      cy.visit('/#/anmeldung/ticketmonitor');
+      cy.visit('/anmeldung/ticketmonitor');
       cy.byTestId('title').should('exist');
       cy.byTestId('text').should('exist');
     }
@@ -47,7 +49,7 @@ describe('TicketScreen', () => {
     // This fullscreen kiosk display has no header/badge like the rest of the app (see
     // sse.service.spec.ts / ticket-screen.component.ts), so its own indicator must stay hidden
     // on a healthy connection - otherwise it would falsely look "disconnected" all the time.
-    cy.visit('/#/anmeldung/ticketmonitor');
+    cy.visit('/anmeldung/ticketmonitor');
     cy.byTestId('title').should('exist');
     cy.byTestId('connectionState').should('not.exist');
   });
@@ -56,7 +58,7 @@ describe('TicketScreen', () => {
 
     beforeEach(() => {
       createDistributionWithTickets();
-      cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+      cy.visit('/anmeldung/ticketmonitor-steuerung');
     });
 
     afterEach(() => {
@@ -123,7 +125,7 @@ describe('TicketScreen', () => {
 
     beforeEach(() => {
       createDistributionWithTickets();
-      cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+      cy.visit('/anmeldung/ticketmonitor-steuerung');
     });
 
     it('tickets switched successfully at tablet breakpoint (sm: button row)', () => {
@@ -169,7 +171,7 @@ describe('TicketScreen', () => {
 
         cy.createDistribution();
         cy.addCustomerToDistribution({customerId, ticketNumber: 1});
-        cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+        cy.visit('/anmeldung/ticketmonitor-steuerung');
 
         // deliberately no click on "Aktuelles Ticket" here
         cy.byTestId('pendingCostContributionText').should(($el) => {
@@ -187,7 +189,7 @@ describe('TicketScreen', () => {
 
         cy.createDistribution();
         cy.addCustomerToDistribution({customerId, ticketNumber: 1});
-        cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+        cy.visit('/anmeldung/ticketmonitor-steuerung');
 
         cy.byTestId('show-currentticket-button').click();
         cy.byTestId('pendingCostContributionText').should(($el) => {
@@ -212,7 +214,7 @@ describe('TicketScreen', () => {
 
         cy.createDistribution();
         cy.addCustomerToDistribution({customerId, ticketNumber: 1});
-        cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+        cy.visit('/anmeldung/ticketmonitor-steuerung');
 
         cy.byTestId('show-currentticket-button').click();
         cy.byTestId('pendingCostContributionText').invoke('text').then(parseCurrencyText).then((initialAmount) => {
@@ -242,7 +244,7 @@ describe('TicketScreen', () => {
 
         cy.createDistribution();
         cy.addCustomerToDistribution({customerId, ticketNumber: 1});
-        cy.visit('/#/anmeldung/ticketmonitor-steuerung');
+        cy.visit('/anmeldung/ticketmonitor-steuerung');
 
         cy.byTestId('show-currentticket-button').click();
         cy.byTestId('pendingCostContributionText').should(($el) => {

--- a/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-create.cy.ts
@@ -7,7 +7,7 @@ describe('User Create', () => {
   });
 
   it('create new user', () => {
-    cy.visit('/#/benutzer/erstellen');
+    cy.visit('/benutzer/erstellen');
 
     cy.getAnyRandomNumber().then((userRandomId) => {
       const username = 'test-username-' + userRandomId;
@@ -28,7 +28,7 @@ describe('User Create', () => {
   });
 
   it('create new user which exists already', () => {
-    cy.visit('/#/benutzer/erstellen');
+    cy.visit('/benutzer/erstellen');
 
     // 1. Intercept the POST request that returns the 409 error
     // Replace '/api/users' with the actual endpoint URL your app uses
@@ -58,7 +58,7 @@ describe('User Create', () => {
   });
 
   it('permissions are grouped by category with a working select-all toggle', () => {
-    cy.visit('/#/benutzer/erstellen');
+    cy.visit('/benutzer/erstellen');
 
     cy.getAnyRandomNumber().then((userRandomId) => {
       const username = 'test-username-' + userRandomId;
@@ -97,7 +97,7 @@ describe('User Create', () => {
   it('remains usable on mobile viewports', () => {
     [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
       cy.viewport(viewport);
-      cy.visit('/#/benutzer/erstellen');
+      cy.visit('/benutzer/erstellen');
 
       cy.byTestId('usernameInput').should('be.visible').type('mobile-test-user');
       cy.byTestId('save-button').should('exist');

--- a/frontend/src/main/webapp/cypress/e2e/user-detail.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-detail.cy.ts
@@ -25,7 +25,7 @@ describe('User Detail', () => {
       };
 
       cy.createUser(userData).then(response => {
-        cy.visit('/#/benutzer/detail/' + response.body.id);
+        cy.visit('/benutzer/detail/' + response.body.id);
 
         cy.byTestId('permission-group-Ausgabe & Betrieb').within(() => {
           cy.byTestId('permission-chip-CHECKIN').should('contain.text', 'Anmeldung');
@@ -39,19 +39,19 @@ describe('User Detail', () => {
 
   it('shows a placeholder when the user has no permissions', () => {
     cy.createDummyUser().then(response => {
-      cy.visit('/#/benutzer/detail/' + response.body.id);
+      cy.visit('/benutzer/detail/' + response.body.id);
 
       cy.byTestId('permissionsText').should('contain.text', '-');
     });
   });
 
   it('userId correct', () => {
-    cy.visit('/#/benutzer/detail/300');
+    cy.visit('/benutzer/detail/300');
     cy.byTestId('usernameText').should('have.text', 'admin');
   });
 
   it('disable and re-enable user', () => {
-    cy.visit('/#/benutzer/detail/300');
+    cy.visit('/benutzer/detail/300');
 
     cy.byTestId('enabledText').should('have.text', 'Ja');
 
@@ -67,7 +67,7 @@ describe('User Detail', () => {
   });
 
   it('edit user', () => {
-    cy.visit('/#/benutzer/detail/100');
+    cy.visit('/benutzer/detail/100');
 
     cy.byTestId('editUserButton').click();
 
@@ -78,22 +78,23 @@ describe('User Detail', () => {
     cy.createDummyUser().then(response => {
       const userId = response.body.id;
 
-      cy.visit('/#/benutzer/detail/' + userId);
+      cy.visit('/benutzer/detail/' + userId);
 
       cy.byTestId('changeUserStateButton').click();
       cy.byTestId('deleteUserButton').click();
 
       cy.url().should('include', '/benutzer/suchen');
 
-      // delete fails, UI stays on user-search and shows toast
-      cy.visit('/#/benutzer/detail/' + userId);
-      cy.url().should('include', '/benutzer/suchen');
+      // re-fetching the now-deleted user 404s, and the app's global navigation-error handler
+      // routes that to the 404 page rather than leaving a blank shell
+      cy.visit('/benutzer/detail/' + userId);
+      cy.url().should('include', '/404');
     });
   });
 
   it('disable and re-enable user on phone', () => {
     cy.viewport(PHONE_VIEWPORT);
-    cy.visit('/#/benutzer/detail/300');
+    cy.visit('/benutzer/detail/300');
 
     // action buttons and the details card stack (flex-col-reverse, buttons below the card) below the
     // lg: breakpoint - on the short phone viewport the now-richer permissions section pushes the
@@ -114,7 +115,7 @@ describe('User Detail', () => {
 
   it('shows the stacked action/details layout at tablet width', () => {
     cy.viewport(TABLET_VIEWPORT);
-    cy.visit('/#/benutzer/detail/300');
+    cy.visit('/benutzer/detail/300');
 
     cy.byTestId('usernameText').should('have.text', 'admin');
     cy.byTestId('editUserButton').should('be.visible');

--- a/frontend/src/main/webapp/cypress/e2e/user-edit.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-edit.cy.ts
@@ -10,10 +10,10 @@ describe('User Edit', () => {
     cy.createDummyUser().then(response => {
       const user = response.body;
 
-      cy.visit('/#/benutzer/detail/' + user.id);
+      cy.visit('/benutzer/detail/' + user.id);
       cy.byTestId('permissionsText').should('not.contain.text', 'Anmeldung');
 
-      cy.visit('/#/benutzer/bearbeiten/' + user.id);
+      cy.visit('/benutzer/bearbeiten/' + user.id);
 
       // Wait for form to be fully loaded with user data
       cy.byTestId('firstnameInput').should('have.value', user.firstname);
@@ -38,7 +38,7 @@ describe('User Edit', () => {
 
       [PHONE_VIEWPORT, TABLET_VIEWPORT].forEach((viewport) => {
         cy.viewport(viewport);
-        cy.visit('/#/benutzer/bearbeiten/' + user.id);
+        cy.visit('/benutzer/bearbeiten/' + user.id);
 
         cy.byTestId('firstnameInput').should('be.visible').and('have.value', user.firstname);
         cy.byTestId('save-button').should('exist');

--- a/frontend/src/main/webapp/cypress/e2e/user-search.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/user-search.cy.ts
@@ -4,7 +4,7 @@ describe('User Search', () => {
 
   beforeEach(() => {
     cy.loginDefault();
-    cy.visit('/#/benutzer/suchen');
+    cy.visit('/benutzer/suchen');
   });
 
   it('search by personnelNumber', () => {

--- a/frontend/src/main/webapp/src/app/app.config.ts
+++ b/frontend/src/main/webapp/src/app/app.config.ts
@@ -8,10 +8,12 @@ import {
 } from '@angular/core';
 import {provideServiceWorker} from '@angular/service-worker';
 import {
+  RedirectCommand,
+  Router,
   provideRouter,
   withComponentInputBinding,
-  withHashLocation,
   withInMemoryScrolling,
+  withNavigationErrorHandler,
   withRouterConfig,
   withViewTransitions
 } from '@angular/router';
@@ -19,7 +21,6 @@ import {
 import {routes} from './app.routes';
 import {provideHttpClient, withInterceptors, withXhr} from '@angular/common/http';
 import {CookieService} from 'ngx-cookie-service';
-import {HashLocationStrategy, LocationStrategy} from '@angular/common';
 import {errorHandlerInterceptor} from './common/http/errorhandler-interceptor.service';
 import {apiPathInterceptor} from './common/http/apipath-interceptor.service';
 import {xsrfInterceptor} from './common/http/xsrf-interceptor.service';
@@ -54,8 +55,12 @@ export const appConfig: ApplicationConfig = {
         anchorScrolling: 'enabled'
       }),
       withViewTransitions(),
-      withHashLocation(),
-      withComponentInputBinding()
+      withComponentInputBinding(),
+      // A resolver failing (e.g. a bookmarked/direct-linked detail page whose entity was since
+      // deleted) needs an explicit fallback here: with real paths, that request is a genuine
+      // full-page load rather than an in-app navigation, so there's no previous in-app route left
+      // to fall back to on failure - without this handler the user is left on a blank shell.
+      withNavigationErrorHandler(() => new RedirectCommand(inject(Router).parseUrl('/404')))
     ),
     provideAppInitializer(() => inject(AuthenticationService).loadUserInfo()),
     provideAppInitializer(() => inject(SwUpdateService).init()),
@@ -79,10 +84,6 @@ export const appConfig: ApplicationConfig = {
     {
       provide: CookieService,
       useClass: CookieService
-    },
-    {
-      provide: LocationStrategy,
-      useClass: HashLocationStrategy
     },
     {
       provide: Window,

--- a/frontend/src/main/webapp/src/app/common/util/url-helper.service.ts
+++ b/frontend/src/main/webapp/src/app/common/util/url-helper.service.ts
@@ -7,10 +7,11 @@ export class UrlHelperService {
 
   /**
    * Derived from `document.baseURI` (the `<base href>` in index.html) rather than the current
-   * pathname - the app uses hash-based routing, so a direct navigation to a non-root path (e.g.
-   * a bookmark to `/login`) briefly puts that path segment into `location.pathname` before the
-   * router normalizes it into the hash. Reading the pathname here raced that normalization and
-   * misidentified the route segment as a deployment subpath (see #2972).
+   * pathname - `location.pathname` mixes the deployment prefix with whatever client-side route is
+   * currently active (e.g. `/tafel-admin/kunden/suchen`), so there's no reliable way to tell where
+   * the prefix ends and the route begins. `<base href>` is templated server-side to exactly the
+   * deployment prefix regardless of the current route, which is what broke here originally when a
+   * bookmark to a non-root path was read from the pathname instead (see #2972).
    */
   getBaseUrl(): string {
     let baseUri = this.document.baseURI;

--- a/frontend/src/main/webapp/src/app/modules/checkin/README.md
+++ b/frontend/src/main/webapp/src/app/modules/checkin/README.md
@@ -84,7 +84,7 @@ It's reused in two places: embedded as a small live preview inside `TicketScreen
 
 `TicketScreenControlComponent` is the staff control panel: buttons call `DistributionTicketScreenApiService` (`showText`, `showCurrentTicket`, `showPreviousTicket`, `showNextTicket(costContributionPaid)`), each a `POST` that causes the backend to broadcast a new SSE message picked up by every open `TicketScreenComponent`. It uses the newer `@angular/forms/signals` API (`form()`, `FormField`, `required`) for the start-time field rather than classic `FormGroup`.
 
-`openScreenInNewTab()` opens `/#/anmeldung/ticketmonitor` in a new tab via `UrlHelperService.getBaseUrl()` — this is meant to be projected onto a second monitor in the waiting area.
+`openScreenInNewTab()` opens `/anmeldung/ticketmonitor` in a new tab via `UrlHelperService.getBaseUrl()` — this is meant to be projected onto a second monitor in the waiting area.
 
 **Important routing detail:** `TicketScreenFullscreenComponent` is *not* a child of the `anmeldung` route group in `app.routes.ts`. It's registered as its own top-level route (`path: 'anmeldung/ticketmonitor'`, guarded only by the plain `authGuard`), so it requires being logged in but **not** the `SCANNER`/`CHECKIN` permission that gates the rest of this module. That's intentional — the monitor is a public-facing display, and whoever's logged into the kiosk running it may not hold either permission.
 

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.spec.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.spec.ts
@@ -121,7 +121,7 @@ describe('TicketScreenControlComponent', () => {
 
     component.openScreenInNewTab();
 
-    expect(window.open).toHaveBeenCalledWith(`${testBaseUrl}/#/anmeldung/ticketmonitor`, '_blank');
+    expect(window.open).toHaveBeenCalledWith(`${testBaseUrl}/anmeldung/ticketmonitor`, '_blank');
   });
 
   it('showStartTime', () => {

--- a/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.ts
+++ b/frontend/src/main/webapp/src/app/modules/checkin/views/ticket-screen-control/ticket-screen-control.component.ts
@@ -74,7 +74,7 @@ export class TicketScreenControlComponent {
 
   openScreenInNewTab() {
     const baseUrl = this.urlHelperService.getBaseUrl();
-    window.open(`${baseUrl}/#/anmeldung/ticketmonitor`, '_blank');
+    window.open(`${baseUrl}/anmeldung/ticketmonitor`, '_blank');
   }
 
   showStartTime() {


### PR DESCRIPTION
## Summary
- Switches Angular routing from `HashLocationStrategy` (`/#/kunden/suchen`) to `PathLocationStrategy` (`/kunden/suchen`), per #2979.
- The backend's SPA fallback route and `<base href>` rewriting (added for #2972/#2978) already generically support real-path deep links, so no backend or nginx proxy changes were needed — verified against both the subpath and subdomain nginx examples in the README.
- Fixes the ticket-monitor "open in new tab" link, which built a `/#/...` URL by hand.
- Adds a global `withNavigationErrorHandler` (redirecting to the 404 page) for resolver failures on a cold page load — e.g. a bookmark to a detail page whose entity was since deleted. Hash routing had been masking this gap because `cy.visit()` only performs a genuine full-page load when the *pathname* changes, not just the hash, so this case was never really exercised before.
- Updates every Cypress spec's `cy.visit()` calls to drop the `#/` prefix, and fixes/tightens two e2e tests whose behavior depended on hash-routing quirks (see commit message for details).

## Test plan
- [x] `./gradlew :backend:test`
- [x] `./gradlew :backend:ktlintCheck`
- [x] `npm run lint` / `typecheck` / `test-ci` (723 unit tests)
- [x] Full local Cypress e2e suite against the packaged app with the `e2e` profile (210/210 passing across all 28 specs)
- [ ] CI

🤖 Generated with Claude Code