### PR TITLE
docs: refine CLAUDE.md accuracy and generalize README nginx examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,9 +159,9 @@ The frontend is an Angular single-page application using Angular Material and Ta
 - **dashboard**: Overview with distribution state, registered customers, food amounts, statistics input
 - **customer**: Search, create, edit, detail views with duplicate detection. Deliberately *not* renamed to match the backend's `household`/`person` model — routes, components, and `CustomerData`/`CustomerAddPersonData` DTOs are unchanged; only `customer-api.service.ts` translates to/from the backend's household+persons wire shape (main person flattened onto the customer object, other persons as `additionalPersons`)
 - **checkin**: Scanner registration, QR code reading, ticket screen for customer calls
-- **logistics**: Food collection recording only (desktop/responsive layouts), one screen (`warenerfassung`). Route/shelter/shop/car/food-category admin CRUD screens actually live under the **settings** module below, not here.
+- **logistics**: Food collection recording only (desktop/responsive layouts), one screen (`warenerfassung`). Shelter/car/food-category admin CRUD screens actually live under the **settings** module below, not here. Routes and shops have no frontend admin UI at all despite backend `/api/routes`/shop support — they're only ever read (never managed) from within the food-collection-recording flow.
 - **user**: User search, create, edit with password change functionality
-- **settings**: System settings and mail recipient configuration, plus admin CRUD screens for shelters (`notschlafstellen`) and food categories (`lebensmittelkategorien`), both with drag-and-drop sortOrder reordering (Angular CDK)
+- **settings**: System settings and mail recipient configuration, plus admin CRUD screens for shelters (`notschlafstellen`), food categories (`lebensmittelkategorien`), and cars (`fahrzeuge`) — all three with drag-and-drop sortOrder reordering (Angular CDK) — as well as employees (`mitarbeiter`), login attempts (`anmelde-versuche`), and static values/limits (`statische-werte`)
 - **statistics**: Chart.js-powered distribution/demographic statistics panels
 
 **Architecture Patterns:**
@@ -438,6 +438,11 @@ Authentication: Basic HTTP auth with JWT token stored in cookie.
 
 ## Special Considerations
 
+- **Saturday Deploy Freeze**: `deploy-prod` in `.github/workflows/release.yml` refuses to run for the
+  entire day every Saturday (Europe/Vienna time). The app is live-used during Saturday distributions
+  (~12:00-24:00) and Flyway migrations run on application boot, so a deploy mid-event would restart
+  the app under load — see issue #2931. If a release doesn't show up in prod, check whether it landed
+  on a Saturday before assuming something's broken.
 - **Distribution State**: Many features require an active distribution (started but not ended). The backend enforces this via the `@TafelActiveDistributionRequired` marker annotation, checked by a global `HandlerInterceptor` (`TafelActiveDistributionRequiredInterceptor`, not an AOP aspect) registered for all controllers; the frontend uses the `tafelIfDistributionActive` directive.
 - **Customer Duplicates**: The system detects potential duplicates based on lastname, firstname, and birthdate. Review duplicate candidates before creating customers. Merging duplicates is a real field-by-field picker plus person/note/distribution-history re-parenting (`HouseholdMergeService`, `views/customer-merge/`), not a deletion - see the household module README.
 - **Income Validation**: Customer income is validated against configurable limits. The validation logic is in `IncomeValidatorService`.

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ The Docker image runs on Amazon Corretto 26 Alpine with timezone set to `Europe/
 ./gradlew :backend:test
 
 # Specific test class
-./gradlew :backend:test --tests "at.wrk.tafel.admin.backend.modules.customer.internal.CustomerServiceTest"
+./gradlew :backend:test --tests "at.wrk.tafel.admin.backend.modules.household.internal.HouseholdServiceTest"
 
-# Specific test method
-./gradlew :backend:test --tests "*CustomerServiceTest.createCustomerSuccessful"
+# Specific test class (wildcard, useful since test method names use backtick display names)
+./gradlew :backend:test --tests "*HouseholdServiceTest"
 ```
 
 Integration tests use Testcontainers to start PostgreSQL automatically.
@@ -182,12 +182,13 @@ admin/
 │       ├── kotlin/.../modules/     # Feature modules (Spring Modulith)
 │       │   ├── base/               #   Shared utilities, countries, employees
 │       │   ├── checkin/            #   Scanner registration, QR check-in
-│       │   ├── customer/           #   Customer CRUD, income validation, PDFs
 │       │   ├── dashboard/          #   Real-time overview, SSE
 │       │   ├── distribution/       #   Distribution events, tickets, statistics
+│       │   ├── household/          #   Household/person CRUD, income validation, PDFs
 │       │   ├── logistics/          #   Routes, food collections, shelters
 │       │   ├── reporting/          #   CSV/PDF reports, statistics exports
-│       │   └── settings/           #   App configuration, mail recipients
+│       │   ├── settings/           #   App configuration, mail recipients
+│       │   └── support/            #   In-app support form, files a GitHub issue
 │       └── resources/
 │           ├── db-migration/       #   Flyway SQL migrations
 │           ├── pdf-templates/      #   XSL-FO templates for PDF generation
@@ -231,9 +232,9 @@ The backend follows a **modular monolith** architecture using Spring Modulith. E
 
 **Key patterns:**
 - Outbox pattern for reliable SSE event publishing
-- Post-processor chain for distribution event side effects (emails, reports)
+- Event listener pattern for distribution close: stats/cost-contribution work runs synchronously in-module, then a `DistributionClosedEvent` is published for `reporting` to pick up async
 - Converter pattern for entity-to-DTO mapping
-- Custom validators for income limits and customer data
+- Custom validators for income limits and household/person data
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,17 @@ map $request_uri $sse_cache_control {
 }
 ```
 
+Both examples proxy to `<backend-host>:8080` - replace that placeholder with wherever your backend is actually reachable (a Docker Compose service name, a container IP, a VM hostname, ...). If that address can change at runtime, resolve it via a `resolver` directive and a variable rather than a static `proxy_pass` target, since nginx otherwise resolves a static hostname once and caches it for the life of the worker process:
+
+```nginx
+resolver 127.0.0.11 valid=30s;  # your DNS server's IP - 127.0.0.11 shown here is Docker's embedded DNS
+set $upstream http://<backend-host>:8080;
+# ...
+proxy_pass $upstream;
+```
+
+If your backend address is stable (a fixed IP or a hostname that won't change), skip the `resolver`/`set` and use `proxy_pass http://<backend-host>:8080;` directly instead.
+
 #### Subpath example
 
 nginx strips the `/tafel-admin/` prefix before forwarding to the backend, and passes it along separately via `X-Forwarded-Prefix` (not currently consumed by the app, but kept for parity/future use and general reverse-proxy convention):
@@ -309,8 +320,7 @@ server {
     listen [::]:443 ssl;
     server_name tafel-admin.example.com;
 
-    # Common Headers
-    resolver 127.0.0.11 valid=30s;  # Docker's embedded DNS, for re-resolving the upstream on restart
+    resolver 127.0.0.11 valid=30s;
 
     location /tafel-admin/ {
         proxy_set_header Host               $host;
@@ -329,7 +339,7 @@ server {
         chunked_transfer_encoding off;
 
         # Logic for re-resolution and path stripping
-        set $upstream http://tafel-admin-backend:8080;
+        set $upstream http://<backend-host>:8080;
         rewrite ^/tafel-admin/(.*) /$1 break;
 
         # SSE-Specific Optimization
@@ -369,7 +379,7 @@ server {
         proxy_set_header Connection '';
         chunked_transfer_encoding off;
 
-        set $upstream http://tafel-admin-backend:8080;
+        set $upstream http://<backend-host>:8080;
 
         add_header Cache-Control $sse_cache_control;
 
@@ -378,21 +388,10 @@ server {
 }
 ```
 
-Both examples were verified end-to-end (path stripping, forwarded headers, and the SSE header) against nginx proxying to a real backend container.
+Both examples were verified end-to-end (path stripping, forwarded headers, and the SSE header) against nginx proxying to a real backend container; swap in your own backend address before using them.
 
 > [!NOTE]
 > The SSE header is set via a `map` rather than the more obvious `if ($request_uri ~* "api/sse") { add_header ...; }`. With `proxy_buffering off` (required here for SSE to stream at all), an `add_header` set inside an `if` block is silently dropped - it never reaches the client, with no error logged. An unconditional `add_header`, or one driven by a `map` variable like above, isn't affected and works reliably. This was confirmed by reproducing both the failure and the fix directly against nginx.
-
-### Permissions
-
-Access control is based on these permissions:
-
-- `CUSTOMER` - Customer management
-- `SCANNER` - Scanner device access
-- `CHECKIN` - Check-in operations
-- `LOGISTICS` - Logistics management
-- `USER_MANAGEMENT` - User administration
-- `SETTINGS` - System settings
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Fixes stale `CLAUDE.md` module descriptions: `settings` was missing several screens that already exist (cars, employees, login attempts, static values), and `logistics` implied route/shop admin CRUD screens exist somewhere when no such UI exists in the frontend. Also documents the Saturday production deploy freeze from `release.yml`, which wasn't captured anywhere.
- Generalizes the README's nginx reverse-proxy examples so they read as a template instead of the author's specific Docker Compose setup (hardcoded backend service name, Docker's embedded DNS resolver called out as if required), and explains the `resolver`/variable technique generically.
- Drops the README's Permissions section, which duplicated `UserPermissions.kt` and wasn't useful as a doc.

Closes #3003

## Test plan
- [x] Docs-only change, no build/test impact
- [x] Verified nginx placeholder substitutions render as valid config syntax
- [x] Confirmed no other doc cross-references the removed Permissions section (`grep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)