### PR TITLE
test(security): cover TafelJwtAuthenticationFilter, drop stale coverage exclusions

### DIFF
--- a/.claude/skills/process-issue/SKILL.md
+++ b/.claude/skills/process-issue/SKILL.md
@@ -55,27 +55,32 @@ unambiguous, so the slug itself just needs to be recognizable, not exhaustive:
 git checkout -b fix/async-request-not-usable-log-noise-2986
 ```
 
-## 4. Build a plan, then implement on Sonnet
+## 4. Build a plan on Opus, then implement on Sonnet
 
-Before writing code, read the relevant module(s) — including any files the issue's comments point
-at — and work out a concrete implementation approach: which files change, what the fix/feature
-actually is, and any real usages/impact you found while investigating (e.g. an audit-style issue
-touching many files should identify which usages are genuinely fine vs. which need a change, not
-just restate the ticket). Since this workflow is fully automated end-to-end (see the top of this
-file), present the plan as a short message rather than blocking on `EnterPlanMode`/`ExitPlanMode`
-(that flow requires live user approval and would stall a background/unattended run) — unless the
-session is already interactively in plan mode for other reasons.
+Do the investigation and planning itself on the Opus model — switch to it first if the session
+isn't already running on Opus. Read the relevant module(s), including any files the issue's
+comments point at, and work out a concrete implementation approach: which files change, what the
+fix/feature actually is, and any real usages/impact you found while investigating (e.g. an
+audit-style issue touching many files should identify which usages are genuinely fine vs. which
+need a change, not just restate the ticket) — this is exactly the kind of judgment call that
+benefits from the stronger model. Since this workflow is fully automated end-to-end (see the top of
+this file), present the plan as a short message rather than blocking on
+`EnterPlanMode`/`ExitPlanMode` (that flow requires live user approval and would stall a
+background/unattended run) — unless the session is already interactively in plan mode for other
+reasons.
 
-Once the plan is settled, do the implementation itself on the Sonnet model specifically (not
-Opus/other), regardless of which model did the planning above — planning benefits from a stronger
-model's judgment on approach/tradeoffs, but the mechanical work of writing the change, tests, and
-fixing lint/type errors doesn't need it, and Sonnet is the cheaper/faster choice for that phase. If
-the current session is already running on Sonnet, just continue in place — there's no separate
-"switch" action available in this harness, so don't spawn a redundant subagent purely to relabel
-who's already doing the work. If the session is running on a different model, delegate the
-implementation (steps below through the hand-off) to a subagent via the `Agent` tool with
-`model: "sonnet"`, giving it the plan, the issue context, and everything from step 1-3 above so it
-doesn't have to re-derive it.
+Once the plan is settled, do the implementation itself on the Sonnet model specifically — switch to
+it if not already there, regardless of which model did the planning above. The mechanical work of
+writing the change, tests, and fixing lint/type errors doesn't need Opus, and Sonnet is the
+cheaper/faster choice for that phase. If the current session is already running on Sonnet, just
+continue in place — there's no separate "switch" action available in this harness, so don't spawn a
+redundant subagent purely to relabel who's already doing the work. If the session is running on a
+different model, delegate the implementation (steps below through the hand-off) to a subagent via
+the `Agent` tool with `model: "sonnet"`, giving it the plan, the issue context, and everything from
+step 1-3 above so it doesn't have to re-derive it. The same logic applies in reverse for the
+planning phase above: if the session isn't already on Opus, delegate the investigation/planning to
+a subagent via the `Agent` tool with `model: "opus"` before handing its plan to the Sonnet
+implementation phase.
 
 ## 5. Implement
 

--- a/.claude/skills/process-issue/SKILL.md
+++ b/.claude/skills/process-issue/SKILL.md
@@ -55,7 +55,29 @@ unambiguous, so the slug itself just needs to be recognizable, not exhaustive:
 git checkout -b fix/async-request-not-usable-log-noise-2986
 ```
 
-## 4. Implement
+## 4. Build a plan, then implement on Sonnet
+
+Before writing code, read the relevant module(s) — including any files the issue's comments point
+at — and work out a concrete implementation approach: which files change, what the fix/feature
+actually is, and any real usages/impact you found while investigating (e.g. an audit-style issue
+touching many files should identify which usages are genuinely fine vs. which need a change, not
+just restate the ticket). Since this workflow is fully automated end-to-end (see the top of this
+file), present the plan as a short message rather than blocking on `EnterPlanMode`/`ExitPlanMode`
+(that flow requires live user approval and would stall a background/unattended run) — unless the
+session is already interactively in plan mode for other reasons.
+
+Once the plan is settled, do the implementation itself on the Sonnet model specifically (not
+Opus/other), regardless of which model did the planning above — planning benefits from a stronger
+model's judgment on approach/tradeoffs, but the mechanical work of writing the change, tests, and
+fixing lint/type errors doesn't need it, and Sonnet is the cheaper/faster choice for that phase. If
+the current session is already running on Sonnet, just continue in place — there's no separate
+"switch" action available in this harness, so don't spawn a redundant subagent purely to relabel
+who's already doing the work. If the session is running on a different model, delegate the
+implementation (steps below through the hand-off) to a subagent via the `Agent` tool with
+`model: "sonnet"`, giving it the plan, the issue context, and everything from step 1-3 above so it
+doesn't have to re-derive it.
+
+## 5. Implement
 
 Follow this repo's conventions (module boundaries, DTO `Request`/`Response`/`Item`
 suffix rules, Angular signal-based patterns, `@if`/`@for` flow-control syntax, etc.) — read the
@@ -70,7 +92,7 @@ relevant module's existing code before writing new code, don't guess at patterns
   directly related to the code you're touching; otherwise `gh issue create` a separate ticket and
   mention it to the user — don't silently expand this PR's scope.
 
-## 5. Test locally before pushing
+## 6. Test locally before pushing
 
 Run the same checks CI will run, so red checks are rare rather than routine:
 
@@ -85,13 +107,13 @@ and `npm run build-prod`. If the change touches any flow covered by Cypress, ver
 using the `fix-e2e` skill's workflow (it owns the backend-restart-with-`e2e`-profile ritual) rather
 than re-deriving that setup here.
 
-## 6. Commit
+## 7. Commit
 
 Conventional Commits subject, matching the format exactly (lowercase
 description, no trailing period, ≤100 char header, valid `type`) — this is enforced by a commit-msg
 hook, `commitlint`, and `pr-title-lint` in CI, and has been the recurring miss in this repo.
 
-## 7. Push and open the PR
+## 8. Push and open the PR
 
 ```bash
 git push -u origin <branch>
@@ -117,7 +139,7 @@ The PR title itself must pass `pr-title-lint` (same Conventional Commits rule as
 repo squash-merges with the PR title becoming the final commit). The `Closes
 #<issue-number>` line is what auto-closes the issue once the squash commit lands on `main`.
 
-## 8. Hand off to process-pr
+## 9. Hand off to process-pr
 
 Invoke the `process-pr` skill for the PR just opened (Skill tool, skill: `process-pr`, args:
 `<owner>/<repo> <pr-number>`) — it re-reads the diff as a self-review pass, fixes anything it finds,

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/ExcludeFromTestcoverage.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/ExcludeFromTestcoverage.kt
@@ -2,7 +2,18 @@ package at.wrk.tafel.admin.backend.common
 
 /**
  * To exclude some things (like generated getters in data classes)
- * from jacoco test coverage
+ * from jacoco test coverage.
+ *
+ * Still the right tool as of jacoco 0.8.14/Kotlin 2.x (re-verified for issue #3010): jacoco has
+ * built-in support for skipping any class/method annotated with a type whose simple name matches
+ * `*Generated` (since 0.8.2, retention must be CLASS or RUNTIME) - which is why this type is
+ * physically named `NoCoverageGenerated`. There is no equivalent *automatic* filter for
+ * Kotlin-compiler-generated data class members (`equals`/`hashCode`/`toString`/`copy`/`componentN`);
+ * Kotlin's own tracking issue for that (KT-10608) is still open, and jacoco 0.8.13's Kotlin
+ * improvements only cover constructors/`@JvmOverloads`, not data classes. So this annotation-based
+ * workaround remains necessary - apply it to genuinely logic-free code (data classes, plain enums,
+ * field-only JPA entities, thin exceptions, Spring `@Configuration` bean-wiring), not to classes
+ * that contain real, testable behavior.
  */
 @Retention(AnnotationRetention.BINARY)
 @Suppress("MatchingDeclarationName") // class itself needs to be named *Generated to be handled by jacoco

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/ExcludeFromTestcoverage.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/ExcludeFromTestcoverage.kt
@@ -4,16 +4,21 @@ package at.wrk.tafel.admin.backend.common
  * To exclude some things (like generated getters in data classes)
  * from jacoco test coverage.
  *
- * Still the right tool as of jacoco 0.8.14/Kotlin 2.x (re-verified for issue #3010): jacoco has
- * built-in support for skipping any class/method annotated with a type whose simple name matches
- * `*Generated` (since 0.8.2, retention must be CLASS or RUNTIME) - which is why this type is
- * physically named `NoCoverageGenerated`. There is no equivalent *automatic* filter for
- * Kotlin-compiler-generated data class members (`equals`/`hashCode`/`toString`/`copy`/`componentN`);
- * Kotlin's own tracking issue for that (KT-10608) is still open, and jacoco 0.8.13's Kotlin
- * improvements only cover constructors/`@JvmOverloads`, not data classes. So this annotation-based
- * workaround remains necessary - apply it to genuinely logic-free code (data classes, plain enums,
- * field-only JPA entities, thin exceptions, Spring `@Configuration` bean-wiring), not to classes
- * that contain real, testable behavior.
+ * Re-verified for issue #3010, including an empirical check against this repo's own build (removed
+ * this annotation from a two-property data class, ran `:backend:test`, and inspected the resulting
+ * `jacocoTestReport` HTML): jacoco's own `KotlinGeneratedFilter` already recognizes Kotlin classes
+ * via `@kotlin.Metadata` and drops `equals`/`hashCode`/`toString`/`copy`/`componentN` from the
+ * report entirely on its own (this is what KT-18383 resolved - JetBrains declined to add a
+ * `@kotlin.Generated` runtime annotation, jetbrains/kotlin#1655, and jacoco instead added native
+ * detection instead, jacoco/jacoco#552 and #689) - so this annotation is no longer what protects
+ * those members. What jacoco does *not* filter on its own is the plain property getters/setters
+ * themselves (they retain line-number debug info, so they stay in the report) - those show up as
+ * "missed" whenever a DTO's properties are only ever exercised through the generated `equals()` (as
+ * most unit tests do via e.g. AssertJ's `isEqualTo`) rather than actually invoked through real
+ * Jackson (de)serialization or explicit property access. That's the annotation's actual remaining
+ * job: apply it to genuinely logic-free code (data classes, plain enums, field-only JPA entities,
+ * thin exceptions, Spring `@Configuration` bean-wiring) to keep their boilerplate getters/setters
+ * from diluting coverage metrics - not to classes that contain real, testable behavior.
  */
 @Retention(AnnotationRetention.BINARY)
 @Suppress("MatchingDeclarationName") // class itself needs to be named *Generated to be handled by jacoco

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthenticationFilter.kt
@@ -1,6 +1,5 @@
 package at.wrk.tafel.admin.backend.common.auth.components
 
-import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -12,14 +11,13 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 import org.springframework.security.web.util.matcher.RequestMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 
-@ExcludeFromTestCoverage
 class TafelJwtAuthenticationFilter(
     private val authenticationManager: AuthenticationManager,
     private val authenticationConverter: AuthenticationConverter,
     private val requestMatcher: RequestMatcher,
 ) : OncePerRequestFilter() {
 
-    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
+    public override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
         if (!requestMatcher.matches(request)) {
             filterChain.doFilter(request, response)
             return

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelLoginFilter.kt
@@ -1,6 +1,5 @@
 package at.wrk.tafel.admin.backend.common.auth.components
 
-import at.wrk.tafel.admin.backend.common.ExcludeFromTestCoverage
 import at.wrk.tafel.admin.backend.common.auth.model.LoginResponse
 import at.wrk.tafel.admin.backend.common.auth.model.TafelUser
 import at.wrk.tafel.admin.backend.config.properties.ApplicationProperties
@@ -21,7 +20,6 @@ import org.springframework.util.MimeTypeUtils
 import tools.jackson.databind.json.JsonMapper
 import java.nio.charset.Charset
 
-@ExcludeFromTestCoverage
 class TafelLoginFilter(
     authenticationManager: AuthenticationManager,
     private val jwtTokenService: JwtTokenService,

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthenticationFilterTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/common/auth/components/TafelJwtAuthenticationFilterTest.kt
@@ -1,0 +1,105 @@
+package at.wrk.tafel.admin.backend.common.auth.components
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.AuthenticationConverter
+import org.springframework.security.web.util.matcher.RequestMatcher
+
+@ExtendWith(MockKExtension::class)
+class TafelJwtAuthenticationFilterTest {
+
+    @RelaxedMockK
+    private lateinit var request: HttpServletRequest
+
+    @RelaxedMockK
+    private lateinit var response: HttpServletResponse
+
+    @RelaxedMockK
+    private lateinit var filterChain: FilterChain
+
+    @RelaxedMockK
+    private lateinit var authenticationManager: AuthenticationManager
+
+    @RelaxedMockK
+    private lateinit var authenticationConverter: AuthenticationConverter
+
+    @RelaxedMockK
+    private lateinit var requestMatcher: RequestMatcher
+
+    @InjectMockKs
+    private lateinit var filter: TafelJwtAuthenticationFilter
+
+    @AfterEach
+    fun afterEach() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `doFilterInternal skips authentication and continues the chain when the request matcher does not match`() {
+        every { requestMatcher.matches(request) } returns false
+
+        filter.doFilterInternal(request, response, filterChain)
+
+        verify(exactly = 1) { filterChain.doFilter(request, response) }
+        verify(exactly = 0) { authenticationConverter.convert(any()) }
+        verify(exactly = 0) { authenticationManager.authenticate(any()) }
+    }
+
+    @Test
+    fun `doFilterInternal authenticates and continues the chain when credentials are valid`() {
+        val authRequest = UsernamePasswordAuthenticationToken.unauthenticated("some-user", "credentials")
+        val authResult: Authentication = UsernamePasswordAuthenticationToken.authenticated("some-user", null, emptyList())
+
+        every { requestMatcher.matches(request) } returns true
+        every { authenticationConverter.convert(request) } returns authRequest
+        every { authenticationManager.authenticate(authRequest) } returns authResult
+
+        filter.doFilterInternal(request, response, filterChain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isSameAs(authResult)
+        verify(exactly = 1) { filterChain.doFilter(request, response) }
+        verify(exactly = 0) { response.sendError(any()) }
+    }
+
+    @Test
+    fun `doFilterInternal clears the context and sends 401 when the converter finds no credentials`() {
+        every { requestMatcher.matches(request) } returns true
+        every { authenticationConverter.convert(request) } returns null
+
+        filter.doFilterInternal(request, response, filterChain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        verify(exactly = 1) { response.sendError(HttpServletResponse.SC_UNAUTHORIZED) }
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
+    }
+
+    @Test
+    fun `doFilterInternal clears the context and sends 401 when authentication fails`() {
+        val authRequest = UsernamePasswordAuthenticationToken.unauthenticated("some-user", "wrong-credentials")
+
+        every { requestMatcher.matches(request) } returns true
+        every { authenticationConverter.convert(request) } returns authRequest
+        every { authenticationManager.authenticate(authRequest) } throws BadCredentialsException("bad credentials")
+
+        filter.doFilterInternal(request, response, filterChain)
+
+        assertThat(SecurityContextHolder.getContext().authentication).isNull()
+        verify(exactly = 1) { response.sendError(HttpServletResponse.SC_UNAUTHORIZED) }
+        verify(exactly = 0) { filterChain.doFilter(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
Audited all 82 `@ExcludeFromTestCoverage` usages per #3010:

- **Is the annotation itself obsolete?** Partly superseded, but still needed for a narrower reason.
  jacoco's built-in `KotlinGeneratedFilter` already recognizes Kotlin classes via `@kotlin.Metadata`
  and drops `equals`/`hashCode`/`toString`/`copy`/`componentN` from coverage reports on its own - this
  is what [KT-18383](https://youtrack.jetbrains.com/issue/KT-18383) actually resolved (JetBrains
  declined to add a `@kotlin.Generated` runtime annotation,
  [jetbrains/kotlin#1655](https://github.com/JetBrains/kotlin/pull/1655); jacoco added native
  detection instead, jacoco/jacoco#552 and #689). Verified this empirically against this repo's own
  build: temporarily removed the annotation from a two-property data class, ran `:backend:test`, and
  inspected the generated `jacocoTestReport` HTML - only the constructor and the two plain getters
  showed up in the per-method table; the generated members were absent entirely, exactly as jacoco's
  filter predicts. What jacoco does **not** filter is the plain property getters/setters themselves
  (they keep line-number debug info), which show as "missed" whenever a DTO is only ever exercised
  through the generated `equals()` (as most unit tests do, e.g. via AssertJ's `isEqualTo`) rather than
  actually invoked via real Jackson (de)serialization or explicit property access - that's the
  annotation's actual remaining job. Corrected the doc comment on `ExcludeFromTestcoverage.kt` to
  reflect this rather than the earlier (wrong) claim that no automatic filter exists at all.
- **Are the usages reasonable?** The large majority (~85 annotation sites: plain `data class` DTOs,
  enums, field-only JPA entities, thin exceptions, Spring `@Configuration` bean-wiring classes) are
  legitimate no-logic boilerplate and were left untouched.
- **Two were not reasonable:**
  - `TafelJwtAuthenticationFilter` was annotated but contains real, previously-untested auth-gating
    logic (request-matcher short-circuit, converter/manager delegation, `SecurityContextHolder`
    population/clearing, 401-on-failure) with no existing test file. Added
    `TafelJwtAuthenticationFilterTest` (MockK, matching the existing
    `TafelJwtAuthConverterTest`/`TafelLoginFilterTest` style) and removed the annotation.
  - `TafelLoginFilter` was annotated but already has full coverage via the existing
    `TafelLoginFilterTest` — the annotation was stale and actively hiding accurate coverage. Removed it.

Also updates the `process-issue` skill to explicitly build a plan (on Opus) before implementing, and
to run the implementation phase on the Sonnet model (per user request during this run).

Closes #3010

## Test plan
- [x] `./gradlew :backend:test`
- [x] `./gradlew :backend:ktlintCheck`
- [x] Manual: removed the annotation from `VersionResponse` temporarily, ran the test, inspected
      `jacocoTestReport` HTML output, reverted
- [ ] CI

🤖 Generated with Claude Code