### PR TITLE
fix(api): never render a raw message code as the user-facing error detail

### DIFF
--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/MessageConfig.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/config/MessageConfig.kt
@@ -8,12 +8,26 @@ import org.springframework.context.support.ReloadableResourceBundleMessageSource
 @Configuration
 class MessageConfig {
 
+    /**
+     * `useCodeAsDefaultMessage` is deliberately left at its `false` default: with it enabled, an
+     * unresolved code is returned *as the message*, and Spring's own error handling probes a whole
+     * family of optional codes it fully expects to be absent - `ErrorResponse.updateAndGetBody()`
+     * and `ResponseEntityExceptionHandler.createProblemDetail()` look up
+     * `problemDetail[.type|.title].<exception class>` with a `null` default and only apply the
+     * result when one is actually configured. Enabling the flag turned every one of those misses
+     * into a hit, so the raw code ended up in the response body a user sees
+     * (`"detail": "problemDetail.org.springframework.http.converter.HttpMessageNotReadableException"`,
+     * plus the same string as the problem `type` URI) - see issue #3008.
+     *
+     * The flip side is that a missing key now yields `null`/`NoSuchMessageException` instead of the
+     * key itself, so every lookup needs an explicit fallback; `GenericExceptionHandler` is the only
+     * consumer of this bean and handles that in its `localizedMessage`.
+     */
     @Bean
     fun messageSource(): MessageSource {
         val messageSource = ReloadableResourceBundleMessageSource()
         messageSource.setBasename("classpath:/i18n/messages")
         messageSource.setDefaultEncoding("UTF-8")
-        messageSource.setUseCodeAsDefaultMessage(true)
         return messageSource
     }
 }

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/README.md
@@ -73,8 +73,21 @@ Entities backing this module are **not** colocated with it: they live under `dat
   three types above) and Spring's own `ErrorResponse`-producing exceptions (e.g.
   `MethodArgumentNotValidException`) into a `ProblemDetail` response.
   - `handleExceptionInternal` is the shared hook all of those funnel through: it localizes the
-    `ProblemDetail`'s `title` (`http-error.<status>.title` message key looked up via `MessageSource`)
-    and logs at `debug` (expected/user-facing failures shouldn't spam the log).
+    `ProblemDetail`'s `title` and `detail` (`http-error.<status>.title`/`.detail` message keys in
+    `i18n/messages.properties`, looked up via `MessageSource`, falling back to `http-error.default.*`
+    for a status with no entry of its own) and logs at `debug` (expected/user-facing failures
+    shouldn't spam the log).
+  - **Only a `detail` this application authored itself survives** — the message a `TafelApiException`
+    was thrown with, and `handleMethodArgumentNotValid`'s own wording. Everything else reaching that
+    hook is one of Spring's built-in MVC exceptions, whose `detail` is English framework-internals
+    text ("Failed to read request"), so it is replaced with the generic German sentence for the
+    status. That matters because the frontend puts `detail` straight into an error toast
+    (`extractErrorMessage()` in `common/api/problem-detail.ts`). Same reason `handleGenericException`
+    never puts the raw exception message in the body — it only logs it.
+    - Related trap, see issue #3008: `MessageConfig` must **not** enable
+      `useCodeAsDefaultMessage`. Spring probes a family of optional `problemDetail.<exception class>`
+      codes it expects to be missing, and that flag turns every miss into a hit, so the raw message
+      code is what ends up in `detail` (and as the problem `type` URI).
   - `handleMethodArgumentNotValid` additionally attaches a structured `errors: [{field, message}]`
     extension property to the `ProblemDetail`, instead of joining field errors into one string.
   - Anything else (`Exception`) is caught by a dedicated `@ExceptionHandler`, logged at `error`, and

--- a/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
+++ b/backend/src/main/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandler.kt
@@ -30,21 +30,28 @@ class GenericExceptionHandler(
 
     companion object {
         private val log = LoggerFactory.getLogger(GenericExceptionHandler::class.java)
+
+        private val NO_MESSAGE_ARGS = arrayOf<Any>()
+        private const val DEFAULT_TITLE_CODE = "http-error.default.title"
+        private const val DEFAULT_DETAIL_CODE = "http-error.default.detail"
+        private const val LAST_RESORT_TITLE = "Fehler"
+        private const val LAST_RESORT_DETAIL = "Es ist ein unerwarteter Fehler aufgetreten."
     }
 
     /**
      * Central hook every default handler in [ResponseEntityExceptionHandler] funnels through
      * (bean-validation failures via [handleMethodArgumentNotValid], and [TafelApiException] and its
      * subclasses via the inherited `handleErrorResponseException`). Localizes the [ProblemDetail]'s
-     * title and renders the response, special-casing SSE requests.
+     * title and detail and renders the response, special-casing SSE requests.
      *
-     * The `body` argument is only non-null when one of our own handlers built the [ProblemDetail]
-     * itself ([handleMethodArgumentNotValid]) - every inherited handler passes `null` and expects
-     * the body to be taken from the exception's own [ErrorResponse.getBody]. Falling straight
-     * through to `ex.message` instead is why a [TafelApiException] used to render its detail as the
-     * exception's `toString()` (`"400 BAD_REQUEST, ProblemDetail[type='null', ...]"`) rather than
-     * the message it was constructed with. Note the existing unit tests never caught that: they
-     * pass `exception.body` explicitly, which production never does.
+     * The `body` argument is non-null both when one of our own handlers built the [ProblemDetail]
+     * itself ([handleMethodArgumentNotValid]) and when an inherited handler built one via
+     * `createProblemDetail` (e.g. `handleHttpMessageNotReadable`); the remaining inherited handlers
+     * pass `null` and expect the body to be taken from the exception's own [ErrorResponse.getBody].
+     * Falling straight through to `ex.message` instead is why a [TafelApiException] used to render
+     * its detail as the exception's `toString()` (`"400 BAD_REQUEST, ProblemDetail[type='null',
+     * ...]"`) rather than the message it was constructed with. Note the existing unit tests never
+     * caught that: they pass `exception.body` explicitly, which production never does.
      */
     public override fun handleExceptionInternal(
         ex: Exception,
@@ -58,11 +65,27 @@ class GenericExceptionHandler(
         val status = HttpStatus.valueOf(statusCode.value())
         val problemDetail = (body as? ProblemDetail)
             ?: (ex as? ErrorResponse)?.body
-            ?: ProblemDetail.forStatusAndDetail(statusCode, ex.message)
+            ?: ProblemDetail.forStatus(statusCode)
+        if (!carriesOwnDetail(ex)) {
+            problemDetail.detail = localizedDetail(status, request)
+        }
         problemDetail.title = localizedTitle(status, request)
 
         return renderResponse(problemDetail, status, request)
     }
+
+    /**
+     * Whether [ex]'s [ProblemDetail] already carries a German, user-readable detail authored by this
+     * application, which must therefore survive the generic substitution in
+     * [handleExceptionInternal]: a [TafelApiException] carries the message passed at its throw site,
+     * and a [MethodArgumentNotValidException] is answered by [handleMethodArgumentNotValid] with its
+     * own wording. Everything else reaching that hook is one of Spring's built-in MVC exceptions,
+     * whose detail is English and phrased in terms of framework internals ("Failed to read request",
+     * "Invalid request content.") - or, before #3008, the unresolved `problemDetail.<exception class>`
+     * message *code*, because `MessageConfig` had `useCodeAsDefaultMessage` enabled. Neither is
+     * something the SPA should put in front of a user, and the full exception is logged above anyway.
+     */
+    private fun carriesOwnDetail(ex: Exception): Boolean = ex is TafelApiException || ex is MethodArgumentNotValidException
 
     /**
      * Without this, an [AccessDeniedException] raised by method security (`@PreAuthorize`) inside a
@@ -100,20 +123,28 @@ class GenericExceptionHandler(
         val status = HttpStatus.FORBIDDEN
         // the raw exception message ("Access Denied") is English and says nothing a user can act
         // on - it stays in the log above, while the response carries the German wording the SPA
-        // already used as its own 403 fallback
-        val problemDetail = ProblemDetail.forStatusAndDetail(status, "Zugriff nicht erlaubt!")
+        // already used as its own 403 fallback (kept identical in http-error.403.detail, so the
+        // user sees the same sentence whichever of the two produced it)
+        val problemDetail = ProblemDetail.forStatusAndDetail(status, localizedDetail(status, request))
         problemDetail.title = localizedTitle(status, request)
 
         return renderResponse(problemDetail, status, request)
     }
 
+    /**
+     * Builds the [ProblemDetail] directly rather than via the inherited `createProblemDetail`: that
+     * helper's only added value is a `MessageSource` lookup of the optional
+     * `problemDetail.org.springframework.web.bind.MethodArgumentNotValidException` code, which this
+     * app doesn't configure - and which, while `useCodeAsDefaultMessage` was enabled, resolved to the
+     * code itself and so *overwrote* the German detail passed here (see #3008).
+     */
     public override fun handleMethodArgumentNotValid(
         ex: MethodArgumentNotValidException,
         headers: HttpHeaders,
         status: HttpStatusCode,
         request: WebRequest,
     ): ResponseEntity<Any> {
-        val problemDetail = createProblemDetail(ex, status, "Validierung fehlgeschlagen", null, null, request)
+        val problemDetail = ProblemDetail.forStatusAndDetail(status, "Validierung fehlgeschlagen")
         problemDetail.setProperty(
             "errors",
             ex.bindingResult.fieldErrors.map { FieldErrorItem(field = it.field, message = it.defaultMessage) },
@@ -147,6 +178,12 @@ class GenericExceptionHandler(
         return null
     }
 
+    /**
+     * The exception's own `message` is deliberately not used as the response detail: for an unexpected
+     * failure that's raw internal text (a stack-trace-flavoured JPA/Jackson message, sometimes
+     * carrying query or payload fragments), and the SPA puts `detail` straight into an error toast.
+     * It's logged in full at `error` here instead.
+     */
     @ExceptionHandler(Exception::class)
     fun handleGenericException(
         exception: Exception,
@@ -155,17 +192,43 @@ class GenericExceptionHandler(
         log.error(exception.message, exception)
 
         val status = HttpStatus.INTERNAL_SERVER_ERROR
-        val problemDetail = ProblemDetail.forStatusAndDetail(status, exception.message)
+        val problemDetail = ProblemDetail.forStatusAndDetail(status, localizedDetail(status, request))
         problemDetail.title = localizedTitle(status, request)
 
         return renderResponse(problemDetail, status, request)
     }
 
-    private fun localizedTitle(status: HttpStatus, request: WebRequest): String = messageSource.getMessage(
-        "http-error.${status.value()}.title",
-        arrayOf<Any>(),
-        request.locale,
+    private fun localizedTitle(status: HttpStatus, request: WebRequest): String = localizedMessage(
+        code = "http-error.${status.value()}.title",
+        defaultCode = DEFAULT_TITLE_CODE,
+        lastResort = LAST_RESORT_TITLE,
+        request = request,
     )
+
+    private fun localizedDetail(status: HttpStatus, request: WebRequest): String = localizedMessage(
+        code = "http-error.${status.value()}.detail",
+        defaultCode = DEFAULT_DETAIL_CODE,
+        lastResort = LAST_RESORT_DETAIL,
+        request = request,
+    )
+
+    /**
+     * Resolves [code], falling back to [defaultCode] for a status without an entry of its own (405,
+     * 415 and friends only ever come from Spring's built-in handlers, so it's easy for one to appear
+     * without anybody adding a key for it).
+     *
+     * Both lookups pass a `null` default message rather than using the throwing `getMessage` overload:
+     * a `NoSuchMessageException` raised *inside* the exception handler would replace a well-formed
+     * error response with a bare 500, which is exactly the failure mode
+     * `MessageSource.useCodeAsDefaultMessage` used to hide - at the cost of leaking the key itself into
+     * the response (see [at.wrk.tafel.admin.backend.config.MessageConfig] and issue #3008). Hence
+     * [lastResort] as the final layer.
+     */
+    private fun localizedMessage(code: String, defaultCode: String, lastResort: String, request: WebRequest): String {
+        val resolved = messageSource.getMessage(code, NO_MESSAGE_ARGS, null, request.locale)
+            ?: messageSource.getMessage(defaultCode, NO_MESSAGE_ARGS, null, request.locale)
+        return resolved ?: lastResort
+    }
 
     /**
      * If the incoming request's `Accept` header contains `text/event-stream`, a normal JSON error

--- a/backend/src/main/resources/i18n/messages.properties
+++ b/backend/src/main/resources/i18n/messages.properties
@@ -1,6 +1,35 @@
+# Titles and details for error responses rendered by GenericExceptionHandler.
+#
+# The detail is what the frontend actually shows the user (extractErrorMessage() in
+# common/api/problem-detail.ts prefers it over anything else), so every status that can be answered
+# by the handler needs a German sentence here: the details Spring's own built-in MVC exceptions carry
+# are English and phrased in terms of framework internals ("Failed to read request",
+# "Invalid request content."). Exceptions this application throws itself (TafelApiException and
+# subclasses) keep the detail passed at their throw site instead - see issue #3008.
+#
+# http-error.default.* is the fallback for any status without an entry of its own.
+http-error.default.title=Fehler
+http-error.default.detail=Es ist ein unerwarteter Fehler aufgetreten.
+
 http-error.400.title=Ungültige Aktion
+http-error.400.detail=Die Anfrage war ungültig oder unvollständig.
 http-error.403.title=Zugriff verweigert
+http-error.403.detail=Zugriff nicht erlaubt!
 http-error.404.title=Nicht gefunden
+http-error.404.detail=Die angeforderte Seite oder Ressource wurde nicht gefunden.
+http-error.405.title=Aktion nicht erlaubt
+http-error.405.detail=Diese Aktion ist für diese Adresse nicht erlaubt.
+http-error.406.title=Format nicht unterstützt
+http-error.406.detail=Das angeforderte Antwortformat wird nicht unterstützt.
 http-error.409.title=Konflikt
+http-error.409.detail=Die Anfrage steht im Konflikt mit dem aktuellen Stand der Daten.
+http-error.413.title=Daten zu groß
+http-error.413.detail=Die übertragenen Daten sind zu groß.
+http-error.415.title=Format nicht unterstützt
+http-error.415.detail=Das Format der Anfrage wird nicht unterstützt.
 http-error.422.title=Verarbeitungsfehler
+http-error.422.detail=Die Anfrage konnte nicht verarbeitet werden.
 http-error.500.title=Interner Serverfehler
+http-error.500.detail=Interner Serverfehler!
+http-error.503.title=Server nicht verfügbar
+http-error.503.detail=Der Server hat nicht rechtzeitig geantwortet. Bitte später erneut versuchen.

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerIT.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerIT.kt
@@ -1,0 +1,110 @@
+package at.wrk.tafel.admin.backend.modules.base.exception
+
+import at.wrk.tafel.admin.backend.TafelBaseIntegrationTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+/**
+ * Exercises [GenericExceptionHandler] through the real `DispatcherServlet` and the real
+ * `MessageSource`, which is the only level at which issue #3008 was visible: the exceptions below are
+ * raised by Spring's own request-handling machinery (argument resolution, content negotiation,
+ * handler mapping) and answered by handlers inherited from `ResponseEntityExceptionHandler`, so a
+ * unit test calling `handleExceptionInternal` directly can neither produce them in their real call
+ * shape nor see what an unresolved `problemDetail.<exception class>` message code does to the body.
+ *
+ * That is exactly how the bug shipped: `messageSource.useCodeAsDefaultMessage = true` turned Spring's
+ * deliberately-optional `problemDetail.*` lookups into hits, so the raw message code was rendered as
+ * the user-facing `detail` (and as the problem `type` URI). `/api/cars` is used purely as a
+ * convenient real endpoint - none of these requests ever reach the controller or the database.
+ *
+ * MockMvc is built from the `WebApplicationContext` directly instead of via `@AutoConfigureMockMvc`,
+ * which lives in a Boot module this project doesn't depend on. The security filter chain is therefore
+ * not in play (method security still is, hence [WithMockUser]) - fine here, since every failure below
+ * happens before the controller is invoked.
+ */
+@WithMockUser(authorities = ["SETTINGS"])
+class GenericExceptionHandlerIT : TafelBaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun beforeEach() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
+    }
+
+    @Test
+    fun `malformed request body is answered with a readable german detail instead of a message code`() {
+        mockMvc.perform(
+            post("/api/cars")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ not json"),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.title").value("Ungültige Aktion"))
+            .andExpect(jsonPath("$.detail").value("Die Anfrage war ungültig oder unvollständig."))
+            // the unresolved code used to be rendered as the problem type as well
+            // ("problemDetail.type.org.springframework...."); a type left at its "about:blank"
+            // default is omitted from the body entirely
+            .andExpect(jsonPath("$.type").doesNotExist())
+    }
+
+    @Test
+    fun `unsupported request method is answered with a readable german detail`() {
+        mockMvc.perform(delete("/api/cars"))
+            .andExpect(status().isMethodNotAllowed)
+            // 405 had no http-error.<status>.title entry at all, so the title used to be the raw
+            // "http-error.405.title" key
+            .andExpect(jsonPath("$.title").value("Aktion nicht erlaubt"))
+            .andExpect(jsonPath("$.detail").value("Diese Aktion ist für diese Adresse nicht erlaubt."))
+    }
+
+    @Test
+    fun `unsupported content type is answered with a readable german detail`() {
+        mockMvc.perform(
+            post("/api/cars")
+                .contentType(MediaType.TEXT_PLAIN)
+                .content("some-text"),
+        )
+            .andExpect(status().isUnsupportedMediaType)
+            .andExpect(jsonPath("$.title").value("Format nicht unterstützt"))
+            .andExpect(jsonPath("$.detail").value("Das Format der Anfrage wird nicht unterstützt."))
+    }
+
+    @Test
+    fun `path variable of the wrong type is answered with a readable german detail`() {
+        mockMvc.perform(
+            put("/api/cars/not-a-number")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"id":null,"licensePlate":"W-1234","name":"Bus","enabled":true,"sortOrder":1}"""),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value("Die Anfrage war ungültig oder unvollständig."))
+    }
+
+    @Test
+    fun `bean validation failure keeps its own wording and the structured field errors`() {
+        mockMvc.perform(
+            post("/api/cars")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"id":null,"licensePlate":"","name":"","enabled":true,"sortOrder":1}"""),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.title").value("Ungültige Aktion"))
+            .andExpect(jsonPath("$.detail").value("Validierung fehlgeschlagen"))
+            .andExpect(jsonPath("$.errors.length()").value(2))
+    }
+}

--- a/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
+++ b/backend/src/test/kotlin/at/wrk/tafel/admin/backend/modules/base/exception/GenericExceptionHandlerTest.kt
@@ -12,14 +12,17 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.MessageSource
 import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpInputMessage
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
@@ -46,21 +49,34 @@ internal class GenericExceptionHandlerTest {
     fun beforeEach() {
         every { request.request.requestURI } returns "/dummy-path"
         every { request.locale } returns Locale.GERMAN
+        stubMessages { code -> "localized-${code.substringAfterLast('.')}" }
+    }
+
+    /**
+     * Stubs the *four*-argument `getMessage` overload - the one the handler deliberately uses, since
+     * it returns `null` for an unconfigured key instead of throwing, see
+     * `GenericExceptionHandler.localizedMessage`.
+     *
+     * [resolve] returning a value for every `http-error.<status>.title`/`.detail` key mirrors what the
+     * real `i18n/messages.properties` provides, so the assertions below can check for
+     * `localized-title`/`localized-detail` regardless of status.
+     */
+    private fun stubMessages(resolve: (String) -> String?) {
+        every { messageSource.getMessage(any<String>(), any(), null, Locale.GERMAN) } answers {
+            resolve(firstArg<String>())
+        }
     }
 
     /**
      * Every one of these passes `body = null`, because that is what Spring actually does: the
      * inherited `handleErrorResponseException` calls `handleExceptionInternal(ex, null, ...)` and
-     * expects the body to be taken from the exception's own [ErrorResponse.getBody]. Passing
+     * expects the body to be taken from the exception's own `ErrorResponse.getBody`. Passing
      * `exception.body` here instead (as these tests used to) exercises a call shape production
      * never produces, and hid that every [TafelApiException] rendered its detail as the exception's
      * `toString()` - `"404 NOT_FOUND, ProblemDetail[type='null', title='Not Found', ...]"`.
      */
     @Test
     fun `handles NotFoundException properly`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.NOT_FOUND.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = NotFoundException("notfound-msg")
 
         val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
@@ -74,9 +90,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles ConflictException properly`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.CONFLICT.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = ConflictException("conflict-msg")
 
         val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
@@ -90,9 +103,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles BusinessRuleException with default status`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = BusinessRuleException("businessrule-msg")
 
         val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
@@ -106,9 +116,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles BusinessRuleException with explicit status`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.UNPROCESSABLE_CONTENT.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = BusinessRuleException("businessrule-msg", status = HttpStatus.UNPROCESSABLE_CONTENT)
 
         val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
@@ -122,9 +129,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `an explicitly passed body still wins over the exception's own`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = BusinessRuleException("businessrule-msg")
         val explicitBody = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "explicit-detail")
 
@@ -134,39 +138,86 @@ internal class GenericExceptionHandlerTest {
         assertThat(errorBody.detail).isEqualTo("explicit-detail")
     }
 
+    /**
+     * The two shapes issue #3008 is about. A built-in MVC exception either carries its own English
+     * detail ("Method 'DELETE' is not supported.") or - for the ones Spring answers via
+     * `createProblemDetail`, such as [HttpMessageNotReadableException] - one already run through the
+     * `MessageSource`, which used to hand back the unresolved `problemDetail.<exception class>` code
+     * itself. Neither may reach the client.
+     */
     @Test
-    fun `falls back to the exception message when it carries no problem detail`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
+    fun `replaces the detail of a spring built-in exception carrying its own message`() {
+        val exception = HttpRequestMethodNotSupportedException("DELETE")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.title).isEqualTo("localized-title")
+        assertThat(errorBody.detail).isEqualTo("localized-detail")
+    }
+
+    @Test
+    fun `replaces an unresolved message code passed as the detail by spring's own handler`() {
+        val exception = HttpMessageNotReadableException("Failed to read request", mockk<HttpInputMessage>(relaxed = true))
+        val springBody = ProblemDetail.forStatusAndDetail(
+            HttpStatus.BAD_REQUEST,
+            "problemDetail.org.springframework.http.converter.HttpMessageNotReadableException",
+        )
+
+        val response = exceptionHandler.handleExceptionInternal(exception, springBody, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request)
+
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.detail).isEqualTo("localized-detail")
+    }
+
+    @Test
+    fun `falls back to the default message code for a status without its own key`() {
+        stubMessages { code -> if (code.startsWith("http-error.default.")) "default-${code.substringAfterLast('.')}" else null }
+        val exception = HttpRequestMethodNotSupportedException("DELETE")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.title).isEqualTo("default-title")
+        assertThat(errorBody.detail).isEqualTo("default-detail")
+    }
+
+    @Test
+    fun `falls back to a hardcoded german message when nothing resolves at all`() {
+        stubMessages { null }
+        val exception = HttpRequestMethodNotSupportedException("DELETE")
+
+        val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, exception.statusCode, request)
+
+        val errorBody = response.body as ProblemDetail
+        assertThat(errorBody.title).isEqualTo("Fehler")
+        assertThat(errorBody.detail).isEqualTo("Es ist ein unerwarteter Fehler aufgetreten.")
+    }
+
+    @Test
+    fun `an exception carrying no problem detail is answered with the localized generic detail`() {
         val exception = IllegalStateException("plain-exception-msg")
 
         val response = exceptionHandler.handleExceptionInternal(exception, null, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request)
 
         val errorBody = response.body as ProblemDetail
-        assertThat(errorBody.detail).isEqualTo("plain-exception-msg")
+        assertThat(errorBody.detail).isEqualTo("localized-detail")
     }
 
     @Test
     fun `handles AccessDeniedException with 403 instead of falling through to 500`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
-
         val response = exceptionHandler.handleAccessDeniedException(AuthorizationDeniedException("Access Denied"), request)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
         val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.FORBIDDEN.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
-        assertThat(errorBody.detail).isEqualTo("Zugriff nicht erlaubt!")
+        assertThat(errorBody.detail).isEqualTo("localized-detail")
     }
 
     @Test
     fun `handles AccessDeniedException for an authenticated user with resolved authorities`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         every { request.request.method } returns "POST"
         SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
             "some-user",
@@ -185,9 +236,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles AccessDeniedException for a non-servlet WebRequest`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.FORBIDDEN.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val plainWebRequest = mockk<WebRequest>(relaxed = true)
         every { plainWebRequest.locale } returns Locale.GERMAN
 
@@ -198,10 +246,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles MethodArgumentNotValidException properly`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.BAD_REQUEST.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
-
         val bindingResult = BeanPropertyBindingResult("target", "targetObject")
         bindingResult.addError(FieldError("targetObject", "fieldOne", "must not be blank"))
         bindingResult.addError(FieldError("targetObject", "fieldTwo", "must be positive"))
@@ -213,6 +257,8 @@ internal class GenericExceptionHandlerTest {
         val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
+        // the wording this handler sets itself survives the generic substitution
+        assertThat(errorBody.detail).isEqualTo("Validierung fehlgeschlagen")
         assertThat(errorBody.properties?.get("errors")).isEqualTo(
             listOf(
                 FieldErrorItem("fieldOne", "must not be blank"),
@@ -223,9 +269,6 @@ internal class GenericExceptionHandlerTest {
 
     @Test
     fun `handles Exception properly`() {
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = IllegalArgumentException("test-msg")
 
         val response = exceptionHandler.handleGenericException(exception, request)
@@ -234,7 +277,8 @@ internal class GenericExceptionHandlerTest {
         val errorBody = response.body as ProblemDetail
         assertThat(errorBody.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
         assertThat(errorBody.title).isEqualTo("localized-title")
-        assertThat(errorBody.detail).isEqualTo("test-msg")
+        // never the raw exception message, which is internal technical text
+        assertThat(errorBody.detail).isEqualTo("localized-detail")
     }
 
     @Test
@@ -249,9 +293,6 @@ internal class GenericExceptionHandlerTest {
     @Test
     fun `handles exception in SSE properly`() {
         every { request.getHeader("Accept") } returns "text/event-stream"
-        every {
-            messageSource.getMessage("http-error.${HttpStatus.INTERNAL_SERVER_ERROR.value()}.title", arrayOf<Any>(), Locale.GERMAN)
-        } returns "localized-title"
         val exception = IllegalArgumentException("test-msg")
         every { jsonMapper.writeValueAsString(any()) } returns exception.message
 

--- a/frontend/src/main/webapp/cypress/e2e/general.cy.ts
+++ b/frontend/src/main/webapp/cypress/e2e/general.cy.ts
@@ -81,6 +81,33 @@ describe('API error responses', () => {
     });
   });
 
+  // The two below are answered by handlers inherited from Spring's ResponseEntityExceptionHandler,
+  // not by anything this app wrote. They used to come back with the unresolved
+  // "problemDetail.<exception class>" message *code* as detail (and as the problem type), which is
+  // what the SPA puts straight into its error toast - see issue #3008.
+  it('answers an unsupported request method with a german problem detail', () => {
+    cy.loginDefault();
+
+    cy.request({method: 'DELETE', url: '/api/cars', failOnStatusCode: false}).then((response) => {
+      expect(response.status).to.eq(405);
+      // 405 had no message key of its own at all, so the title used to be the raw
+      // "http-error.405.title" key
+      expect(response.body.title).to.eq('Aktion nicht erlaubt');
+      expect(response.body.detail).to.eq('Diese Aktion ist für diese Adresse nicht erlaubt.');
+    });
+  });
+
+  it('answers a path variable of the wrong type with a german problem detail', () => {
+    cy.loginDefault();
+
+    cy.request({method: 'GET', url: '/api/households/not-a-number', failOnStatusCode: false}).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body.title).to.eq('Ungültige Aktion');
+      expect(response.body.detail).to.eq('Die Anfrage war ungültig oder unvollständig.');
+      expect(response.body).to.not.have.property('type');
+    });
+  });
+
 });
 
 describe('Navigation Progress Bar', () => {


### PR DESCRIPTION
## Summary

Closes #3008

### Root cause

Not the missing `problemDetail.*` entries themselves — `MessageConfig` had
`messageSource.useCodeAsDefaultMessage = true`. Spring's `ErrorResponse.updateAndGetBody()` and
`ResponseEntityExceptionHandler.createProblemDetail()` probe a family of *optional*
`problemDetail[.type|.title].<exception class>` codes with a `null` default and only apply the
result when one is actually configured; that flag turned every one of those expected misses into a
hit, so the raw code was written into the response body.

Two more symptoms of the same flag that the ticket doesn't mention:

- `http-error.<status>.title` was only configured for 400/403/404/409/422/500, so a 405 or 415
  came back with the literal `"http-error.405.title"` as its title.
- `handleMethodArgumentNotValid` built its body via the inherited `createProblemDetail`, so the
  code overwrote its own `"Validierung fehlgeschlagen"` — every bean-validation failure toasted
  `problemDetail.org.springframework.web.bind.MethodArgumentNotValidException` too.

### Fix

- `MessageConfig`: flag removed (documented why it must stay off).
- `messages.properties`: `http-error.<status>.detail` alongside the existing `.title` keys, plus
  `http-error.default.*` for a status without an entry of its own. 403/500 reuse the exact wording
  the frontend already falls back to, so the user sees the same sentence either way.
- `GenericExceptionHandler`: localizes `detail` as well as `title`. **Only a detail this
  application authored itself survives** — a `TafelApiException`'s throw-site message and
  `handleMethodArgumentNotValid`'s wording; everything else reaching the shared hook is one of
  Spring's built-in MVC exceptions, whose detail is English framework-internals text
  (`"Failed to read request"`), and is replaced by the generic German sentence for the status.
  Message lookups no longer use the throwing `getMessage` overload (that would answer an
  unconfigured status with a bare 500 *from inside the exception handler*), with a hardcoded German
  last resort behind the `default` keys.

Picked up inline, same file and same bug class ("raw internal text becomes the user-facing
detail"): `handleGenericException` used the raw exception `message` as the 500's detail, i.e. JPA/
Jackson internals — sometimes carrying query or payload fragments — went into a browser toast. It
now gets the generic German 500 sentence and is still logged in full at `error`. Shout if you'd
rather have that split out.

### Testing

`GenericExceptionHandlerTest` was extended, but the bug was invisible at that level — a unit test
calling `handleExceptionInternal` directly can neither produce these exceptions in their real call
shape nor see what an unresolved message code does to the body. New `GenericExceptionHandlerIT`
drives the real `DispatcherServlet` and the real `MessageSource` (malformed body, unsupported
method, unsupported content type, wrong-typed path variable, validation failure) and fails against
the old code. Two Cypress cases were added to the existing "API error responses" block for the
deployed-app view; those two are the only part not run locally (the `e2e` profile needs the backend
port that another session is holding) — CI covers them.

No frontend change: `extractErrorMessage()` already prefers `detail`, and the existing e2e
assertion on the 403 wording is unaffected. No user-guide change either — the guide documents
screens and flows, not individual error strings.

## Test plan
- [x] ./gradlew :backend:test (full suite)
- [x] ./gradlew :backend:ktlintCheck
- [x] npm run lint / typecheck / test-ci
- [ ] CI (incl. the two new Cypress cases)

🤖 Generated with Claude Code