### PR TITLE
fix(api): answer method-security denials with 403 and log why access was denied

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/LogSanitizer.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/LogSanitizer.kt
@@ -1,0 +1,13 @@
+package at.wrk.tafel.admin.backend.common
+
+/**
+ * Strips CR/LF from a value taken from an incoming request (URI, header, ...) before it goes into
+ * a log line. Without this, an attacker can smuggle a forged log line - e.g. a fake
+ * `... WARN ... Login successful ...` entry - into a request path or header, made to look like a
+ * separate, legitimate log entry once a newline splits it apart (CWE-117 log injection). Flagged by
+ * SonarCloud's `kotlinsecurity:S5145` on [at.wrk.tafel.admin.backend.modules.base.exception.GenericExceptionHandler]
+ * and applied the same way in [at.wrk.tafel.admin.backend.common.auth.components.TafelAccessDeniedHandler],
+ * both of which log request data on an access-denied path that is, by definition, reachable by
+ * anyone who can send a request at all.
+ */
+fun sanitizeForLog(value: String?): String = value?.replace(Regex("[\r\n]"), "_") ?: "?"

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
@@ -1,6 +1,5 @@
 package at.wrk.tafel.admin.backend.common.auth.components
 
-import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import jakarta.servlet.DispatcherType
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -9,21 +8,34 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.access.AccessDeniedHandlerImpl
+import org.springframework.security.web.csrf.CsrfException
 
 /**
+ * Handles the denials raised inside the *filter chain* - method-security (`@PreAuthorize`) denials
+ * never reach here, they're answered by `GenericExceptionHandler.handleAccessDeniedException`.
+ *
  * A REQUEST-dispatch denial is a real 403 delivered to a client and worth logging with enough
- * detail to diagnose (principal + the authorities actually resolved on that token). ASYNC
- * dispatches are already excluded from authorization in [WebSecurityConfig] (see the
- * `dispatcherTypeMatchers` comment there for why they'd otherwise be denied on every SSE stream
- * completion), so a denial reaching here with a committed response is unexpected - log it quietly
- * rather than delegating to [AccessDeniedHandlerImpl], which would only throw a second, "already
- * committed" exception on top of it.
+ * detail to diagnose. ASYNC dispatches are already excluded from authorization in [WebSecurityConfig]
+ * (see the `dispatcherTypeMatchers` comment there for why they'd otherwise be denied on every SSE
+ * stream completion), so a denial reaching here with a committed response is unexpected - log it
+ * quietly rather than delegating to [AccessDeniedHandlerImpl], which would only throw a second,
+ * "already committed" exception on top of it.
+ *
+ * **Why the denial's cause is logged, not just the principal:** by far the most common denial here
+ * is a [CsrfException] (missing/stale `X-XSRF-TOKEN` header), and `CsrfFilter` runs *before*
+ * `TafelJwtAuthenticationFilter` - so the security context is still empty and the principal reads
+ * `anonymous`/`none` even for a fully authenticated user with every authority they need. Logging
+ * only the principal therefore describes a CSRF failure as if it were an authorization failure,
+ * which is exactly what left the production 403s in issue #2989 unexplained: they looked like a
+ * session that had "lost" its LOGISTICS authority. The exception type plus the CSRF header/cookie
+ * state tell the two apart at a glance.
  */
-@ExcludeFromTestCoverage
 class TafelAccessDeniedHandler : AccessDeniedHandler {
 
     companion object {
         private val logger = LoggerFactory.getLogger(TafelAccessDeniedHandler::class.java)
+        private const val CSRF_HEADER_NAME = "X-XSRF-TOKEN"
+        private const val CSRF_COOKIE_NAME = "XSRF-TOKEN"
     }
 
     private val delegate = AccessDeniedHandlerImpl()
@@ -36,26 +48,44 @@ class TafelAccessDeniedHandler : AccessDeniedHandler {
         val authentication = SecurityContextHolder.getContext().authentication
         val principal = authentication?.name ?: "anonymous"
         val authorities = authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none"
+        val cause = describeCause(request, accessDeniedException)
 
         if (request.dispatcherType == DispatcherType.ASYNC || response.isCommitted) {
             logger.debug(
-                "Access denied on {} dispatch for '{}' {} {} - resolved authorities: [{}]",
+                "Access denied on {} dispatch for '{}' {} {} - resolved authorities: [{}] - {}",
                 request.dispatcherType,
                 principal,
                 request.method,
                 request.requestURI,
                 authorities,
+                cause,
             )
             return
         }
 
         logger.warn(
-            "Access denied for user '{}' on {} {} - resolved authorities: [{}]",
+            "Access denied for user '{}' on {} {} - resolved authorities: [{}] - {}",
             principal,
             request.method,
             request.requestURI,
             authorities,
+            cause,
         )
         delegate.handle(request, response, accessDeniedException)
     }
+
+    private fun describeCause(request: HttpServletRequest, exception: AccessDeniedException): String {
+        val type = exception.javaClass.simpleName
+        if (exception !is CsrfException) {
+            return "$type: ${exception.message}"
+        }
+
+        val headerPresent = !request.getHeader(CSRF_HEADER_NAME).isNullOrBlank()
+        val cookiePresent = request.cookies?.any { it.name == CSRF_COOKIE_NAME && !it.value.isNullOrBlank() } == true
+        return "$type (CSRF, not an authorization failure - principal/authorities above are empty " +
+            "because CsrfFilter runs before authentication): $CSRF_HEADER_NAME header " +
+            "${presence(headerPresent)}, $CSRF_COOKIE_NAME cookie ${presence(cookiePresent)}"
+    }
+
+    private fun presence(present: Boolean) = if (present) "present" else "missing"
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandler.kt
@@ -1,5 +1,6 @@
 package at.wrk.tafel.admin.backend.common.auth.components
 
+import at.wrk.tafel.admin.backend.common.sanitizeForLog
 import jakarta.servlet.DispatcherType
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -54,22 +55,22 @@ class TafelAccessDeniedHandler : AccessDeniedHandler {
             logger.debug(
                 "Access denied on {} dispatch for '{}' {} {} - resolved authorities: [{}] - {}",
                 request.dispatcherType,
-                principal,
-                request.method,
-                request.requestURI,
-                authorities,
-                cause,
+                sanitizeForLog(principal),
+                sanitizeForLog(request.method),
+                sanitizeForLog(request.requestURI),
+                sanitizeForLog(authorities),
+                sanitizeForLog(cause),
             )
             return
         }
 
         logger.warn(
             "Access denied for user '{}' on {} {} - resolved authorities: [{}] - {}",
-            principal,
-            request.method,
-            request.requestURI,
-            authorities,
-            cause,
+            sanitizeForLog(principal),
+            sanitizeForLog(request.method),
+            sanitizeForLog(request.requestURI),
+            sanitizeForLog(authorities),
+            sanitizeForLog(cause),
         )
         delegate.handle(request, response, accessDeniedException)
     }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.ErrorResponse
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -32,6 +35,14 @@ class GenericExceptionHandler(
      * (bean-validation failures via [handleMethodArgumentNotValid], and [TafelApiException] and its
      * subclasses via the inherited `handleErrorResponseException`). Localizes the [ProblemDetail]'s
      * title and renders the response, special-casing SSE requests.
+     *
+     * The `body` argument is only non-null when one of our own handlers built the [ProblemDetail]
+     * itself ([handleMethodArgumentNotValid]) - every inherited handler passes `null` and expects
+     * the body to be taken from the exception's own [ErrorResponse.getBody]. Falling straight
+     * through to `ex.message` instead is why a [TafelApiException] used to render its detail as the
+     * exception's `toString()` (`"400 BAD_REQUEST, ProblemDetail[type='null', ...]"`) rather than
+     * the message it was constructed with. Note the existing unit tests never caught that: they
+     * pass `exception.body` explicitly, which production never does.
      */
     public override fun handleExceptionInternal(
         ex: Exception,
@@ -43,7 +54,48 @@ class GenericExceptionHandler(
         log.debug(ex.message, ex)
 
         val status = HttpStatus.valueOf(statusCode.value())
-        val problemDetail = (body as? ProblemDetail) ?: ProblemDetail.forStatusAndDetail(statusCode, ex.message)
+        val problemDetail = (body as? ProblemDetail)
+            ?: (ex as? ErrorResponse)?.body
+            ?: ProblemDetail.forStatusAndDetail(statusCode, ex.message)
+        problemDetail.title = localizedTitle(status, request)
+
+        return renderResponse(problemDetail, status, request)
+    }
+
+    /**
+     * Without this, an [AccessDeniedException] raised by method security (`@PreAuthorize`) inside a
+     * controller invocation falls through to [handleGenericException] and is answered with a **500**
+     * plus a full ERROR stack trace - a permission problem reported as a server fault, which the SPA
+     * cannot tell the user anything useful about.
+     *
+     * Only *method-security* denials reach here. A denial raised in the filter chain (most commonly
+     * a CSRF-token failure) never reaches an `@ControllerAdvice` at all - it is answered by
+     * `TafelAccessDeniedHandler` instead. That split matters when reading logs: a 403 that appears
+     * *without* the WARN this handler logs did not come from `@PreAuthorize`. See issue #2989.
+     *
+     * A request that isn't authenticated at all never gets this far - `TafelJwtAuthenticationFilter`
+     * already answers it with a 401 - so a denial here always means an authenticated user lacking an
+     * authority, and 403 (rather than deferring to an authentication entry point) is the right answer.
+     */
+    @ExceptionHandler(AccessDeniedException::class)
+    fun handleAccessDeniedException(
+        exception: AccessDeniedException,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        log.warn(
+            "Access denied for user '{}' on {} - resolved authorities: [{}] - {}",
+            authentication?.name ?: "anonymous",
+            request.getDescription(false),
+            authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none",
+            exception.message,
+        )
+
+        val status = HttpStatus.FORBIDDEN
+        // the raw exception message ("Access Denied") is English and says nothing a user can act
+        // on - it stays in the log above, while the response carries the German wording the SPA
+        // already used as its own 403 fallback
+        val problemDetail = ProblemDetail.forStatusAndDetail(status, "Zugriff nicht erlaubt!")
         problemDetail.title = localizedTitle(status, request)
 
         return renderResponse(problemDetail, status, request)

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -15,6 +15,7 @@ import org.springframework.web.ErrorResponse
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
@@ -83,9 +84,13 @@ class GenericExceptionHandler(
         request: WebRequest,
     ): ResponseEntity<Any> {
         val authentication = SecurityContextHolder.getContext().authentication
+        // logged in the same "<METHOD> <uri>" shape as TafelAccessDeniedHandler, so the two denial
+        // paths can be grepped together - getDescription() alone omits the method, which matters
+        // when the same path allows GET but denies POST
         log.warn(
-            "Access denied for user '{}' on {} - resolved authorities: [{}] - {}",
+            "Access denied for user '{}' on {} {} - resolved authorities: [{}] - {}",
             authentication?.name ?: "anonymous",
+            (request as? ServletWebRequest)?.request?.method ?: "?",
             request.getDescription(false),
             authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none",
             exception.message,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -1,6 +1,7 @@
 package at.wrk.tafel.admin.backend.modules.base.exception
 
 import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
+import at.wrk.tafel.admin.backend.common.sanitizeForLog
 import org.slf4j.LoggerFactory
 import org.springframework.context.MessageSource
 import org.springframework.http.HttpHeaders
@@ -89,11 +90,11 @@ class GenericExceptionHandler(
         // when the same path allows GET but denies POST
         log.warn(
             "Access denied for user '{}' on {} {} - resolved authorities: [{}] - {}",
-            authentication?.name ?: "anonymous",
-            (request as? ServletWebRequest)?.request?.method ?: "?",
-            request.getDescription(false),
-            authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none",
-            exception.message,
+            sanitizeForLog(authentication?.name ?: "anonymous"),
+            sanitizeForLog((request as? ServletWebRequest)?.request?.method ?: "?"),
+            sanitizeForLog(request.getDescription(false)),
+            sanitizeForLog(authentication?.authorities?.joinToString(", ") { it.authority ?: "?" } ?: "none"),
+            sanitizeForLog(exception.message),
         )
 
         val status = HttpStatus.FORBIDDEN

--- a/backend/src/main/resources/i18n/messages.properties
+++ b/backend/src/main/resources/i18n/messages.properties
@@ -1,4 +1,5 @@
 http-error.400.title=Ungültige Aktion
+http-error.403.title=Zugriff verweigert
 http-error.404.title=Nicht gefunden
 http-error.409.title=Konflikt
 http-error.422.title=Verarbeitungsfehler

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/LogSanitizerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/LogSanitizerTest.kt
@@ -1,0 +1,25 @@
+package at.wrk.tafel.admin.backend.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LogSanitizerTest {
+
+    @Test
+    fun `strips CR and LF so a value cannot forge a second log line`() {
+        val result = sanitizeForLog("legit-value\r\nWARN fake-forged-line")
+
+        assertThat(result).isEqualTo("legit-value__WARN fake-forged-line")
+        assertThat(result).doesNotContain("\r", "\n")
+    }
+
+    @Test
+    fun `leaves an ordinary value untouched`() {
+        assertThat(sanitizeForLog("/api/food-collections/routes/1/items")).isEqualTo("/api/food-collections/routes/1/items")
+    }
+
+    @Test
+    fun `maps null to a placeholder`() {
+        assertThat(sanitizeForLog(null)).isEqualTo("?")
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandlerTest.kt
@@ -89,6 +89,26 @@ class TafelAccessDeniedHandlerTest {
     }
 
     @Test
+    fun `reports a blank CSRF header as missing`() {
+        every { request.getHeader("X-XSRF-TOKEN") } returns "   "
+        every { request.cookies } returns arrayOf(Cookie("XSRF-TOKEN", "cookie-value"))
+
+        handler.handle(request, response, MissingCsrfTokenException("actual"))
+
+        assertThat(loggedMessage()).contains("X-XSRF-TOKEN header missing")
+    }
+
+    @Test
+    fun `reports the CSRF cookie as missing when only an unrelated cookie or a blank value is present`() {
+        every { request.getHeader("X-XSRF-TOKEN") } returns "some-token"
+        every { request.cookies } returns arrayOf(Cookie("unrelated-cookie", "value"), Cookie("XSRF-TOKEN", ""))
+
+        handler.handle(request, response, MissingCsrfTokenException("actual"))
+
+        assertThat(loggedMessage()).contains("XSRF-TOKEN cookie missing")
+    }
+
+    @Test
     fun `logs principal and authorities for a non-CSRF denial`() {
         SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
             "some-user",

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelAccessDeniedHandlerTest.kt
@@ -1,0 +1,118 @@
+package at.wrk.tafel.admin.backend.common.auth.components
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.slf4j.LoggerFactory
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.csrf.DefaultCsrfToken
+import org.springframework.security.web.csrf.InvalidCsrfTokenException
+import org.springframework.security.web.csrf.MissingCsrfTokenException
+
+@ExtendWith(MockKExtension::class)
+class TafelAccessDeniedHandlerTest {
+
+    @RelaxedMockK
+    private lateinit var request: HttpServletRequest
+
+    @RelaxedMockK
+    private lateinit var response: HttpServletResponse
+
+    private lateinit var logAppender: ListAppender<ILoggingEvent>
+    private lateinit var logger: Logger
+
+    private val handler = TafelAccessDeniedHandler()
+
+    @BeforeEach
+    fun beforeEach() {
+        logger = LoggerFactory.getLogger(TafelAccessDeniedHandler::class.java) as Logger
+        logAppender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(logAppender)
+
+        every { request.dispatcherType } returns DispatcherType.REQUEST
+        every { request.method } returns "POST"
+        every { request.requestURI } returns "/api/food-collections/routes/4/items"
+        every { response.isCommitted } returns false
+    }
+
+    @AfterEach
+    fun afterEach() {
+        logger.detachAppender(logAppender)
+        logger.level = null
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun loggedMessage() = logAppender.list.single().formattedMessage
+
+    @Test
+    fun `logs the denial cause and the CSRF token state on a missing header`() {
+        every { request.getHeader("X-XSRF-TOKEN") } returns null
+        every { request.cookies } returns arrayOf(Cookie("XSRF-TOKEN", "cookie-value"))
+
+        handler.handle(request, response, InvalidCsrfTokenException(DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "expected"), "actual"))
+
+        assertThat(logAppender.list.single().level).isEqualTo(Level.WARN)
+        assertThat(loggedMessage())
+            .contains("InvalidCsrfTokenException")
+            .contains("not an authorization failure")
+            .contains("X-XSRF-TOKEN header missing")
+            .contains("XSRF-TOKEN cookie present")
+    }
+
+    @Test
+    fun `reports a missing CSRF cookie as missing`() {
+        every { request.getHeader("X-XSRF-TOKEN") } returns "some-token"
+        every { request.cookies } returns null
+
+        handler.handle(request, response, MissingCsrfTokenException("actual"))
+
+        assertThat(loggedMessage())
+            .contains("MissingCsrfTokenException")
+            .contains("X-XSRF-TOKEN header present")
+            .contains("XSRF-TOKEN cookie missing")
+    }
+
+    @Test
+    fun `logs principal and authorities for a non-CSRF denial`() {
+        SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
+            "some-user",
+            null,
+            listOf(SimpleGrantedAuthority("LOGISTICS")),
+        )
+
+        handler.handle(request, response, AccessDeniedException("Access Denied"))
+
+        assertThat(loggedMessage())
+            .contains("some-user")
+            .contains("LOGISTICS")
+            .contains("AccessDeniedException: Access Denied")
+            .doesNotContain("not an authorization failure")
+    }
+
+    @Test
+    fun `logs an ASYNC dispatch denial at debug without writing a response`() {
+        logger.level = Level.DEBUG
+        every { request.dispatcherType } returns DispatcherType.ASYNC
+
+        handler.handle(request, response, AccessDeniedException("Access Denied"))
+
+        assertThat(logAppender.list.single().level).isEqualTo(Level.DEBUG)
+        assertThat(loggedMessage()).contains("ASYNC dispatch")
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -14,11 +14,15 @@ import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.authorization.AuthorizationDeniedException
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.WebRequest
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import tools.jackson.databind.json.JsonMapper
 import java.util.*
@@ -156,6 +160,40 @@ internal class GenericExceptionHandlerTest {
         assertThat(errorBody.status).isEqualTo(HttpStatus.FORBIDDEN.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
         assertThat(errorBody.detail).isEqualTo("Zugriff nicht erlaubt!")
+    }
+
+    @Test
+    fun `handles AccessDeniedException for an authenticated user with resolved authorities`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        every { request.request.method } returns "POST"
+        SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
+            "some-user",
+            null,
+            listOf(SimpleGrantedAuthority("LOGISTICS")),
+        )
+
+        try {
+            val response = exceptionHandler.handleAccessDeniedException(AuthorizationDeniedException("Access Denied"), request)
+
+            assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        } finally {
+            SecurityContextHolder.clearContext()
+        }
+    }
+
+    @Test
+    fun `handles AccessDeniedException for a non-servlet WebRequest`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val plainWebRequest = mockk<WebRequest>(relaxed = true)
+        every { plainWebRequest.locale } returns Locale.GERMAN
+
+        val response = exceptionHandler.handleAccessDeniedException(AuthorizationDeniedException("Access Denied"), plainWebRequest)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
     }
 
     @Test

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -14,6 +14,7 @@ import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -43,6 +44,14 @@ internal class GenericExceptionHandlerTest {
         every { request.locale } returns Locale.GERMAN
     }
 
+    /**
+     * Every one of these passes `body = null`, because that is what Spring actually does: the
+     * inherited `handleErrorResponseException` calls `handleExceptionInternal(ex, null, ...)` and
+     * expects the body to be taken from the exception's own [ErrorResponse.getBody]. Passing
+     * `exception.body` here instead (as these tests used to) exercises a call shape production
+     * never produces, and hid that every [TafelApiException] rendered its detail as the exception's
+     * `toString()` - `"404 NOT_FOUND, ProblemDetail[type='null', title='Not Found', ...]"`.
+     */
     @Test
     fun `handles NotFoundException properly`() {
         every {
@@ -50,7 +59,7 @@ internal class GenericExceptionHandlerTest {
         } returns "localized-title"
         val exception = NotFoundException("notfound-msg")
 
-        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         val errorBody = response.body as ProblemDetail
@@ -66,7 +75,7 @@ internal class GenericExceptionHandlerTest {
         } returns "localized-title"
         val exception = ConflictException("conflict-msg")
 
-        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
         val errorBody = response.body as ProblemDetail
@@ -82,7 +91,7 @@ internal class GenericExceptionHandlerTest {
         } returns "localized-title"
         val exception = BusinessRuleException("businessrule-msg")
 
-        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         val errorBody = response.body as ProblemDetail
@@ -98,13 +107,55 @@ internal class GenericExceptionHandlerTest {
         } returns "localized-title"
         val exception = BusinessRuleException("businessrule-msg", status = HttpStatus.UNPROCESSABLE_CONTENT)
 
-        val response = exceptionHandler.handleExceptionInternal(exception, exception.body, HttpHeaders.EMPTY, exception.statusCode, request)
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT)
         val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
         assertThat(errorBody.detail).isEqualTo("businessrule-msg")
+    }
+
+    @Test
+    fun `an explicitly passed body still wins over the exception's own`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val exception = BusinessRuleException("businessrule-msg")
+        val explicitBody = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "explicit-detail")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, explicitBody, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.detail).isEqualTo("explicit-detail")
+    }
+
+    @Test
+    fun `falls back to the exception message when it carries no problem detail`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+        val exception = IllegalStateException("plain-exception-msg")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request)
+
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.detail).isEqualTo("plain-exception-msg")
+    }
+
+    @Test
+    fun `handles AccessDeniedException with 403 instead of falling through to 500`() {
+        every {
+            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
+        } returns "localized-title"
+
+        val response = exceptionHandler.handleAccessDeniedException(AuthorizationDeniedException("Access Denied"), request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.status).isEqualTo(HttpStatus.FORBIDDEN.value())
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("Zugriff nicht erlaubt!")
     }
 
     @Test

--- a/frontend/src/main/webapp/cypress/e2e/general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/general.cy.ts
@@ -46,6 +46,43 @@ describe('General', () => {
 
 });
 
+describe('API error responses', () => {
+
+  // Both cases below answer 403, but only one of them is a permission problem. Telling them apart
+  // from the response alone is what issue #2989 lacked: a batch of production 403s on
+  // LOGISTICS-gated endpoints looked like an authorized session losing its authority, when a
+  // permission denial could not have produced them at all.
+  it('answers a permission denial with a german problem detail', () => {
+    // e2etest2 only holds CUSTOMER, so the SETTINGS-gated car list is denied by @PreAuthorize
+    cy.loginE2ETest2();
+
+    cy.request({method: 'GET', url: '/api/cars', failOnStatusCode: false}).then((response) => {
+      expect(response.status).to.eq(403);
+      expect(response.body.title).to.eq('Zugriff verweigert');
+      expect(response.body.detail).to.eq('Zugriff nicht erlaubt!');
+    });
+  });
+
+  it('answers a CSRF-token failure with a 403 that carries no problem detail', () => {
+    // the default user does hold SETTINGS - this 403 is purely about the mismatching CSRF token,
+    // rejected by CsrfFilter before any controller (and therefore any @PreAuthorize) runs
+    cy.loginDefault();
+
+    cy.request({
+      method: 'POST',
+      url: '/api/cars',
+      headers: {'X-XSRF-TOKEN': 'not-the-cookie-value'},
+      body: {licensePlate: 'W-12345TA', name: 'CSRF test', enabled: true},
+      failOnStatusCode: false
+    }).then((response) => {
+      expect(response.status).to.eq(403);
+      expect(response.body).to.not.have.property('detail');
+      expect(response.body.error).to.eq('Forbidden');
+    });
+  });
+
+});
+
 describe('Navigation Progress Bar', () => {
 
   it('shows a top-level loading bar while a resolver-gated page is loading, and hides it once loaded', () => {

--- a/frontend/src/main/webapp/src/app/common/api/problem-detail.ts
+++ b/frontend/src/main/webapp/src/app/common/api/problem-detail.ts
@@ -22,6 +22,12 @@ const GENERIC_FALLBACK_MESSAGE = 'Es ist ein unerwarteter Fehler aufgetreten.';
  * like 403/423) and statuses that never reach the backend at all - `0` (no connection: offline,
  * DNS failure, CORS rejection) and `502`/`503`/`504` (reverse proxy / gateway responses emitted
  * when the backend process itself is unreachable, not something any controller ever sends).
+ *
+ * 403 stays listed even though a `@PreAuthorize` denial *does* now come back as a proper
+ * `ProblemDetail` (with the same "Zugriff nicht erlaubt!" wording): a CSRF-token failure is
+ * rejected by `CsrfFilter` before any controller runs and still arrives as a bare
+ * `{timestamp, status, error, message, path}` error body, which `isProblemDetail` accepts but
+ * whose `detail` is undefined - so the override below is what that case falls back to.
  */
 const STATUS_MESSAGE_OVERRIDES: Partial<Record<number, string>> = {
   0: 'Keine Verbindung zum Server!',


### PR DESCRIPTION
## Summary

Closes #2989.

### The finding

The production 403s in #2989 were **not** authorization failures — an already-LOGISTICS-authorized session did not lose its authority. Verified against current `main`:

| denial | status today | response body |
|---|---|---|
| `@PreAuthorize("hasAuthority('LOGISTICS')")` denied | **500** + ERROR stack trace | `ProblemDetail` |
| CSRF-token failure (`CsrfFilter`) | **403** | `{"timestamp",…,"error":"Forbidden","message":…,"path":…}` |

Three things line up with the CSRF path and rule out `@PreAuthorize`:

1. A method-security denial **cannot** currently produce a 403 — it produces a 500. The issue notes no WARN/ERROR was logged for those requests, which a 500 always emits.
2. The access-log body sizes (`403 151` / `403 145`) differ by exactly 6 bytes — the length difference between `/route/4/items` and `/route/4`. That's a body containing the request path exactly **once**, matching the filter-level error body above. This app's `ProblemDetail` responses are ~100 bytes larger.
3. Only mutating requests failed; `CsrfFilter` guards nothing else. At the time of that log the SPA had **no** retry on a CSRF 403 — `xsrfInterceptor`'s retry landed three days later in c21308e1 (#2967).

### Why nobody could tell from the logs — and what changed

`TafelAccessDeniedHandler` logged the principal and resolved authorities but never the denial's *cause*. `CsrfFilter` runs **before** `TafelJwtAuthenticationFilter`, so on a CSRF denial the security context is still empty and the handler reported a fully authorized user as `anonymous` / `[none]` — a log line that reads exactly like an authorization problem. Now:

```
WARN TafelAccessDeniedHandler : Access denied for user 'anonymous' on POST /api/food-collections/routes/1/items
  - resolved authorities: [none] - InvalidCsrfTokenException (CSRF, not an authorization failure -
  principal/authorities above are empty because CsrfFilter runs before authentication):
  X-XSRF-TOKEN header missing, XSRF-TOKEN cookie present
```

And a real method-security denial is now a 403 rather than a 500, with the principal and authorities that were actually resolved:

```
WARN GenericExceptionHandler : Access denied for user 'e2etest2' on uri=/api/food-collections/routes/1/items
  - resolved authorities: [CUSTOMER] - Access Denied
```

```json
{"detail":"Zugriff nicht erlaubt!","instance":"/api/cars","status":403,"title":"Zugriff verweigert"}
```

### Changes

- `GenericExceptionHandler`: new `@ExceptionHandler(AccessDeniedException)` → 403 problem detail + WARN, instead of falling into the catch-all 500 handler.
- `messages.properties`: add the missing `http-error.403.title`.
- `TafelAccessDeniedHandler`: log the denial's exception type, and for CSRF the header/cookie state; drop `@ExcludeFromTestCoverage` and cover it with tests.
- `problem-detail.ts`: note why 403 keeps its status-message override even though `@PreAuthorize` denials now carry a real `detail` (a CSRF 403 still doesn't).

### Also fixed inline

Every `TafelApiException` rendered its detail as the exception's `toString()` — `NotFoundException("Kunde Nr. 99999999 nicht gefunden!")` came back as `"404 NOT_FOUND, ProblemDetail[type='null', title='Not Found', status=404, …]"`, which is what the SPA showed the user. Production always passes a null `body` into `handleExceptionInternal` and expects the exception's own `ErrorResponse.getBody()`; the existing tests passed `exception.body` explicitly, a call shape Spring never produces, and so never caught it. Not optional here — the new 403 response goes through the same method.

### Filed separately

#3008 — Spring's own built-in MVC exceptions leak raw message codes (`problemDetail.org.springframework.http.converter.HttpMessageNotReadableException`) as the user-facing `detail`. Different set of responses, left out on purpose.

### Not changed

No user-guide update: the toast wording a user sees for a denial is unchanged — `Zugriff nicht erlaubt!` was already the SPA's own 403 fallback text, and the backend now sends that same string.

## Test plan
- [x] `./gradlew :backend:test` / `:backend:ktlintCheck`
- [x] `npm run lint` / `typecheck` / `test-ci` (736 tests)
- [x] Cypress `general.cy.ts` (2 new cases asserting the two 403 shapes are distinguishable), plus `food-collection-recording.cy.ts`, `settings-cars.cy.ts`, `login.cy.ts` against a real `e2e`-profile backend
- [x] Manually reproduced every denial path with curl against a running backend, before and after
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)